### PR TITLE
feat(map): reshape building polygon (US-9)

### DIFF
--- a/docs/superpowers/plans/2026-04-29-reshape-building-polygon.md
+++ b/docs/superpowers/plans/2026-04-29-reshape-building-polygon.md
@@ -1,0 +1,3886 @@
+# Reshape Building Polygon — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a long-press → action sheet → reshape edit-mode flow to the FireCheck map screen. An enumerator can move, add, or remove vertices on an existing building polygon, with live red-edge feedback for self-intersection, save-time validation against five rules, an audit revision row, and offline-first sync via a new `update_feature_geometry` Supabase RPC with optimistic prev-geometry concurrency.
+
+**Architecture:** A new `ReshapeModeController` (Riverpod `Notifier`) holds the in-memory working copy + undo stack and gates the new UI surface (top banner, vertex/midpoint handle overlay, remove-confirm dialog). The map renderer gains four signature additions (`onPolygonLongPress`, `reshapeWorkingPolygonGeojson`, `reshapeInvalidEdgeGeojson`, projection helper exposed via callback) so the overlay can position handles in screen pixels and the in-progress polygon can render in real time. Save commits a Drift transaction (update `features.geometry_geojson` + insert `feature_geometry_revisions` row + insert `sync_jobs` row). The new `feature_geometry_update` sync entity flows through the existing `SyncWorker` retry/backoff/dead-letter machinery and lands in the new `update_feature_geometry` RPC, which does prev-geometry `ST_Equals` concurrency control and inserts a server-side revision row in one transaction.
+
+**Tech Stack:** Flutter 3.22 / Dart 3.4+, `mapbox_maps_flutter ^2.5` (resolved 2.22), `flutter_riverpod ^2.5`, manual `Provider<>(...)` syntax (no codegen), Drift v2 (existing `schemaVersion` is 5; this plan bumps to 6), `flutter_test`, `uuid ^4`, ARB-based i18n via `flutter_localizations` (arb dir `lib/core/i18n/`), Supabase Postgres + PostGIS.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-reshape-building-polygon-design.md`
+
+---
+
+## File structure
+
+### Files to create
+
+| Path | Responsibility |
+|---|---|
+| `lib/core/geo/polygon_validator.dart` | Pure-Dart 5-rule validator. Returns `PolygonValidationResult` with `intersectingEdges` for live red-edge feedback. Uses CCW orientation test for self-intersection (O(n²)). |
+| `lib/core/db/tables/feature_geometry_revisions.dart` | Drift table: `id`, `featureId`, `prevGeojson`, `newGeojson`, `editedBy`, `editedAt`, `overrideReason?`, `syncStatus`, `createdAt`. |
+| `lib/features/map/reshape/domain/reshape_op.dart` | Sealed class `ReshapeOp` with `Move`/`Add`/`Remove` variants. Pure value types. |
+| `lib/features/map/reshape/domain/reshape_mode_state.dart` | `ReshapeModeState` value type (`originalFeature`, `workingRings`, `undoStack`, `selfIntersects`, `saving`, `overrideReason`). |
+| `lib/features/map/reshape/presentation/reshape_mode_controller.dart` | `ReshapeModeController extends Notifier<ReshapeModeState>` — enter/cancel/move/add/remove/undo/markSaving. Pure state — no I/O. |
+| `lib/features/map/reshape/presentation/reshape_providers.dart` | Riverpod providers: `reshapeModeControllerProvider`, `reshapeRepositoryProvider`. |
+| `lib/features/map/reshape/presentation/vertex_handle.dart` | Pure-UI `StatelessWidget`. 14×14 white circle, 2px blue ring, 44×44 hit area. |
+| `lib/features/map/reshape/presentation/midpoint_handle.dart` | Pure-UI `StatelessWidget`. 10×10 hollow blue dot, 44×44 hit area. |
+| `lib/features/map/reshape/presentation/reshape_banner.dart` | Top banner: `Cancel | "Reshape • N edits" | Save` + Undo chip. Pure UI driven by props. |
+| `lib/features/map/reshape/presentation/reshape_action_sheet.dart` | `Future<ReshapeAction?> showReshapeActionSheet(...)`. Three items: Open form, Reshape (disabled when locked), Cancel. |
+| `lib/features/map/reshape/presentation/reshape_remove_confirm_dialog.dart` | `Future<bool> showReshapeRemoveConfirm(...)`. Native AlertDialog. Confirm disabled when ringLength == 3. |
+| `lib/features/map/reshape/presentation/reshape_overlay.dart` | Absolute-positioned `Stack` of vertex + midpoint handles. Projects lat/lng → screen px via callback exposed by renderer. Dispatches drag / long-press to controller. |
+| `lib/features/map/reshape/data/feature_geometry_revisions_repository.dart` | Atomic Drift transaction: update `features.geometry_geojson` + insert `feature_geometry_revisions` row + insert `sync_jobs` row. |
+| `supabase/migrations/011_feature_geometry_updates.sql` | `feature_geometry_revisions` table + RLS + `update_feature_geometry` RPC with prev-geometry `ST_Equals` check. |
+| `test/core/geo/polygon_validator_test.dart` | Unit tests for the 5 rules. |
+| `test/core/db/feature_geometry_revisions_test.dart` | Drift in-memory: atomic transaction; rollback. |
+| `test/features/map/reshape/reshape_op_test.dart` | Sealed class round-trip tests. |
+| `test/features/map/reshape/reshape_mode_controller_test.dart` | State transitions, undo stack, lock-while-dirty. |
+| `test/features/map/reshape/vertex_handle_test.dart` | 44×44 hit-area, hit-test on tap. |
+| `test/features/map/reshape/midpoint_handle_test.dart` | Same shape as vertex_handle_test. |
+| `test/features/map/reshape/reshape_banner_test.dart` | Edit count, dirty/clean Save state, Undo enabled. |
+| `test/features/map/reshape/reshape_action_sheet_test.dart` | Returns each ReshapeAction; Reshape disabled when locked. |
+| `test/features/map/reshape/reshape_remove_confirm_dialog_test.dart` | Confirm disabled at 3 vertices; returns true / false / null. |
+| `test/features/map/reshape/reshape_overlay_test.dart` | Handles render at projected positions; gestures dispatch. |
+| `test/features/map/map_screen_reshape_test.dart` | End-to-end widget tests for the orchestration. |
+| `test/core/sync/feature_geometry_update_sync_test.dart` | Sync entity round-trip via `FakeSyncApi`. |
+
+### Files to modify
+
+| Path | Change |
+|---|---|
+| `lib/core/db/database.dart` | Register `FeatureGeometryRevisions`; bump `schemaVersion` to 6; add `from < 6` migration in `onUpgrade`. |
+| `lib/core/sync/data/sync_api.dart` | Add `Future<SyncOutcome> uploadFeatureGeometryUpdate(FeatureGeometryRevision)`. |
+| `lib/core/sync/data/supabase_sync_api.dart` | Implement RPC call to `update_feature_geometry`; map PG `P0001 geometry_conflict` → permanent failure. |
+| `lib/core/sync/data/fake_sync_api.dart` | Record uploaded revisions; configurable failure injection. |
+| `lib/core/sync/worker/sync_worker.dart` | Add `'feature_geometry_update'` branch in the per-entity dispatch. |
+| `lib/features/map/presentation/map_renderer.dart` | `MapRenderer.build()` gains `onPolygonLongPress(Feature)?`, `reshapeWorkingPolygonGeojson?`, `reshapeInvalidEdgeGeojson?`, `onProjectionReady(MapProjection)?`. `FakeMapRenderer` adds `simulatePolygonLongPress` and an identity-within-bounds `MapProjection`. `MapboxMapRenderer` wires the long-press hit-test and projection helpers. |
+| `lib/features/map/presentation/map_screen.dart` | Add `_handlePolygonLongPress`; mount `ReshapeBanner` + `ReshapeOverlay` when reshape state is non-inactive; hide add-mode pill while reshape is active; lock-while-dirty UX. |
+| `lib/features/assignment/presentation/assignment_lock_providers.dart` | No code change; consumed by `ReshapeModeController` directly. |
+| `lib/core/i18n/app_en.arb` | 12 new keys. |
+| `lib/core/i18n/app_tl.arb` | Mirror the 12 keys (English fallback per project convention). |
+
+### Files NOT modified
+
+- `lib/core/geo/centroid.dart`, `point_in_polygon.dart`, `polygon_bounds.dart`, `polyline_midpoint.dart` — untouched (only consumed).
+- `lib/features/map/data/feature_repository.dart` — geometry update happens via the new repository.
+- `lib/features/survey/building_form/presentation/override_reason_dialog.dart` — reused as-is; no changes.
+- Recenter and zoom button code paths — untouched.
+
+---
+
+## Task ordering rationale
+
+1. **Validator (T1–T3):** Pure Dart, zero dependencies, easiest to unit-test. Other code references it.
+2. **Drift table + migration (T4):** New table + schemaVersion bump.
+3. **Repository (T5):** Atomic transaction, in-memory Drift tests.
+4. **i18n (T6):** Add ARB keys early so widgets and orchestration can reference them.
+5. **Sealed types (T7):** `ReshapeOp` + `ReshapeModeState` — pure value types.
+6. **Controller (T8):** State machine on top of T7. Pure logic; no UI.
+7. **Pure-UI widgets (T9–T13):** `VertexHandle`, `MidpointHandle`, `ReshapeBanner`, action sheet, remove dialog.
+8. **Renderer plumbing (T14):** Add 4 new optional params to `MapRenderer.build()` + `FakeMapRenderer` test seams + `MapboxMapRenderer` real implementation. Keeps existing call sites compiling with `null` defaults.
+9. **Reshape overlay (T15):** Handles + gestures, tested with `FakeMapRenderer`'s identity projection.
+10. **Sync (T16–T18):** Interface, fake recorder, real Supabase impl, `SyncWorker` branch.
+11. **Map-screen orchestration (T19–T22):** Long-press → action sheet, distance gate → enterReshape, mount banner + overlay, save commit, lock-while-dirty.
+12. **Server migration (T23):** `011_feature_geometry_updates.sql`.
+13. **Final regression (T24):** `flutter analyze`, full test suite, manual happy-path checklist.
+
+---
+
+## Task 1: PolygonValidator — rules 1, 2, and the public API
+
+**Files:**
+- Create: `lib/core/geo/polygon_validator.dart`
+- Create: `test/core/geo/polygon_validator_test.dart`
+
+- [ ] **Step 1: Write failing tests for rules 1 & 2 + the public shape**
+
+Create `test/core/geo/polygon_validator_test.dart`:
+
+```dart
+import 'package:firecheck/core/geo/polygon_validator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // Brgy. Tisa rectangle (reused throughout the project — see
+  // override_check_test.dart). All vertices well inside this boundary.
+  const boundary = '''
+{"type":"Polygon","coordinates":[[
+  [123.870,10.310],[123.890,10.310],[123.890,10.330],[123.870,10.330],[123.870,10.310]
+]]}''';
+
+  group('rule 1 — tooFewVertices', () {
+    test('passes with 3 unique vertices', () {
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.881, lat: 10.320),
+            (lng: 123.880, lat: 10.321),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isTrue);
+      expect(result.error, isNull);
+    });
+
+    test('fails with 2 unique vertices', () {
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.881, lat: 10.320),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isFalse);
+      expect(result.error, PolygonValidationError.tooFewVertices);
+    });
+  });
+
+  group('rule 2 — zeroOrNegativeArea', () {
+    test('fails for colinear vertices', () {
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.881, lat: 10.320),
+            (lng: 123.882, lat: 10.320),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isFalse);
+      expect(result.error, PolygonValidationError.zeroOrNegativeArea);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run tests; confirm they fail**
+
+```bash
+flutter test test/core/geo/polygon_validator_test.dart
+```
+
+Expected: compile error — `validateBuildingPolygon` undefined.
+
+- [ ] **Step 3: Implement rules 1 & 2 + the public API**
+
+Create `lib/core/geo/polygon_validator.dart`:
+
+```dart
+import 'dart:math' as math;
+
+import 'package:firecheck/core/geo/point_in_polygon.dart';
+
+typedef LngLat = ({double lng, double lat});
+
+// Identifies an intersecting pair of edges in the working outer ring.
+// `aStart` and `bStart` index into rings[0]; the edge runs from index N to
+// (N+1) % ringLength.
+typedef EdgeIndex = ({int aStart, int bStart});
+
+enum PolygonValidationError {
+  tooFewVertices,
+  zeroOrNegativeArea,
+  selfIntersection,
+  vertexOutsideBoundary,
+  zeroLengthEdge,
+}
+
+class PolygonValidationResult {
+  const PolygonValidationResult.valid()
+      : valid = true,
+        error = null,
+        intersectingEdges = null;
+
+  const PolygonValidationResult.invalid(
+    this.error, {
+    this.intersectingEdges,
+  }) : valid = false;
+
+  final bool valid;
+  final PolygonValidationError? error;
+  final List<EdgeIndex>? intersectingEdges;
+}
+
+/// Validates [rings] against the five reshape rules in declared order.
+/// Short-circuits on the first failure.
+///
+/// `rings[0]` is the outer ring (open form: no duplicated end vertex).
+/// Holes are not validated — building polygons only have an outer ring.
+PolygonValidationResult validateBuildingPolygon(
+  List<List<LngLat>> rings, {
+  required String boundaryGeojson,
+}) {
+  if (rings.isEmpty) {
+    return const PolygonValidationResult.invalid(
+      PolygonValidationError.tooFewVertices,
+    );
+  }
+  final outer = rings[0];
+
+  // Rule 1: at least 3 unique vertices.
+  if (_uniqueVertexCount(outer) < 3) {
+    return const PolygonValidationResult.invalid(
+      PolygonValidationError.tooFewVertices,
+    );
+  }
+
+  // Rule 2: non-zero area (shoelace, in WGS84 sq-degrees; epsilon 1e-12).
+  if (_signedArea(outer).abs() < 1e-12) {
+    return const PolygonValidationResult.invalid(
+      PolygonValidationError.zeroOrNegativeArea,
+    );
+  }
+
+  // Rules 3, 4, 5 added in subsequent tasks.
+
+  return const PolygonValidationResult.valid();
+}
+
+int _uniqueVertexCount(List<LngLat> ring) {
+  final seen = <String>{};
+  for (final v in ring) {
+    seen.add('${v.lng.toStringAsFixed(9)},${v.lat.toStringAsFixed(9)}');
+  }
+  return seen.length;
+}
+
+double _signedArea(List<LngLat> ring) {
+  if (ring.length < 3) return 0;
+  var sum = 0.0;
+  for (var i = 0; i < ring.length; i++) {
+    final a = ring[i];
+    final b = ring[(i + 1) % ring.length];
+    sum += (b.lng - a.lng) * (b.lat + a.lat);
+  }
+  return sum / 2.0;
+}
+```
+
+- [ ] **Step 4: Run tests; confirm they pass**
+
+```bash
+flutter test test/core/geo/polygon_validator_test.dart
+```
+
+Expected: 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/geo/polygon_validator.dart test/core/geo/polygon_validator_test.dart
+git commit -m "feat(geo): PolygonValidator rules 1-2 (vertex count, area) (US-9 T1)"
+```
+
+---
+
+## Task 2: PolygonValidator — rule 3 (self-intersection) with EdgeIndex reporting
+
+**Files:**
+- Modify: `lib/core/geo/polygon_validator.dart`
+- Modify: `test/core/geo/polygon_validator_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `test/core/geo/polygon_validator_test.dart` inside the same `void main() { ... }` (place after the rule-2 group):
+
+```dart
+  group('rule 3 — selfIntersection', () {
+    test('passes for a simple convex quad', () {
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.881, lat: 10.320),
+            (lng: 123.881, lat: 10.321),
+            (lng: 123.880, lat: 10.321),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isTrue);
+    });
+
+    test('fails for a bowtie (4 vertices crossing)', () {
+      // Vertices ordered so edges 0-1 and 2-3 cross.
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.881, lat: 10.321),
+            (lng: 123.881, lat: 10.320),
+            (lng: 123.880, lat: 10.321),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isFalse);
+      expect(result.error, PolygonValidationError.selfIntersection);
+      expect(result.intersectingEdges, isNotNull);
+      expect(result.intersectingEdges!.isNotEmpty, isTrue);
+      // Bowtie edge pairs in this 4-vertex layout: (0,2).
+      expect(
+        result.intersectingEdges!.any(
+          (e) => (e.aStart == 0 && e.bStart == 2) || (e.aStart == 2 && e.bStart == 0),
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not report adjacent edges as intersecting', () {
+      // Plain triangle — adjacent edges share endpoints, must not flag.
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.881, lat: 10.320),
+            (lng: 123.880, lat: 10.321),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isTrue);
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests; confirm the new ones fail (compile fine, but bowtie passes erroneously)**
+
+```bash
+flutter test test/core/geo/polygon_validator_test.dart
+```
+
+Expected: bowtie test FAILS (returns valid because rule 3 not yet implemented); other rule-3 tests PASS by accident.
+
+- [ ] **Step 3: Implement rule 3**
+
+In `lib/core/geo/polygon_validator.dart`, replace the `// Rules 3, 4, 5 added in subsequent tasks.` line with:
+
+```dart
+  // Rule 3: non-self-intersecting (open segments, ignore adjacent pairs).
+  final intersections = _findSelfIntersections(outer);
+  if (intersections.isNotEmpty) {
+    return PolygonValidationResult.invalid(
+      PolygonValidationError.selfIntersection,
+      intersectingEdges: intersections,
+    );
+  }
+```
+
+Then append these helpers at the bottom of the file (above the closing brace of the file):
+
+```dart
+List<EdgeIndex> _findSelfIntersections(List<LngLat> ring) {
+  final n = ring.length;
+  final hits = <EdgeIndex>[];
+  for (var i = 0; i < n; i++) {
+    final a1 = ring[i];
+    final a2 = ring[(i + 1) % n];
+    for (var j = i + 1; j < n; j++) {
+      // Skip adjacent edges (share a vertex) and the wraparound pair.
+      if (j == i + 1) continue;
+      if (i == 0 && j == n - 1) continue;
+      final b1 = ring[j];
+      final b2 = ring[(j + 1) % n];
+      if (_segmentsIntersect(a1, a2, b1, b2)) {
+        hits.add((aStart: i, bStart: j));
+      }
+    }
+  }
+  return hits;
+}
+
+// Standard CCW orientation test for open-segment intersection.
+// Returns true iff the open segments (a1,a2) and (b1,b2) cross.
+bool _segmentsIntersect(LngLat a1, LngLat a2, LngLat b1, LngLat b2) {
+  final d1 = _ccw(b1, b2, a1);
+  final d2 = _ccw(b1, b2, a2);
+  final d3 = _ccw(a1, a2, b1);
+  final d4 = _ccw(a1, a2, b2);
+
+  if (((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) &&
+      ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0))) {
+    return true;
+  }
+  // Collinear-touch cases are not considered self-intersection in this app —
+  // only "transverse" crossings.
+  return false;
+}
+
+double _ccw(LngLat p, LngLat q, LngLat r) {
+  return (q.lng - p.lng) * (r.lat - p.lat) - (q.lat - p.lat) * (r.lng - p.lng);
+}
+```
+
+- [ ] **Step 4: Run tests; confirm all rule-3 tests pass**
+
+```bash
+flutter test test/core/geo/polygon_validator_test.dart
+```
+
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/geo/polygon_validator.dart test/core/geo/polygon_validator_test.dart
+git commit -m "feat(geo): PolygonValidator rule 3 (self-intersection + EdgeIndex) (US-9 T2)"
+```
+
+---
+
+## Task 3: PolygonValidator — rules 4 & 5 (boundary, zero-length edge)
+
+**Files:**
+- Modify: `lib/core/geo/polygon_validator.dart`
+- Modify: `test/core/geo/polygon_validator_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to the same `main()` in the test file (after the rule-3 group):
+
+```dart
+  group('rule 4 — vertexOutsideBoundary', () {
+    test('passes when all vertices are inside boundary', () {
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.881, lat: 10.320),
+            (lng: 123.880, lat: 10.321),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isTrue);
+    });
+
+    test('fails when one vertex is outside boundary', () {
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 124.000, lat: 10.320), // way outside
+            (lng: 123.880, lat: 10.321),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isFalse);
+      expect(result.error, PolygonValidationError.vertexOutsideBoundary);
+    });
+  });
+
+  group('rule 5 — zeroLengthEdge', () {
+    test('fails when two adjacent vertices are coincident', () {
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.880, lat: 10.320), // duplicate
+            (lng: 123.881, lat: 10.320),
+            (lng: 123.880, lat: 10.321),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isFalse);
+      expect(result.error, PolygonValidationError.zeroLengthEdge);
+    });
+
+    test('passes when adjacent vertices are 1cm apart (above epsilon)', () {
+      // ~1e-7 degrees is ~1cm at the equator — well above 1e-9 epsilon.
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.8800001, lat: 10.320), // 1cm east
+            (lng: 123.881, lat: 10.320),
+            (lng: 123.880, lat: 10.321),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isTrue);
+    });
+  });
+
+  group('rule ordering', () {
+    test('returns rule 1 when polygon also fails rule 3', () {
+      // 2 vertices fails rule 1; can't fail rule 3 simultaneously, so build
+      // a case that fails rule 1 + rule 5. Two vertices, both coincident.
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.880, lat: 10.320),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.error, PolygonValidationError.tooFewVertices);
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests; confirm new ones fail**
+
+```bash
+flutter test test/core/geo/polygon_validator_test.dart
+```
+
+Expected: rule-4 outside-boundary test FAILS; rule-5 zero-length test FAILS.
+
+- [ ] **Step 3: Implement rules 4 & 5**
+
+In `lib/core/geo/polygon_validator.dart`, replace the body of `validateBuildingPolygon` so the post-rule-3 area becomes:
+
+```dart
+  // Rule 3 — already implemented above.
+
+  // Rule 4: every vertex inside the assignment boundary.
+  for (final v in outer) {
+    if (!pointInPolygonGeojson(v.lat, v.lng, boundaryGeojson)) {
+      return const PolygonValidationResult.invalid(
+        PolygonValidationError.vertexOutsideBoundary,
+      );
+    }
+  }
+
+  // Rule 5: no zero-length edges (adjacent vertices not coincident).
+  const epsilon = 1e-9;
+  for (var i = 0; i < outer.length; i++) {
+    final a = outer[i];
+    final b = outer[(i + 1) % outer.length];
+    final dLng = (b.lng - a.lng).abs();
+    final dLat = (b.lat - a.lat).abs();
+    if (dLng < epsilon && dLat < epsilon) {
+      return const PolygonValidationResult.invalid(
+        PolygonValidationError.zeroLengthEdge,
+      );
+    }
+  }
+
+  return const PolygonValidationResult.valid();
+```
+
+Remove the old final `return PolygonValidationResult.valid();` at the bottom of the function so there's only one.
+
+Note: `_uniqueVertexCount` is permissive of literal duplicate (lng,lat) pairs only — for rule 1 we need *unique* vertex count, not edge count, so the existing `_uniqueVertexCount` is correct. The "two vertices both coincident" test in `rule ordering` correctly returns `tooFewVertices` since the unique count is 1.
+
+- [ ] **Step 4: Run tests; confirm all rules pass**
+
+```bash
+flutter test test/core/geo/polygon_validator_test.dart
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/geo/polygon_validator.dart test/core/geo/polygon_validator_test.dart
+git commit -m "feat(geo): PolygonValidator rules 4-5 (boundary, zero-length edge) (US-9 T3)"
+```
+
+---
+
+## Task 4: Drift table `feature_geometry_revisions` + schema migration
+
+**Files:**
+- Create: `lib/core/db/tables/feature_geometry_revisions.dart`
+- Modify: `lib/core/db/database.dart`
+
+- [ ] **Step 1: Create the table file**
+
+Create `lib/core/db/tables/feature_geometry_revisions.dart`:
+
+```dart
+import 'package:drift/drift.dart';
+
+@TableIndex(name: 'fgr_feature_id_idx',  columns: {#featureId})
+@TableIndex(name: 'fgr_sync_status_idx', columns: {#syncStatus})
+class FeatureGeometryRevisions extends Table {
+  TextColumn     get id              => text()();
+  TextColumn     get featureId       => text()();
+  TextColumn     get prevGeojson     => text()();
+  TextColumn     get newGeojson      => text()();
+  TextColumn     get editedBy        => text()();
+  DateTimeColumn get editedAt        => dateTime()();
+  TextColumn     get overrideReason  => text().nullable()();
+  TextColumn     get syncStatus      => text().withDefault(const Constant('pending'))();
+                                                            // pending|ready_to_upload|uploaded|failed
+  DateTimeColumn get createdAt       => dateTime()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+```
+
+- [ ] **Step 2: Register the table and bump schemaVersion**
+
+In `lib/core/db/database.dart`:
+
+1. Add an import at the top:
+```dart
+import 'package:firecheck/core/db/tables/feature_geometry_revisions.dart';
+```
+
+2. Add `FeatureGeometryRevisions,` to the `tables: [...]` list inside the `@DriftDatabase` annotation (alphabetical placement: between `Features,` and `HouseholdSurveys,` doesn't fit — place it after `Features,`).
+
+3. Change `int get schemaVersion => 5;` to `int get schemaVersion => 6;`.
+
+4. In `onUpgrade`, after the `if (from < 5) { ... }` block, add:
+```dart
+          if (from < 6) {
+            // v5 → v6: feature_geometry_revisions table for US-9 reshape.
+            await m.createTable(featureGeometryRevisions);
+            await m.createIndex(fgrFeatureIdIdx);
+            await m.createIndex(fgrSyncStatusIdx);
+          }
+```
+
+- [ ] **Step 3: Regenerate the Drift code**
+
+```bash
+dart run build_runner build --delete-conflicting-outputs
+```
+
+Expected: `database.g.dart` regenerated; new table accessor `featureGeometryRevisions` and index symbols `fgrFeatureIdIdx`, `fgrSyncStatusIdx` are emitted.
+
+- [ ] **Step 4: Verify the build is clean**
+
+```bash
+flutter analyze
+```
+
+Expected: no errors. (`info`-level lints are acceptable.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/db/tables/feature_geometry_revisions.dart \
+        lib/core/db/database.dart \
+        lib/core/db/database.g.dart
+git commit -m "feat(db): feature_geometry_revisions table + v5→v6 migration (US-9 T4)"
+```
+
+---
+
+## Task 5: `FeatureGeometryRevisionsRepository` — atomic save transaction
+
+**Files:**
+- Create: `lib/features/map/reshape/data/feature_geometry_revisions_repository.dart`
+- Create: `test/core/db/feature_geometry_revisions_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `test/core/db/feature_geometry_revisions_test.dart`:
+
+```dart
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/features/map/reshape/data/feature_geometry_revisions_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase db;
+  late FeatureGeometryRevisionsRepository repo;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = FeatureGeometryRevisionsRepository(db);
+
+    // Seed one assignment + one feature so the FK on revisions is satisfied
+    // and the geometry update has something to update.
+    await db.into(db.assignments).insert(
+      AssignmentsCompanion.insert(
+        id: 'a1',
+        enumeratorId: 'e1',
+        boundaryPolygonGeojson: '{}',
+      ),
+    );
+    await db.into(db.features).insert(
+      FeaturesCompanion.insert(
+        id: 'f1',
+        assignmentId: 'a1',
+        featureType: 'building',
+        geometryGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[0,1],[0,0]]]}',
+        createdAt: DateTime.utc(2026, 1, 1),
+      ),
+    );
+  });
+
+  tearDown(() => db.close());
+
+  test('saveReshape writes feature update + revision row + sync_job atomically', () async {
+    const newGeojson = '{"type":"Polygon","coordinates":[[[0,0],[2,0],[0,2],[0,0]]]}';
+
+    await repo.saveReshape(
+      revisionId: 'r1',
+      featureId: 'f1',
+      prevGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[0,1],[0,0]]]}',
+      newGeojson: newGeojson,
+      editedBy: 'e1',
+      editedAt: DateTime.utc(2026, 4, 29, 12, 0),
+      overrideReason: null,
+    );
+
+    final feature = await (db.select(db.features)
+          ..where((t) => t.id.equals('f1')))
+        .getSingle();
+    expect(feature.geometryGeojson, newGeojson);
+
+    final revisions = await db.select(db.featureGeometryRevisions).get();
+    expect(revisions, hasLength(1));
+    expect(revisions.first.id, 'r1');
+    expect(revisions.first.syncStatus, 'ready_to_upload');
+    expect(revisions.first.overrideReason, isNull);
+
+    final jobs = await db.select(db.syncJobs).get();
+    expect(jobs, hasLength(1));
+    expect(jobs.first.entityType, 'feature_geometry_update');
+    expect(jobs.first.entityId, 'r1');
+    expect(jobs.first.status, 'pending');
+  });
+
+  test('saveReshape persists overrideReason when provided', () async {
+    await repo.saveReshape(
+      revisionId: 'r2',
+      featureId: 'f1',
+      prevGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[0,1],[0,0]]]}',
+      newGeojson:  '{"type":"Polygon","coordinates":[[[0,0],[2,0],[0,2],[0,0]]]}',
+      editedBy: 'e1',
+      editedAt: DateTime.utc(2026, 4, 29, 12, 0),
+      overrideReason: 'corner visible from sidewalk',
+    );
+
+    final revisions = await db.select(db.featureGeometryRevisions).get();
+    expect(revisions.first.overrideReason, 'corner visible from sidewalk');
+  });
+
+  test('getById returns the revision', () async {
+    await repo.saveReshape(
+      revisionId: 'r3',
+      featureId: 'f1',
+      prevGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[0,1],[0,0]]]}',
+      newGeojson:  '{"type":"Polygon","coordinates":[[[0,0],[2,0],[0,2],[0,0]]]}',
+      editedBy: 'e1',
+      editedAt: DateTime.utc(2026, 4, 29, 12, 0),
+      overrideReason: null,
+    );
+
+    final found = await repo.getById('r3');
+    expect(found, isNotNull);
+    expect(found!.featureId, 'f1');
+  });
+}
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+```bash
+flutter test test/core/db/feature_geometry_revisions_test.dart
+```
+
+Expected: compile error — repo class undefined.
+
+- [ ] **Step 3: Implement the repository**
+
+Create `lib/features/map/reshape/data/feature_geometry_revisions_repository.dart`:
+
+```dart
+import 'package:drift/drift.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:uuid/uuid.dart';
+
+class FeatureGeometryRevisionsRepository {
+  FeatureGeometryRevisionsRepository(this._db, {Uuid? uuid})
+      : _uuid = uuid ?? const Uuid();
+
+  final AppDatabase _db;
+  final Uuid _uuid;
+
+  /// Atomically:
+  ///  1. updates `features.geometry_geojson` to [newGeojson]
+  ///  2. inserts a `feature_geometry_revisions` row with status `ready_to_upload`
+  ///  3. inserts a `sync_jobs` row (`entity_type='feature_geometry_update'`, status `pending`)
+  Future<void> saveReshape({
+    required String revisionId,
+    required String featureId,
+    required String prevGeojson,
+    required String newGeojson,
+    required String editedBy,
+    required DateTime editedAt,
+    required String? overrideReason,
+  }) async {
+    await _db.transaction(() async {
+      await (_db.update(_db.features)..where((t) => t.id.equals(featureId)))
+          .write(FeaturesCompanion(geometryGeojson: Value(newGeojson)));
+
+      await _db.into(_db.featureGeometryRevisions).insert(
+            FeatureGeometryRevisionsCompanion.insert(
+              id: revisionId,
+              featureId: featureId,
+              prevGeojson: prevGeojson,
+              newGeojson: newGeojson,
+              editedBy: editedBy,
+              editedAt: editedAt,
+              overrideReason: Value(overrideReason),
+              syncStatus: const Value('ready_to_upload'),
+              createdAt: DateTime.now(),
+            ),
+          );
+
+      await _db.into(_db.syncJobs).insert(
+            SyncJobsCompanion.insert(
+              id: _uuid.v4(),
+              entityType: 'feature_geometry_update',
+              entityId: revisionId,
+              createdAt: DateTime.now(),
+            ),
+          );
+    });
+  }
+
+  Future<FeatureGeometryRevision?> getById(String id) {
+    return (_db.select(_db.featureGeometryRevisions)
+          ..where((t) => t.id.equals(id)))
+        .getSingleOrNull();
+  }
+
+  Future<void> markSynced(String id) async {
+    await (_db.update(_db.featureGeometryRevisions)
+          ..where((t) => t.id.equals(id)))
+        .write(const FeatureGeometryRevisionsCompanion(
+            syncStatus: Value('uploaded')));
+  }
+
+  Future<void> markFailed(String id) async {
+    await (_db.update(_db.featureGeometryRevisions)
+          ..where((t) => t.id.equals(id)))
+        .write(const FeatureGeometryRevisionsCompanion(
+            syncStatus: Value('failed')));
+  }
+}
+```
+
+- [ ] **Step 4: Run tests; confirm pass**
+
+```bash
+flutter test test/core/db/feature_geometry_revisions_test.dart
+```
+
+Expected: 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/map/reshape/data/feature_geometry_revisions_repository.dart \
+        test/core/db/feature_geometry_revisions_test.dart
+git commit -m "feat(reshape): FeatureGeometryRevisionsRepository — atomic save transaction (US-9 T5)"
+```
+
+---
+
+## Task 6: i18n keys
+
+**Files:**
+- Modify: `lib/core/i18n/app_en.arb`
+- Modify: `lib/core/i18n/app_tl.arb`
+
+- [ ] **Step 1: Add 12 keys to `app_en.arb`**
+
+Open `lib/core/i18n/app_en.arb`. Just before the closing `}` of the JSON object, add (preserve any trailing comma on the previous line):
+
+```json
+  "reshapeActionSheetTitle": "Building polygon",
+  "reshapeActionSheetOpenForm": "Open form",
+  "reshapeActionSheetReshape": "Reshape",
+  "reshapeBannerTitle": "Reshape • {count} edits",
+  "@reshapeBannerTitle": {
+    "placeholders": {"count": {"type": "int"}}
+  },
+  "reshapeBannerSave": "Save",
+  "reshapeRemoveConfirmTitle": "Remove vertex?",
+  "reshapeRemoveConfirmBody": "You can undo this from the banner.",
+  "reshapeRemoveConfirmRemove": "Remove",
+  "reshapeErrorTooFewVertices": "Polygon must have at least 3 vertices",
+  "reshapeErrorZeroArea": "Polygon area is too small",
+  "reshapeErrorSelfIntersection": "Edges cannot cross. Tap Undo or move a corner.",
+  "reshapeErrorOutsideBoundary": "Some vertices are outside the assignment area",
+  "reshapeErrorZeroLengthEdge": "Adjacent corners cannot be on the same spot",
+  "reshapeLockedSnackbar": "Assignment is closed; reshape unavailable",
+  "reshapeLockWhileDirtyBanner": "Assignment was closed by supervisor — your edits cannot be saved",
+  "reshapeLockExit": "Exit"
+```
+
+(That's 17 keys, including 4 error variants — keep all to cover every snackbar scenario.)
+
+- [ ] **Step 2: Mirror to `app_tl.arb`**
+
+Open `lib/core/i18n/app_tl.arb`. Add the same keys with English values as fallback (project convention; final TL translations are pending). Use identical key names; do not include the `@reshapeBannerTitle` metadata block again — `app_tl.arb` follows the convention of value-only mirrors (verify by `grep '@' lib/core/i18n/app_tl.arb` — only `@@locale` should appear).
+
+- [ ] **Step 3: Regenerate localizations**
+
+```bash
+flutter gen-l10n
+```
+
+Expected: `lib/generated/l10n/app_localizations.dart` (and `_en.dart`, `_tl.dart`) regenerated with new methods.
+
+- [ ] **Step 4: Verify clean analyze**
+
+```bash
+flutter analyze
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/i18n/app_en.arb lib/core/i18n/app_tl.arb lib/generated/l10n/
+git commit -m "i18n(reshape): 17 ARB keys for reshape mode (US-9 T6, TL pending translation)"
+```
+
+---
+
+## Task 7: ReshapeOp sealed class + ReshapeModeState
+
+**Files:**
+- Create: `lib/features/map/reshape/domain/reshape_op.dart`
+- Create: `lib/features/map/reshape/domain/reshape_mode_state.dart`
+- Create: `test/features/map/reshape/reshape_op_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `test/features/map/reshape/reshape_op_test.dart`:
+
+```dart
+import 'package:firecheck/features/map/reshape/domain/reshape_op.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Move op stores prev and next', () {
+    const op = Move(
+      ringIdx: 0,
+      vertexIdx: 1,
+      prev: (lng: 0, lat: 0),
+      next: (lng: 1, lat: 1),
+    );
+    expect(op.ringIdx, 0);
+    expect(op.vertexIdx, 1);
+    expect(op.prev, (lng: 0.0, lat: 0.0));
+    expect(op.next, (lng: 1.0, lat: 1.0));
+  });
+
+  test('Add op stores inserted lngLat', () {
+    const op = Add(
+      ringIdx: 0,
+      vertexIdx: 2,
+      lngLat: (lng: 5, lat: 5),
+    );
+    expect(op.lngLat, (lng: 5.0, lat: 5.0));
+  });
+
+  test('Remove op stores removed lngLat', () {
+    const op = Remove(
+      ringIdx: 0,
+      vertexIdx: 0,
+      removed: (lng: 9, lat: 9),
+    );
+    expect(op.removed, (lng: 9.0, lat: 9.0));
+  });
+
+  test('switch over ReshapeOp is exhaustive', () {
+    const List<ReshapeOp> ops = [
+      Move(ringIdx: 0, vertexIdx: 0, prev: (lng: 0, lat: 0), next: (lng: 1, lat: 1)),
+      Add(ringIdx: 0, vertexIdx: 0, lngLat: (lng: 0, lat: 0)),
+      Remove(ringIdx: 0, vertexIdx: 0, removed: (lng: 0, lat: 0)),
+    ];
+    final names = ops.map((op) => switch (op) {
+          Move() => 'move',
+          Add() => 'add',
+          Remove() => 'remove',
+        });
+    expect(names, ['move', 'add', 'remove']);
+  });
+}
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+```bash
+flutter test test/features/map/reshape/reshape_op_test.dart
+```
+
+Expected: compile error — class undefined.
+
+- [ ] **Step 3: Implement**
+
+Create `lib/features/map/reshape/domain/reshape_op.dart`:
+
+```dart
+import 'package:firecheck/core/geo/polygon_validator.dart' show LngLat;
+
+sealed class ReshapeOp {
+  const ReshapeOp({required this.ringIdx, required this.vertexIdx});
+  final int ringIdx;
+  final int vertexIdx;
+}
+
+class Move extends ReshapeOp {
+  const Move({
+    required super.ringIdx,
+    required super.vertexIdx,
+    required this.prev,
+    required this.next,
+  });
+  final LngLat prev;
+  final LngLat next;
+}
+
+class Add extends ReshapeOp {
+  const Add({
+    required super.ringIdx,
+    required super.vertexIdx,
+    required this.lngLat,
+  });
+  final LngLat lngLat;
+}
+
+class Remove extends ReshapeOp {
+  const Remove({
+    required super.ringIdx,
+    required super.vertexIdx,
+    required this.removed,
+  });
+  final LngLat removed;
+}
+```
+
+Create `lib/features/map/reshape/domain/reshape_mode_state.dart`:
+
+```dart
+import 'package:firecheck/core/db/database.dart' show Feature;
+import 'package:firecheck/core/geo/polygon_validator.dart' show LngLat;
+import 'package:firecheck/features/map/reshape/domain/reshape_op.dart';
+
+class ReshapeModeState {
+  const ReshapeModeState({
+    this.originalFeature,
+    this.workingRings = const [],
+    this.undoStack = const [],
+    this.selfIntersects = false,
+    this.saving = false,
+    this.overrideReason,
+  });
+
+  final Feature? originalFeature;
+  final List<List<LngLat>> workingRings;
+  final List<ReshapeOp> undoStack;
+  final bool selfIntersects;
+  final bool saving;
+  final String? overrideReason;
+
+  bool get isActive => originalFeature != null;
+  bool get isDirty => undoStack.isNotEmpty;
+
+  ReshapeModeState copyWith({
+    Object? originalFeature = _sentinel,
+    List<List<LngLat>>? workingRings,
+    List<ReshapeOp>? undoStack,
+    bool? selfIntersects,
+    bool? saving,
+    Object? overrideReason = _sentinel,
+  }) {
+    return ReshapeModeState(
+      originalFeature: identical(originalFeature, _sentinel)
+          ? this.originalFeature
+          : originalFeature as Feature?,
+      workingRings: workingRings ?? this.workingRings,
+      undoStack: undoStack ?? this.undoStack,
+      selfIntersects: selfIntersects ?? this.selfIntersects,
+      saving: saving ?? this.saving,
+      overrideReason: identical(overrideReason, _sentinel)
+          ? this.overrideReason
+          : overrideReason as String?,
+    );
+  }
+
+  static const _sentinel = Object();
+}
+```
+
+- [ ] **Step 4: Run tests; pass**
+
+```bash
+flutter test test/features/map/reshape/reshape_op_test.dart
+```
+
+Expected: 4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/map/reshape/domain/ test/features/map/reshape/reshape_op_test.dart
+git commit -m "feat(reshape): ReshapeOp sealed class + ReshapeModeState (US-9 T7)"
+```
+
+---
+
+## Task 8: ReshapeModeController — state machine
+
+**Files:**
+- Create: `lib/features/map/reshape/presentation/reshape_mode_controller.dart`
+- Create: `lib/features/map/reshape/presentation/reshape_providers.dart`
+- Create: `test/features/map/reshape/reshape_mode_controller_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `test/features/map/reshape/reshape_mode_controller_test.dart`:
+
+```dart
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/features/map/reshape/domain/reshape_op.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_mode_controller.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+ProviderContainer _container() => ProviderContainer();
+
+Feature _seedBuilding({String id = 'f1'}) => Feature(
+      id: id,
+      assignmentId: 'a1',
+      featureType: 'building',
+      geometryGeojson:
+          '{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}',
+      isNew: false,
+      status: 'unfilled',
+      createdAt: DateTime.utc(2026, 1, 1),
+    );
+
+void main() {
+  test('initial state is inactive', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    final state = c.read(reshapeModeControllerProvider);
+    expect(state.isActive, isFalse);
+  });
+
+  test('enterReshape parses geojson into workingRings', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    c.read(reshapeModeControllerProvider.notifier).enterReshape(
+          feature: _seedBuilding(),
+          overrideReason: null,
+        );
+    final s = c.read(reshapeModeControllerProvider);
+    expect(s.isActive, isTrue);
+    expect(s.workingRings, hasLength(1));
+    // Open form: 4 unique vertices (closed ring's duplicate stripped).
+    expect(s.workingRings[0], hasLength(4));
+    expect(s.isDirty, isFalse);
+  });
+
+  test('moveVertex pushes a Move op and updates the ring', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    final notifier = c.read(reshapeModeControllerProvider.notifier);
+    notifier.enterReshape(feature: _seedBuilding(), overrideReason: null);
+    notifier.moveVertex(0, 0, (lng: 5, lat: 5));
+    final s = c.read(reshapeModeControllerProvider);
+    expect(s.workingRings[0][0], (lng: 5.0, lat: 5.0));
+    expect(s.undoStack, hasLength(1));
+    expect(s.undoStack.last, isA<Move>());
+    expect(s.isDirty, isTrue);
+  });
+
+  test('addVertex inserts at index and pushes Add', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    final n = c.read(reshapeModeControllerProvider.notifier);
+    n.enterReshape(feature: _seedBuilding(), overrideReason: null);
+    n.addVertex(0, 1, (lng: 0.5, lat: 0));
+    final s = c.read(reshapeModeControllerProvider);
+    expect(s.workingRings[0], hasLength(5));
+    expect(s.workingRings[0][1], (lng: 0.5, lat: 0));
+  });
+
+  test('removeVertex removes and pushes Remove', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    final n = c.read(reshapeModeControllerProvider.notifier);
+    n.enterReshape(feature: _seedBuilding(), overrideReason: null);
+    n.removeVertex(0, 0);
+    final s = c.read(reshapeModeControllerProvider);
+    expect(s.workingRings[0], hasLength(3));
+  });
+
+  test('removeVertex is a no-op at 3 vertices', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    final n = c.read(reshapeModeControllerProvider.notifier);
+    n.enterReshape(feature: _seedBuilding(), overrideReason: null);
+    n.removeVertex(0, 0); // 4 → 3
+    n.removeVertex(0, 0); // 3 → blocked
+    final s = c.read(reshapeModeControllerProvider);
+    expect(s.workingRings[0], hasLength(3));
+  });
+
+  test('undo pops and inverts last op', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    final n = c.read(reshapeModeControllerProvider.notifier);
+    n.enterReshape(feature: _seedBuilding(), overrideReason: null);
+    n.moveVertex(0, 0, (lng: 5, lat: 5));
+    n.undo();
+    final s = c.read(reshapeModeControllerProvider);
+    expect(s.workingRings[0][0], (lng: 0.0, lat: 0.0));
+    expect(s.undoStack, isEmpty);
+  });
+
+  test('cancel returns to inactive', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    final n = c.read(reshapeModeControllerProvider.notifier);
+    n.enterReshape(feature: _seedBuilding(), overrideReason: null);
+    n.moveVertex(0, 0, (lng: 5, lat: 5));
+    n.cancel();
+    final s = c.read(reshapeModeControllerProvider);
+    expect(s.isActive, isFalse);
+  });
+
+  test('selfIntersects flag tracks bowtie state during drag', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    final n = c.read(reshapeModeControllerProvider.notifier);
+    n.enterReshape(feature: _seedBuilding(), overrideReason: null);
+
+    // Make the polygon a bowtie by swapping two opposite vertices.
+    n.moveVertex(0, 1, (lng: 1, lat: 1)); // was (1,0); coincides with v[2]
+    final s1 = c.read(reshapeModeControllerProvider);
+    // Coincident with neighbor → not strictly self-intersecting transverse;
+    // selfIntersects may be false depending on implementation. The contract
+    // is "best-effort flag during drag; final correctness checked at save."
+    // What matters: this call did not crash and updated the working ring.
+    expect(s1.workingRings[0][1], (lng: 1.0, lat: 1.0));
+
+    // Force a transverse bowtie: swap diagonal corners.
+    n.moveVertex(0, 1, (lng: 0, lat: 1));
+    n.moveVertex(0, 3, (lng: 1, lat: 0));
+    final s2 = c.read(reshapeModeControllerProvider);
+    expect(s2.selfIntersects, isTrue);
+  });
+}
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+```bash
+flutter test test/features/map/reshape/reshape_mode_controller_test.dart
+```
+
+Expected: compile error — controller and provider undefined.
+
+- [ ] **Step 3: Implement controller and provider**
+
+Create `lib/features/map/reshape/presentation/reshape_mode_controller.dart`:
+
+```dart
+import 'dart:convert';
+
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/geo/polygon_validator.dart';
+import 'package:firecheck/features/map/reshape/domain/reshape_mode_state.dart';
+import 'package:firecheck/features/map/reshape/domain/reshape_op.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ReshapeModeController extends Notifier<ReshapeModeState> {
+  @override
+  ReshapeModeState build() => const ReshapeModeState();
+
+  void enterReshape({required Feature feature, String? overrideReason}) {
+    final rings = _parseGeojson(feature.geometryGeojson);
+    state = ReshapeModeState(
+      originalFeature: feature,
+      workingRings: rings,
+      undoStack: const [],
+      selfIntersects: false,
+      saving: false,
+      overrideReason: overrideReason,
+    );
+  }
+
+  void cancel() {
+    state = const ReshapeModeState();
+  }
+
+  void moveVertex(int ringIdx, int vertexIdx, LngLat next) {
+    if (!state.isActive) return;
+    final rings = _cloneRings(state.workingRings);
+    final prev = rings[ringIdx][vertexIdx];
+    rings[ringIdx][vertexIdx] = next;
+    final newStack = [
+      ...state.undoStack,
+      Move(ringIdx: ringIdx, vertexIdx: vertexIdx, prev: prev, next: next),
+    ];
+    state = state.copyWith(
+      workingRings: rings,
+      undoStack: newStack,
+      selfIntersects: _hasSelfIntersection(rings[0]),
+    );
+  }
+
+  void addVertex(int ringIdx, int vertexIdx, LngLat lngLat) {
+    if (!state.isActive) return;
+    final rings = _cloneRings(state.workingRings);
+    rings[ringIdx].insert(vertexIdx, lngLat);
+    final newStack = [
+      ...state.undoStack,
+      Add(ringIdx: ringIdx, vertexIdx: vertexIdx, lngLat: lngLat),
+    ];
+    state = state.copyWith(
+      workingRings: rings,
+      undoStack: newStack,
+      selfIntersects: _hasSelfIntersection(rings[0]),
+    );
+  }
+
+  void removeVertex(int ringIdx, int vertexIdx) {
+    if (!state.isActive) return;
+    final ring = state.workingRings[ringIdx];
+    if (ring.length <= 3) return; // AC3: prevent drop below 3
+    final removed = ring[vertexIdx];
+    final rings = _cloneRings(state.workingRings);
+    rings[ringIdx].removeAt(vertexIdx);
+    final newStack = [
+      ...state.undoStack,
+      Remove(ringIdx: ringIdx, vertexIdx: vertexIdx, removed: removed),
+    ];
+    state = state.copyWith(
+      workingRings: rings,
+      undoStack: newStack,
+      selfIntersects: _hasSelfIntersection(rings[0]),
+    );
+  }
+
+  void undo() {
+    if (state.undoStack.isEmpty) return;
+    final top = state.undoStack.last;
+    final rings = _cloneRings(state.workingRings);
+    switch (top) {
+      case Move():
+        rings[top.ringIdx][top.vertexIdx] = top.prev;
+      case Add():
+        rings[top.ringIdx].removeAt(top.vertexIdx);
+      case Remove():
+        rings[top.ringIdx].insert(top.vertexIdx, top.removed);
+    }
+    state = state.copyWith(
+      workingRings: rings,
+      undoStack: state.undoStack.sublist(0, state.undoStack.length - 1),
+      selfIntersects: _hasSelfIntersection(rings[0]),
+    );
+  }
+
+  void markSaving(bool saving) {
+    state = state.copyWith(saving: saving);
+  }
+
+  /// Serializes the current working copy back to a closed-ring GeoJSON Polygon.
+  String serializeWorkingPolygon() {
+    final rings = state.workingRings.map((r) {
+      final closed = [...r, r.first];
+      return closed.map((v) => [v.lng, v.lat]).toList();
+    }).toList();
+    return jsonEncode({'type': 'Polygon', 'coordinates': rings});
+  }
+}
+
+List<List<LngLat>> _parseGeojson(String s) {
+  final m = jsonDecode(s) as Map<String, dynamic>;
+  final coords = m['coordinates'] as List;
+  return coords.map<List<LngLat>>((ring) {
+    final list = (ring as List).map<LngLat>((p) {
+      final pair = p as List;
+      return (lng: (pair[0] as num).toDouble(), lat: (pair[1] as num).toDouble());
+    }).toList();
+    // Strip the duplicated closing vertex if present (open form).
+    if (list.length >= 2 && list.first == list.last) {
+      list.removeLast();
+    }
+    return list;
+  }).toList();
+}
+
+List<List<LngLat>> _cloneRings(List<List<LngLat>> rings) {
+  return rings.map((r) => List<LngLat>.from(r)).toList();
+}
+
+bool _hasSelfIntersection(List<LngLat> outer) {
+  // Reuse the same algorithm via a no-op boundary check — we only need rule 3
+  // here. Build a boundary that contains the whole world so rule 4 always
+  // passes; rules 1, 2 are cheap.
+  const worldBoundary =
+      '{"type":"Polygon","coordinates":[[[-180,-90],[180,-90],[180,90],[-180,90],[-180,-90]]]}';
+  final r = validateBuildingPolygon([outer], boundaryGeojson: worldBoundary);
+  return r.error == PolygonValidationError.selfIntersection;
+}
+```
+
+Create `lib/features/map/reshape/presentation/reshape_providers.dart`:
+
+```dart
+import 'package:firecheck/core/db/database_provider.dart';
+import 'package:firecheck/features/map/reshape/data/feature_geometry_revisions_repository.dart';
+import 'package:firecheck/features/map/reshape/domain/reshape_mode_state.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_mode_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final reshapeModeControllerProvider =
+    NotifierProvider<ReshapeModeController, ReshapeModeState>(
+  ReshapeModeController.new,
+);
+
+final reshapeRepositoryProvider =
+    Provider<FeatureGeometryRevisionsRepository>((ref) {
+  return FeatureGeometryRevisionsRepository(ref.watch(appDatabaseProvider));
+});
+```
+
+Note: `appDatabaseProvider` already exists in this codebase (used by other repositories). If the import path differs, adjust to the project convention — search for `Provider<AppDatabase>` to find it.
+
+- [ ] **Step 4: Run; pass**
+
+```bash
+flutter test test/features/map/reshape/reshape_mode_controller_test.dart
+```
+
+Expected: all tests PASS. (The bowtie test verifies `selfIntersects` becomes true after diagonal swap.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/map/reshape/presentation/reshape_mode_controller.dart \
+        lib/features/map/reshape/presentation/reshape_providers.dart \
+        test/features/map/reshape/reshape_mode_controller_test.dart
+git commit -m "feat(reshape): ReshapeModeController + Riverpod providers (US-9 T8)"
+```
+
+---
+
+## Task 9: VertexHandle + MidpointHandle widgets
+
+**Files:**
+- Create: `lib/features/map/reshape/presentation/vertex_handle.dart`
+- Create: `lib/features/map/reshape/presentation/midpoint_handle.dart`
+- Create: `test/features/map/reshape/vertex_handle_test.dart`
+- Create: `test/features/map/reshape/midpoint_handle_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `test/features/map/reshape/vertex_handle_test.dart`:
+
+```dart
+import 'package:firecheck/features/map/reshape/presentation/vertex_handle.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('VertexHandle has 44x44 hit area', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: Center(child: VertexHandle()),
+      ),
+    ));
+    final size = tester.getSize(find.byType(VertexHandle));
+    expect(size.width, greaterThanOrEqualTo(44));
+    expect(size.height, greaterThanOrEqualTo(44));
+  });
+}
+```
+
+Create `test/features/map/reshape/midpoint_handle_test.dart`:
+
+```dart
+import 'package:firecheck/features/map/reshape/presentation/midpoint_handle.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('MidpointHandle has 44x44 hit area', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: Center(child: MidpointHandle()),
+      ),
+    ));
+    final size = tester.getSize(find.byType(MidpointHandle));
+    expect(size.width, greaterThanOrEqualTo(44));
+    expect(size.height, greaterThanOrEqualTo(44));
+  });
+}
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+```bash
+flutter test test/features/map/reshape/vertex_handle_test.dart test/features/map/reshape/midpoint_handle_test.dart
+```
+
+Expected: compile errors — widgets undefined.
+
+- [ ] **Step 3: Implement widgets**
+
+Create `lib/features/map/reshape/presentation/vertex_handle.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+
+class VertexHandle extends StatelessWidget {
+  const VertexHandle({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // 44x44 hit target with a 14x14 visual.
+    return SizedBox(
+      width: 44,
+      height: 44,
+      child: Center(
+        child: Container(
+          width: 14,
+          height: 14,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            shape: BoxShape.circle,
+            border: Border.all(color: const Color(0xFF3182CE), width: 2),
+            boxShadow: const [
+              BoxShadow(blurRadius: 3, color: Color(0x66000000)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+Create `lib/features/map/reshape/presentation/midpoint_handle.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+
+class MidpointHandle extends StatelessWidget {
+  const MidpointHandle({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 44,
+      height: 44,
+      child: Center(
+        child: Container(
+          width: 10,
+          height: 10,
+          decoration: BoxDecoration(
+            color: const Color(0x993182CE),
+            shape: BoxShape.circle,
+            border: Border.all(color: Colors.white, width: 1.5),
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run tests; pass**
+
+```bash
+flutter test test/features/map/reshape/vertex_handle_test.dart test/features/map/reshape/midpoint_handle_test.dart
+```
+
+Expected: 2 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/map/reshape/presentation/vertex_handle.dart \
+        lib/features/map/reshape/presentation/midpoint_handle.dart \
+        test/features/map/reshape/vertex_handle_test.dart \
+        test/features/map/reshape/midpoint_handle_test.dart
+git commit -m "feat(reshape): VertexHandle + MidpointHandle pure-UI widgets (US-9 T9)"
+```
+
+---
+
+## Task 10: ReshapeBanner widget
+
+**Files:**
+- Create: `lib/features/map/reshape/presentation/reshape_banner.dart`
+- Create: `test/features/map/reshape/reshape_banner_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `test/features/map/reshape/reshape_banner_test.dart`:
+
+```dart
+import 'package:firecheck/features/map/reshape/presentation/reshape_banner.dart';
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en')],
+      home: Scaffold(body: child),
+    );
+
+void main() {
+  testWidgets('renders edit count and title', (tester) async {
+    await tester.pumpWidget(_wrap(const ReshapeBanner(
+      editCount: 3,
+      undoEnabled: true,
+      saveEnabled: true,
+    )));
+    expect(find.textContaining('3'), findsOneWidget);
+  });
+
+  testWidgets('Save tap fires onSave', (tester) async {
+    var saves = 0;
+    await tester.pumpWidget(_wrap(ReshapeBanner(
+      editCount: 1,
+      undoEnabled: true,
+      saveEnabled: true,
+      onSave: () => saves++,
+    )));
+    await tester.tap(find.byKey(const Key('reshape.banner.save')));
+    expect(saves, 1);
+  });
+
+  testWidgets('Cancel tap fires onCancel', (tester) async {
+    var cancels = 0;
+    await tester.pumpWidget(_wrap(ReshapeBanner(
+      editCount: 0,
+      undoEnabled: false,
+      saveEnabled: false,
+      onCancel: () => cancels++,
+    )));
+    await tester.tap(find.byKey(const Key('reshape.banner.cancel')));
+    expect(cancels, 1);
+  });
+
+  testWidgets('Undo tap fires onUndo when enabled', (tester) async {
+    var undos = 0;
+    await tester.pumpWidget(_wrap(ReshapeBanner(
+      editCount: 1,
+      undoEnabled: true,
+      saveEnabled: true,
+      onUndo: () => undos++,
+    )));
+    await tester.tap(find.byKey(const Key('reshape.banner.undo')));
+    expect(undos, 1);
+  });
+
+  testWidgets('Save disabled does not fire onSave', (tester) async {
+    var saves = 0;
+    await tester.pumpWidget(_wrap(ReshapeBanner(
+      editCount: 0,
+      undoEnabled: false,
+      saveEnabled: false,
+      onSave: () => saves++,
+    )));
+    await tester.tap(find.byKey(const Key('reshape.banner.save')));
+    expect(saves, 0);
+  });
+}
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+```bash
+flutter test test/features/map/reshape/reshape_banner_test.dart
+```
+
+Expected: compile errors — widget undefined.
+
+- [ ] **Step 3: Implement**
+
+Create `lib/features/map/reshape/presentation/reshape_banner.dart`:
+
+```dart
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+
+class ReshapeBanner extends StatelessWidget {
+  const ReshapeBanner({
+    super.key,
+    required this.editCount,
+    required this.undoEnabled,
+    required this.saveEnabled,
+    this.onCancel,
+    this.onUndo,
+    this.onSave,
+  });
+
+  final int editCount;
+  final bool undoEnabled;
+  final bool saveEnabled;
+  final VoidCallback? onCancel;
+  final VoidCallback? onUndo;
+  final VoidCallback? onSave;
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context)!;
+    return Material(
+      color: const Color(0xFF3182CE),
+      child: SafeArea(
+        bottom: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              child: Row(
+                children: [
+                  TextButton(
+                    key: const Key('reshape.banner.cancel'),
+                    onPressed: onCancel,
+                    style: TextButton.styleFrom(foregroundColor: Colors.white),
+                    child: const Text('Cancel'),
+                  ),
+                  Expanded(
+                    child: Text(
+                      l.reshapeBannerTitle(editCount),
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  FilledButton(
+                    key: const Key('reshape.banner.save'),
+                    onPressed: saveEnabled ? onSave : null,
+                    style: FilledButton.styleFrom(
+                      backgroundColor: Colors.white,
+                      foregroundColor: const Color(0xFF3182CE),
+                      disabledBackgroundColor:
+                          Colors.white.withValues(alpha: 0.4),
+                    ),
+                    child: Text(l.reshapeBannerSave),
+                  ),
+                ],
+              ),
+            ),
+            // Undo chip below the row.
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(12, 0, 0, 6),
+                child: TextButton.icon(
+                  key: const Key('reshape.banner.undo'),
+                  onPressed: undoEnabled ? onUndo : null,
+                  icon: const Icon(Icons.undo, color: Colors.white, size: 16),
+                  label: const Text('Undo',
+                      style: TextStyle(color: Colors.white)),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run tests; pass**
+
+```bash
+flutter test test/features/map/reshape/reshape_banner_test.dart
+```
+
+Expected: 5 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/map/reshape/presentation/reshape_banner.dart \
+        test/features/map/reshape/reshape_banner_test.dart
+git commit -m "feat(reshape): ReshapeBanner widget — Cancel | edits | Save + Undo (US-9 T10)"
+```
+
+---
+
+## Task 11: ReshapeRemoveConfirmDialog
+
+**Files:**
+- Create: `lib/features/map/reshape/presentation/reshape_remove_confirm_dialog.dart`
+- Create: `test/features/map/reshape/reshape_remove_confirm_dialog_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `test/features/map/reshape/reshape_remove_confirm_dialog_test.dart`:
+
+```dart
+import 'package:firecheck/features/map/reshape/presentation/reshape_remove_confirm_dialog.dart';
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en')],
+      home: child,
+    );
+
+void main() {
+  testWidgets('confirm tap returns true', (tester) async {
+    bool? result;
+    await tester.pumpWidget(_wrap(Builder(builder: (ctx) {
+      return TextButton(
+        onPressed: () async {
+          result = await showReshapeRemoveConfirm(ctx, currentRingLength: 5);
+        },
+        child: const Text('open'),
+      );
+    })));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('reshape.remove.confirm')));
+    await tester.pumpAndSettle();
+    expect(result, isTrue);
+  });
+
+  testWidgets('cancel tap returns false', (tester) async {
+    bool? result;
+    await tester.pumpWidget(_wrap(Builder(builder: (ctx) {
+      return TextButton(
+        onPressed: () async {
+          result = await showReshapeRemoveConfirm(ctx, currentRingLength: 5);
+        },
+        child: const Text('open'),
+      );
+    })));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('reshape.remove.cancel')));
+    await tester.pumpAndSettle();
+    expect(result, isFalse);
+  });
+
+  testWidgets('confirm disabled at 3 vertices', (tester) async {
+    await tester.pumpWidget(_wrap(Builder(builder: (ctx) {
+      return TextButton(
+        onPressed: () async {
+          await showReshapeRemoveConfirm(ctx, currentRingLength: 3);
+        },
+        child: const Text('open'),
+      );
+    })));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    final btn = tester.widget<FilledButton>(
+      find.byKey(const Key('reshape.remove.confirm')),
+    );
+    expect(btn.onPressed, isNull);
+  });
+}
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+```bash
+flutter test test/features/map/reshape/reshape_remove_confirm_dialog_test.dart
+```
+
+- [ ] **Step 3: Implement**
+
+Create `lib/features/map/reshape/presentation/reshape_remove_confirm_dialog.dart`:
+
+```dart
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+
+Future<bool> showReshapeRemoveConfirm(
+  BuildContext context, {
+  required int currentRingLength,
+}) async {
+  final l = AppLocalizations.of(context)!;
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (ctx) {
+      final canConfirm = currentRingLength > 3;
+      return AlertDialog(
+        title: Text(l.reshapeRemoveConfirmTitle),
+        content: Text(l.reshapeRemoveConfirmBody),
+        actions: [
+          TextButton(
+            key: const Key('reshape.remove.cancel'),
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(l.cancelLabel),
+          ),
+          FilledButton(
+            key: const Key('reshape.remove.confirm'),
+            onPressed:
+                canConfirm ? () => Navigator.of(ctx).pop(true) : null,
+            style: FilledButton.styleFrom(
+              backgroundColor: const Color(0xFFC53030),
+            ),
+            child: Text(l.reshapeRemoveConfirmRemove),
+          ),
+        ],
+      );
+    },
+  );
+  return result ?? false;
+}
+```
+
+- [ ] **Step 4: Run; pass**
+
+```bash
+flutter test test/features/map/reshape/reshape_remove_confirm_dialog_test.dart
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/map/reshape/presentation/reshape_remove_confirm_dialog.dart \
+        test/features/map/reshape/reshape_remove_confirm_dialog_test.dart
+git commit -m "feat(reshape): showReshapeRemoveConfirm — confirm disabled at 3 vertices (US-9 T11)"
+```
+
+---
+
+## Task 12: ReshapeActionSheet
+
+**Files:**
+- Create: `lib/features/map/reshape/presentation/reshape_action_sheet.dart`
+- Create: `test/features/map/reshape/reshape_action_sheet_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `test/features/map/reshape/reshape_action_sheet_test.dart`:
+
+```dart
+import 'package:firecheck/features/map/reshape/presentation/reshape_action_sheet.dart';
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en')],
+      home: child,
+    );
+
+void main() {
+  testWidgets('returns openForm on Open form tap', (tester) async {
+    ReshapeAction? r;
+    await tester.pumpWidget(_wrap(Builder(builder: (ctx) {
+      return TextButton(
+        onPressed: () async {
+          r = await showReshapeActionSheet(ctx, locked: false);
+        },
+        child: const Text('open'),
+      );
+    })));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('reshape.actionsheet.openForm')));
+    await tester.pumpAndSettle();
+    expect(r, ReshapeAction.openForm);
+  });
+
+  testWidgets('returns reshape on Reshape tap', (tester) async {
+    ReshapeAction? r;
+    await tester.pumpWidget(_wrap(Builder(builder: (ctx) {
+      return TextButton(
+        onPressed: () async {
+          r = await showReshapeActionSheet(ctx, locked: false);
+        },
+        child: const Text('open'),
+      );
+    })));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+    await tester.pumpAndSettle();
+    expect(r, ReshapeAction.reshape);
+  });
+
+  testWidgets('Reshape item disabled when locked', (tester) async {
+    await tester.pumpWidget(_wrap(Builder(builder: (ctx) {
+      return TextButton(
+        onPressed: () async {
+          await showReshapeActionSheet(ctx, locked: true);
+        },
+        child: const Text('open'),
+      );
+    })));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    final tile = tester.widget<ListTile>(
+      find.byKey(const Key('reshape.actionsheet.reshape')),
+    );
+    expect(tile.enabled, isFalse);
+  });
+}
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+```bash
+flutter test test/features/map/reshape/reshape_action_sheet_test.dart
+```
+
+- [ ] **Step 3: Implement**
+
+Create `lib/features/map/reshape/presentation/reshape_action_sheet.dart`:
+
+```dart
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+
+enum ReshapeAction { openForm, reshape }
+
+Future<ReshapeAction?> showReshapeActionSheet(
+  BuildContext context, {
+  required bool locked,
+}) {
+  final l = AppLocalizations.of(context)!;
+  return showModalBottomSheet<ReshapeAction>(
+    context: context,
+    builder: (ctx) {
+      return SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              title: Text(l.reshapeActionSheetTitle,
+                  style: const TextStyle(fontWeight: FontWeight.bold)),
+              dense: true,
+            ),
+            ListTile(
+              key: const Key('reshape.actionsheet.openForm'),
+              leading: const Icon(Icons.edit_document),
+              title: Text(l.reshapeActionSheetOpenForm),
+              onTap: () => Navigator.of(ctx).pop(ReshapeAction.openForm),
+            ),
+            ListTile(
+              key: const Key('reshape.actionsheet.reshape'),
+              enabled: !locked,
+              leading: const Icon(Icons.share_location),
+              title: Text(l.reshapeActionSheetReshape),
+              onTap: locked
+                  ? null
+                  : () => Navigator.of(ctx).pop(ReshapeAction.reshape),
+            ),
+            ListTile(
+              leading: const Icon(Icons.close),
+              title: Text(l.cancelLabel),
+              onTap: () => Navigator.of(ctx).pop(),
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+```
+
+- [ ] **Step 4: Run; pass**
+
+```bash
+flutter test test/features/map/reshape/reshape_action_sheet_test.dart
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/map/reshape/presentation/reshape_action_sheet.dart \
+        test/features/map/reshape/reshape_action_sheet_test.dart
+git commit -m "feat(reshape): showReshapeActionSheet — Open form / Reshape (locked-aware) / Cancel (US-9 T12)"
+```
+
+---
+
+## Task 13: MapRenderer signature additions + FakeMapRenderer test seams
+
+**Files:**
+- Modify: `lib/features/map/presentation/map_renderer.dart`
+
+- [ ] **Step 1: Extend the abstract `MapRenderer.build` signature**
+
+In `lib/features/map/presentation/map_renderer.dart`, replace the abstract `MapRenderer` class with:
+
+```dart
+/// Minimal surface the map screen actually needs.
+// ignore: one_member_abstracts
+abstract class MapRenderer {
+  Widget build(
+    BuildContext context, {
+    required List<Feature> features,
+    required String boundaryGeojson,
+    required void Function(Feature) onFeatureTap,
+    void Function(double lat, double lng)? onLongPress,
+    void Function(double zoom, double lat, double lng)? onCameraChanged,
+    bool addModeActive,
+    CameraTarget? cameraTarget,
+    CameraTarget? initialCameraTarget,
+    // US-9 reshape additions:
+    void Function(Feature)? onPolygonLongPress,
+    String? reshapeWorkingPolygonGeojson,
+    String? reshapeInvalidEdgeGeojson,
+    void Function(MapProjection projection)? onProjectionReady,
+  });
+}
+
+/// Lat/lng ↔ screen-px projection seam exposed by the renderer to overlays.
+abstract class MapProjection {
+  Offset screenPointFromLngLat(double lng, double lat);
+  ({double lng, double lat}) lngLatFromScreenPoint(Offset point);
+}
+```
+
+- [ ] **Step 2: Extend `FakeMapRenderer`**
+
+In the same file, update `FakeMapRenderer` so its fields and `build` cover the new params, and provide a fake `MapProjection`:
+
+Replace `FakeMapRenderer`'s field declarations and `build` with:
+
+```dart
+class FakeMapRenderer implements MapRenderer {
+  void Function(double, double)? _lastOnLongPress;
+  void Function(double, double, double)? _lastOnCameraChanged;
+  void Function(Feature)? _lastOnPolygonLongPress;
+  CameraTarget? lastCameraTarget;
+  CameraTarget? lastInitialCameraTarget;
+  String? lastReshapeWorkingPolygonGeojson;
+  String? lastReshapeInvalidEdgeGeojson;
+  final List<CameraTarget> cameraTargetHistory = [];
+
+  Future<void> simulateLongPress(double lat, double lng) async {
+    _lastOnLongPress?.call(lat, lng);
+  }
+
+  Future<void> simulateCameraChanged(double zoom, double lat, double lng) async {
+    _lastOnCameraChanged?.call(zoom, lat, lng);
+  }
+
+  Future<void> simulatePolygonLongPress(Feature f) async {
+    _lastOnPolygonLongPress?.call(f);
+  }
+
+  @override
+  Widget build(
+    BuildContext context, {
+    required List<Feature> features,
+    required String boundaryGeojson,
+    required void Function(Feature) onFeatureTap,
+    void Function(double lat, double lng)? onLongPress,
+    void Function(double zoom, double lat, double lng)? onCameraChanged,
+    bool addModeActive = false,
+    CameraTarget? cameraTarget,
+    CameraTarget? initialCameraTarget,
+    void Function(Feature)? onPolygonLongPress,
+    String? reshapeWorkingPolygonGeojson,
+    String? reshapeInvalidEdgeGeojson,
+    void Function(MapProjection projection)? onProjectionReady,
+  }) {
+    _lastOnLongPress = onLongPress;
+    _lastOnCameraChanged = onCameraChanged;
+    _lastOnPolygonLongPress = onPolygonLongPress;
+    lastInitialCameraTarget = initialCameraTarget;
+    if (cameraTarget != null && cameraTarget != lastCameraTarget) {
+      cameraTargetHistory.add(cameraTarget);
+    }
+    lastCameraTarget = cameraTarget;
+    lastReshapeWorkingPolygonGeojson = reshapeWorkingPolygonGeojson;
+    lastReshapeInvalidEdgeGeojson = reshapeInvalidEdgeGeojson;
+
+    // Identity projection: each lng,lat maps to (lng, lat) screen pixels.
+    onProjectionReady?.call(_IdentityProjection());
+
+    return ListView(
+      shrinkWrap: true,
+      children: [
+        if (addModeActive)
+          const Padding(
+            padding: EdgeInsets.all(8),
+            child: Text('add-mode'),
+          ),
+        ...features.map((f) {
+          return GestureDetector(
+            key: Key('fake-map-feature-${f.id}'),
+            onTap: () => onFeatureTap(f),
+            onLongPress: f.isNew
+                ? null
+                : () => onPolygonLongPress?.call(f),
+            child: Container(
+              key: f.isNew
+                  ? Key('fake-map-new-feature-${f.id}')
+                  : Key('fake-map-poly-${f.id}'),
+              margin: const EdgeInsets.all(4),
+              padding: const EdgeInsets.all(8),
+              color: _colorForStatus(f.status),
+              child: Text('feature ${f.id}'),
+            ),
+          );
+        }),
+      ],
+    );
+  }
+
+  Color _colorForStatus(String status) {
+    switch (status) {
+      case 'complete':
+        return const Color(0x66276749);
+      case 'in_progress':
+        return const Color(0x66B7791F);
+      default:
+        return const Color(0x66C53030);
+    }
+  }
+}
+
+class _IdentityProjection implements MapProjection {
+  @override
+  Offset screenPointFromLngLat(double lng, double lat) => Offset(lng, lat);
+
+  @override
+  ({double lng, double lat}) lngLatFromScreenPoint(Offset point) =>
+      (lng: point.dx, lat: point.dy);
+}
+```
+
+- [ ] **Step 3: Extend `MapboxMapRenderer` and `_MapboxMapView`**
+
+In `MapboxMapRenderer.build`, accept the new params and pass them through to `_MapboxMapView`. Then add the matching final fields to `_MapboxMapView` constructor / class.
+
+Replace `MapboxMapRenderer.build` body and `_MapboxMapView` constructor + fields with the equivalent that propagates the four new params (mirroring how `cameraTarget` / `initialCameraTarget` already flow). The new fields: `onPolygonLongPress`, `reshapeWorkingPolygonGeojson`, `reshapeInvalidEdgeGeojson`, `onProjectionReady`.
+
+In `_MapboxMapViewState._onMapCreated`, after the existing `await _renderBoundary(); await _renderFeatures(); await _renderNewFeatures();`, add:
+
+```dart
+    // Expose lat/lng ↔ screen-px projection to ReshapeOverlay.
+    widget.onProjectionReady?.call(_MapboxProjection(map));
+```
+
+In the existing `addOnPolygonAnnotationClickListener` block, also wire a long-press: mapbox_maps_flutter does not surface per-annotation long-press; instead, in `_MapboxMapView.build()`'s `MapWidget`, replace the existing `onLongTapListener` with:
+
+```dart
+      onLongTapListener: (MapContentGestureContext ctx) async {
+        // Add-mode placement remains unchanged.
+        if (widget.addModeActive && widget.onLongPress != null) {
+          final pos = ctx.point.coordinates;
+          widget.onLongPress!(pos.lat.toDouble(), pos.lng.toDouble());
+          return;
+        }
+        // Reshape entry: hit-test all rendered polygons against the long-press point.
+        final cb = widget.onPolygonLongPress;
+        if (cb == null) return;
+        final hit = _hitTestPolygon(
+          ctx.point.coordinates.lat.toDouble(),
+          ctx.point.coordinates.lng.toDouble(),
+        );
+        if (hit != null) cb(hit);
+      },
+```
+
+Add this method to `_MapboxMapViewState`:
+
+```dart
+  Feature? _hitTestPolygon(double lat, double lng) {
+    for (final f in widget.features) {
+      if (f.isNew) continue;
+      if (pointInPolygonGeojson(lat, lng, f.geometryGeojson)) return f;
+    }
+    return null;
+  }
+```
+
+Add the import at the top of the file:
+
+```dart
+import 'package:firecheck/core/geo/point_in_polygon.dart';
+```
+
+In `didUpdateWidget`, add a re-render of the in-progress polygon when `reshapeWorkingPolygonGeojson` changes (covered in Step 4 below as a separate concern; for this task just store the value and trigger a rerender).
+
+Append at the bottom of the file (above the last closing brace):
+
+```dart
+/// Caches lat/lng → screen-px projections for the *current* working ring's
+/// vertices. Refreshed by [refresh] on every camera change. Synchronous reads
+/// against a memoized table are required because ReshapeOverlay rebuilds on
+/// every Riverpod tick (drag updates) and cannot afford an async hop.
+///
+/// Reverse mapping (screen → lng/lat) for in-flight drags uses the linear
+/// inverse of the cached two-point sample (top-left + top-right of the
+/// camera bounds), which is accurate to within a fraction of a pixel inside
+/// the visible viewport at the zoom levels used for reshape (≥17).
+class _MapboxProjection implements MapProjection {
+  _MapboxProjection(this._map);
+  final MapboxMap _map;
+
+  // Two cached calibration points refreshed on each camera change.
+  Offset? _topLeftPx;
+  Position? _topLeftLngLat;
+  Offset? _bottomRightPx;
+  Position? _bottomRightLngLat;
+
+  /// Call after the map's camera changes (and once at first ready). Awaits the
+  /// async pixelForCoordinate twice; the cached samples then feed both the
+  /// forward and inverse synchronous methods below.
+  Future<void> refresh(double viewportWidth, double viewportHeight) async {
+    final size = MbxImage(width: viewportWidth.toInt(), height: viewportHeight.toInt(), data: Uint8List(0));
+    // Coordinates of viewport corners — the values we need for the linear
+    // calibration that the sync API exposes.
+    final tl = await _map.coordinateForPixel(ScreenCoordinate(x: 0, y: 0));
+    final br = await _map.coordinateForPixel(
+      ScreenCoordinate(x: viewportWidth, y: viewportHeight),
+    );
+    _topLeftPx = const Offset(0, 0);
+    _topLeftLngLat = tl;
+    _bottomRightPx = Offset(viewportWidth, viewportHeight);
+    _bottomRightLngLat = br;
+  }
+
+  @override
+  Offset screenPointFromLngLat(double lng, double lat) {
+    final tlP = _topLeftPx, brP = _bottomRightPx;
+    final tlC = _topLeftLngLat, brC = _bottomRightLngLat;
+    if (tlP == null || brP == null || tlC == null || brC == null) {
+      return Offset.zero;
+    }
+    final tx = (lng - tlC.lng) / (brC.lng - tlC.lng);
+    final ty = (lat - tlC.lat) / (brC.lat - tlC.lat);
+    return Offset(
+      tlP.dx + tx * (brP.dx - tlP.dx),
+      tlP.dy + ty * (brP.dy - tlP.dy),
+    );
+  }
+
+  @override
+  ({double lng, double lat}) lngLatFromScreenPoint(Offset p) {
+    final tlP = _topLeftPx, brP = _bottomRightPx;
+    final tlC = _topLeftLngLat, brC = _bottomRightLngLat;
+    if (tlP == null || brP == null || tlC == null || brC == null) {
+      return (lng: 0.0, lat: 0.0);
+    }
+    final tx = (p.dx - tlP.dx) / (brP.dx - tlP.dx);
+    final ty = (p.dy - tlP.dy) / (brP.dy - tlP.dy);
+    return (
+      lng: tlC.lng + tx * (brC.lng - tlC.lng),
+      lat: tlC.lat + ty * (brC.lat - tlC.lat),
+    );
+  }
+}
+```
+
+Wire `refresh` into the existing `onCameraChangeListener` in `_MapboxMapView.build()` — call `await projection.refresh(constraints.maxWidth, constraints.maxHeight)` and then `widget.onProjectionReady?.call(projection)`. Wrap the renderer body in a `LayoutBuilder` to access `constraints`. Initial refresh runs at the end of `_onMapCreated`. Replace the existing `widget.onProjectionReady?.call(_MapboxProjection(map));` line at end of `_onMapCreated` with a `LayoutBuilder`-aware first refresh.
+
+Add the imports at the top of `map_renderer.dart`:
+
+```dart
+import 'dart:typed_data';
+```
+
+The linear-corner calibration is approximate near map edges and at very low zoom. At zoom ≥17 (the typical reshape working zoom) inside the visible viewport, error is sub-pixel — acceptable for finger-drag UX. For future precision, swap this projection for per-vertex `pixelForCoordinate` cached on every camera change (covered by spec §14 as "open questions deferred to implementation"; the test seam in `FakeMapRenderer` is unaffected because it ships an identity projection that's correct for the test bounds).
+
+- [ ] **Step 4: Render the working polygon overlay during edit**
+
+In `_MapboxMapViewState`:
+
+a. Add a private field `PolygonAnnotation? _reshapeWorkingAnnotation;`.
+
+b. Add a method:
+
+```dart
+  Future<void> _rerenderReshapeWorkingPolygon() async {
+    final manager = _featureManager;
+    if (manager == null) return;
+    if (_reshapeWorkingAnnotation != null) {
+      await manager.delete(_reshapeWorkingAnnotation!);
+      _reshapeWorkingAnnotation = null;
+    }
+    final geojson = widget.reshapeWorkingPolygonGeojson;
+    if (geojson == null || geojson.isEmpty) return;
+    final polygon = _decodePolygon(geojson);
+    if (polygon == null) return;
+    _reshapeWorkingAnnotation = await manager.create(
+      PolygonAnnotationOptions(
+        geometry: polygon,
+        fillColor: 0xFF3182CE,
+        fillOpacity: 0.3,
+      ),
+    );
+  }
+```
+
+c. Call it from `didUpdateWidget` whenever `reshapeWorkingPolygonGeojson` differs from the previous build:
+
+```dart
+    if (oldWidget.reshapeWorkingPolygonGeojson !=
+        widget.reshapeWorkingPolygonGeojson) {
+      unawaited(_rerenderReshapeWorkingPolygon());
+    }
+```
+
+- [ ] **Step 5: Verify analyze and existing widget tests still pass**
+
+```bash
+flutter analyze
+flutter test test/features/map/
+```
+
+Expected: no analyzer errors. All existing map tests pass (they pass `null` or omit the new params; defaults handle it).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/map/presentation/map_renderer.dart
+git commit -m "feat(map): MapRenderer reshape seams — onPolygonLongPress + working polygon overlay (US-9 T13)"
+```
+
+---
+
+## Task 14: ReshapeOverlay — handle positioning and gesture dispatch
+
+**Files:**
+- Create: `lib/features/map/reshape/presentation/reshape_overlay.dart`
+- Create: `test/features/map/reshape/reshape_overlay_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `test/features/map/reshape/reshape_overlay_test.dart`:
+
+```dart
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/features/map/presentation/map_renderer.dart';
+import 'package:firecheck/features/map/reshape/presentation/midpoint_handle.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_mode_controller.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_overlay.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_providers.dart';
+import 'package:firecheck/features/map/reshape/presentation/vertex_handle.dart';
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Feature _seedBuilding() => Feature(
+      id: 'f1',
+      assignmentId: 'a1',
+      featureType: 'building',
+      geometryGeojson:
+          '{"type":"Polygon","coordinates":[[[10,10],[100,10],[100,100],[10,100],[10,10]]]}',
+      isNew: false,
+      status: 'unfilled',
+      createdAt: DateTime.utc(2026, 1, 1),
+    );
+
+Widget _wrap(ProviderContainer container, Widget child) =>
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('en')],
+        home: Scaffold(
+          body: SizedBox(
+            width: 200,
+            height: 200,
+            child: child,
+          ),
+        ),
+      ),
+    );
+
+void main() {
+  testWidgets('renders 4 vertex + 4 midpoint handles for a 4-vertex ring',
+      (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container
+        .read(reshapeModeControllerProvider.notifier)
+        .enterReshape(feature: _seedBuilding(), overrideReason: null);
+
+    await tester.pumpWidget(_wrap(
+      container,
+      ReshapeOverlay(projection: _IdentityProjection()),
+    ));
+    expect(find.byType(VertexHandle), findsNWidgets(4));
+    expect(find.byType(MidpointHandle), findsNWidgets(4));
+  });
+
+  testWidgets('inactive state renders nothing', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    await tester.pumpWidget(_wrap(
+      container,
+      ReshapeOverlay(projection: _IdentityProjection()),
+    ));
+    expect(find.byType(VertexHandle), findsNothing);
+    expect(find.byType(MidpointHandle), findsNothing);
+  });
+}
+
+class _IdentityProjection implements MapProjection {
+  @override
+  Offset screenPointFromLngLat(double lng, double lat) => Offset(lng, lat);
+  @override
+  ({double lng, double lat}) lngLatFromScreenPoint(Offset p) =>
+      (lng: p.dx, lat: p.dy);
+}
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+```bash
+flutter test test/features/map/reshape/reshape_overlay_test.dart
+```
+
+- [ ] **Step 3: Implement**
+
+Create `lib/features/map/reshape/presentation/reshape_overlay.dart`:
+
+```dart
+import 'package:firecheck/features/map/presentation/map_renderer.dart';
+import 'package:firecheck/features/map/reshape/presentation/midpoint_handle.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_mode_controller.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_providers.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_remove_confirm_dialog.dart';
+import 'package:firecheck/features/map/reshape/presentation/vertex_handle.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ReshapeOverlay extends ConsumerWidget {
+  const ReshapeOverlay({super.key, required this.projection});
+  final MapProjection projection;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(reshapeModeControllerProvider);
+    if (!state.isActive) return const SizedBox.shrink();
+    final notifier = ref.read(reshapeModeControllerProvider.notifier);
+    final ring = state.workingRings[0];
+
+    final children = <Widget>[];
+
+    // Vertex handles
+    for (var i = 0; i < ring.length; i++) {
+      final v = ring[i];
+      final p = projection.screenPointFromLngLat(v.lng, v.lat);
+      children.add(Positioned(
+        left: p.dx - 22,
+        top: p.dy - 22,
+        child: GestureDetector(
+          key: Key('reshape.vertex.$i'),
+          onPanUpdate: (d) {
+            final newScreen = p + d.delta;
+            final newLngLat =
+                projection.lngLatFromScreenPoint(newScreen);
+            notifier.moveVertex(0, i, newLngLat);
+          },
+          onLongPress: () async {
+            final confirm = await showReshapeRemoveConfirm(
+              context,
+              currentRingLength: ring.length,
+            );
+            if (confirm) notifier.removeVertex(0, i);
+          },
+          child: const VertexHandle(),
+        ),
+      ));
+    }
+
+    // Midpoint handles between consecutive vertices.
+    for (var i = 0; i < ring.length; i++) {
+      final a = ring[i];
+      final b = ring[(i + 1) % ring.length];
+      final mLng = (a.lng + b.lng) / 2;
+      final mLat = (a.lat + b.lat) / 2;
+      final p = projection.screenPointFromLngLat(mLng, mLat);
+      // Insert index for the new vertex equals (i+1) so it lands between
+      // current i and current i+1 in the working ring.
+      final insertAt = i + 1;
+      children.add(Positioned(
+        left: p.dx - 22,
+        top: p.dy - 22,
+        child: GestureDetector(
+          key: Key('reshape.midpoint.$i'),
+          onPanStart: (d) {
+            // A2 gesture: insert immediately, then drag the freshly inserted
+            // vertex with the same gesture.
+            notifier.addVertex(0, insertAt, (lng: mLng, lat: mLat));
+          },
+          onPanUpdate: (d) {
+            final cur =
+                ref.read(reshapeModeControllerProvider).workingRings[0];
+            // The just-inserted vertex sits at insertAt; move it.
+            if (insertAt >= cur.length) return;
+            final v = cur[insertAt];
+            final screen = projection.screenPointFromLngLat(v.lng, v.lat);
+            final next = screen + d.delta;
+            final nextLngLat = projection.lngLatFromScreenPoint(next);
+            notifier.moveVertex(0, insertAt, nextLngLat);
+          },
+          child: const MidpointHandle(),
+        ),
+      ));
+    }
+
+    return Stack(children: children);
+  }
+}
+```
+
+- [ ] **Step 4: Run; pass**
+
+```bash
+flutter test test/features/map/reshape/reshape_overlay_test.dart
+```
+
+Expected: 2 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/map/reshape/presentation/reshape_overlay.dart \
+        test/features/map/reshape/reshape_overlay_test.dart
+git commit -m "feat(reshape): ReshapeOverlay — vertex + midpoint handles with gestures (US-9 T14)"
+```
+
+---
+
+## Task 15: SyncApi.uploadFeatureGeometryUpdate — interface + Fake
+
+**Files:**
+- Modify: `lib/core/sync/data/sync_api.dart`
+- Modify: `lib/core/sync/data/fake_sync_api.dart`
+
+- [ ] **Step 1: Extend the interface**
+
+In `lib/core/sync/data/sync_api.dart`, add an import:
+
+```dart
+import 'package:firecheck/core/db/database.dart';
+```
+
+(Already present — but ensure `FeatureGeometryRevision` resolves; if the existing `database.dart` import already covers it, no change.)
+
+Add this method to the abstract class:
+
+```dart
+  Future<SyncOutcome> uploadFeatureGeometryUpdate(FeatureGeometryRevision revision);
+```
+
+- [ ] **Step 2: Extend the fake**
+
+In `lib/core/sync/data/fake_sync_api.dart`, add a recording field and impl:
+
+```dart
+  final List<FeatureGeometryRevision> uploadedReshapes = [];
+  // Optional injected outcome for test scenarios. Default success.
+  SyncOutcome reshapeOutcome = const SyncOutcome.success();
+
+  @override
+  Future<SyncOutcome> uploadFeatureGeometryUpdate(
+      FeatureGeometryRevision revision) async {
+    uploadedReshapes.add(revision);
+    return reshapeOutcome;
+  }
+```
+
+(Match the existing `SyncOutcome.success()` constructor name used by the project. If the actual constructor differs, look at how `uploadSubmission` in this same file constructs success/failure outcomes and mirror.)
+
+- [ ] **Step 3: Verify build**
+
+```bash
+flutter analyze
+flutter test test/core/sync/
+```
+
+Expected: no errors. (No tests yet for this new method — added in Task 17.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/core/sync/data/sync_api.dart lib/core/sync/data/fake_sync_api.dart
+git commit -m "feat(sync): SyncApi.uploadFeatureGeometryUpdate + Fake recorder (US-9 T15)"
+```
+
+---
+
+## Task 16: SupabaseSyncApi — `update_feature_geometry` RPC client
+
+**Files:**
+- Modify: `lib/core/sync/data/supabase_sync_api.dart`
+
+- [ ] **Step 1: Implement the RPC call**
+
+Append to `SupabaseSyncApi`:
+
+```dart
+  @override
+  Future<SyncOutcome> uploadFeatureGeometryUpdate(
+      FeatureGeometryRevision revision) async {
+    try {
+      await _client.rpc(
+        'update_feature_geometry',
+        params: {
+          'p_revision_id': revision.id,
+          'p_feature_id': revision.featureId,
+          'p_prev_geojson': revision.prevGeojson,
+          'p_new_geojson': revision.newGeojson,
+          'p_edited_at': revision.editedAt.toIso8601String(),
+          'p_override_reason': revision.overrideReason,
+        },
+      );
+      return const SyncOutcome.success();
+    } on PostgrestException catch (e) {
+      // P0001 + 'geometry_conflict' → permanent failure (server has newer geom)
+      // 42501 'forbidden' (RLS / auth) → permanent (re-auth won't help; supervisor
+      //                                  changed permissions or assignment)
+      if (e.code == 'P0001' || e.code == '42501') {
+        return SyncOutcome.permanentFailure(reason: e.message);
+      }
+      // Network or transient server error.
+      return SyncOutcome.transientFailure(reason: e.message);
+    } on Object catch (e) {
+      return SyncOutcome.transientFailure(reason: e.toString());
+    }
+  }
+```
+
+(Match the actual `SyncOutcome` factory names — search the file for `SyncOutcome.permanent` / `SyncOutcome.transient` and use whichever the codebase uses. If the existing methods use a different shape (e.g., `failure(permanent: true)`), mirror that exactly.)
+
+- [ ] **Step 2: Verify build**
+
+```bash
+flutter analyze
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/core/sync/data/supabase_sync_api.dart
+git commit -m "feat(sync): SupabaseSyncApi.uploadFeatureGeometryUpdate (P0001→permanent) (US-9 T16)"
+```
+
+---
+
+## Task 17: SyncWorker `feature_geometry_update` branch + tests
+
+**Files:**
+- Modify: `lib/core/sync/worker/sync_worker.dart`
+- Create: `test/core/sync/feature_geometry_update_sync_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `test/core/sync/feature_geometry_update_sync_test.dart`:
+
+```dart
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/data/fake_sync_api.dart';
+import 'package:firecheck/core/sync/domain/sync_outcome.dart';
+import 'package:firecheck/core/sync/worker/sync_worker.dart';
+import 'package:firecheck/features/map/reshape/data/feature_geometry_revisions_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase db;
+  late FeatureGeometryRevisionsRepository repo;
+  late FakeSyncApi api;
+  late SyncWorker worker;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = FeatureGeometryRevisionsRepository(db);
+    api = FakeSyncApi();
+    worker = SyncWorker(db: db, api: api);
+
+    await db.into(db.assignments).insert(AssignmentsCompanion.insert(
+          id: 'a1', enumeratorId: 'e1', boundaryPolygonGeojson: '{}',
+        ));
+    await db.into(db.features).insert(FeaturesCompanion.insert(
+          id: 'f1',
+          assignmentId: 'a1',
+          featureType: 'building',
+          geometryGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[0,1],[0,0]]]}',
+          createdAt: DateTime.utc(2026, 1, 1),
+        ));
+  });
+
+  tearDown(() => db.close());
+
+  test('success → revision uploaded; sync_job success', () async {
+    await repo.saveReshape(
+      revisionId: 'r1',
+      featureId: 'f1',
+      prevGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[0,1],[0,0]]]}',
+      newGeojson:  '{"type":"Polygon","coordinates":[[[0,0],[2,0],[0,2],[0,0]]]}',
+      editedBy: 'e1',
+      editedAt: DateTime.utc(2026, 4, 29),
+      overrideReason: null,
+    );
+
+    await worker.runOnce();
+
+    expect(api.uploadedReshapes, hasLength(1));
+    final job = (await db.select(db.syncJobs).get()).first;
+    expect(job.status, 'success');
+    final rev = (await db.select(db.featureGeometryRevisions).get()).first;
+    expect(rev.syncStatus, 'uploaded');
+  });
+
+  test('permanent failure → revision failed; sync_job dead', () async {
+    api.reshapeOutcome = const SyncOutcome.permanentFailure(
+      reason: 'geometry_conflict',
+    );
+
+    await repo.saveReshape(
+      revisionId: 'r2',
+      featureId: 'f1',
+      prevGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[0,1],[0,0]]]}',
+      newGeojson:  '{"type":"Polygon","coordinates":[[[0,0],[2,0],[0,2],[0,0]]]}',
+      editedBy: 'e1',
+      editedAt: DateTime.utc(2026, 4, 29),
+      overrideReason: null,
+    );
+
+    await worker.runOnce();
+
+    final job = (await db.select(db.syncJobs).get()).first;
+    expect(job.status, 'dead');
+    final rev = (await db.select(db.featureGeometryRevisions).get()).first;
+    expect(rev.syncStatus, 'failed');
+  });
+}
+```
+
+(If `SyncOutcome.permanentFailure` is named differently in the project, match its actual constructor.)
+
+- [ ] **Step 2: Run; confirm fail**
+
+```bash
+flutter test test/core/sync/feature_geometry_update_sync_test.dart
+```
+
+Expected: tests fail because `SyncWorker` does not yet handle `'feature_geometry_update'`.
+
+- [ ] **Step 3: Wire the new entity_type branch**
+
+In `lib/core/sync/worker/sync_worker.dart`, locate the existing per-entity dispatch (a switch / if-else over `job.entityType`) and add a branch:
+
+```dart
+        case 'feature_geometry_update':
+          {
+            final revRepo = FeatureGeometryRevisionsRepository(db);
+            final rev = await revRepo.getById(job.entityId);
+            if (rev == null) {
+              await _markJobDead(job, 'revision missing');
+              return;
+            }
+            final outcome = await api.uploadFeatureGeometryUpdate(rev);
+            await _applyOutcome(
+              job: job,
+              outcome: outcome,
+              onSuccess: () => revRepo.markSynced(rev.id),
+              onPermanent: () => revRepo.markFailed(rev.id),
+            );
+            break;
+          }
+```
+
+(Match the project's existing pattern — search the file for the `'submission'` or `'photo'` branch and mirror its shape exactly. If the worker uses helper methods like `_runWithRetry` or `_recordSuccess`, use those.)
+
+Add the import:
+```dart
+import 'package:firecheck/features/map/reshape/data/feature_geometry_revisions_repository.dart';
+```
+
+- [ ] **Step 4: Run tests; pass**
+
+```bash
+flutter test test/core/sync/feature_geometry_update_sync_test.dart
+flutter test test/core/sync/
+```
+
+Expected: 2 new PASS; existing sync tests unaffected.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/sync/worker/sync_worker.dart \
+        test/core/sync/feature_geometry_update_sync_test.dart
+git commit -m "feat(sync): SyncWorker feature_geometry_update branch (US-9 T17)"
+```
+
+---
+
+## Task 18: Map screen — long-press handler + action sheet wiring
+
+**Files:**
+- Modify: `lib/features/map/presentation/map_screen.dart`
+- Create: `test/features/map/map_screen_reshape_test.dart`
+
+- [ ] **Step 1: Write failing tests for the action-sheet entry path**
+
+Create `test/features/map/map_screen_reshape_test.dart` (initial pass — more cases land in T19/T20/T21):
+
+```dart
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/features/map/presentation/map_renderer.dart';
+import 'package:firecheck/features/map/presentation/map_providers.dart';
+import 'package:firecheck/features/map/presentation/map_screen.dart';
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Reuse the project's existing test harness — search for an existing
+// map_screen_*_test.dart that builds a fully-stubbed MapScreen tree
+// (currentAssignmentProvider, currentFeaturesProvider, currentUserProvider,
+// isAssignmentLockedProvider, locationServiceProvider, syncControllerProvider,
+// analyticsServiceProvider all overridden). Mirror that harness exactly.
+//
+// For brevity in this task spec, the harness factory is `_buildMapScreen()`.
+
+void main() {
+  testWidgets('long-press on a polygon (add-mode off) opens action sheet',
+      (tester) async {
+    final fake = FakeMapRenderer();
+    // setup: pump a MapScreen with addMode=false and one polygon feature
+    // (see _buildMapScreen helper).
+
+    await tester.pumpWidget(/* _buildMapScreen */(fake));
+    await tester.pumpAndSettle();
+
+    final feature = Feature(
+      id: 'f1',
+      assignmentId: 'a1',
+      featureType: 'building',
+      geometryGeojson:
+          '{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}',
+      isNew: false,
+      status: 'unfilled',
+      createdAt: DateTime.utc(2026, 1, 1),
+    );
+
+    await fake.simulatePolygonLongPress(feature);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('reshape.actionsheet.openForm')), findsOneWidget);
+    expect(find.byKey(const Key('reshape.actionsheet.reshape')), findsOneWidget);
+  });
+
+  testWidgets('long-press on a polygon (add-mode on) does NOT open sheet',
+      (tester) async {
+    final fake = FakeMapRenderer();
+    // setup: addModeActive starts true OR toggle the pill before the long press
+    // (see existing add-mode tests for the pattern).
+    await tester.pumpWidget(/* _buildMapScreen with add-mode active */(fake));
+    await tester.pumpAndSettle();
+
+    final feature = Feature(
+      id: 'f1',
+      assignmentId: 'a1',
+      featureType: 'building',
+      geometryGeojson:
+          '{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}',
+      isNew: false,
+      status: 'unfilled',
+      createdAt: DateTime.utc(2026, 1, 1),
+    );
+
+    await fake.simulatePolygonLongPress(feature);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('reshape.actionsheet.openForm')), findsNothing);
+  });
+}
+```
+
+The harness factory `_buildMapScreen(...)` and its provider overrides should be copied from the existing `test/features/map/map_screen_zoom_test.dart` (US-13) — that file already builds a fully-mocked map screen and the same overrides apply here. Reuse all of: `currentAssignmentProvider`, `currentFeaturesProvider`, `currentUserProvider`, `currentPositionProvider`, `mapRendererProvider`, `isAssignmentLockedProvider`, `locationServiceProvider`, `analyticsServiceProvider`.
+
+- [ ] **Step 2: Run; confirm fail**
+
+```bash
+flutter test test/features/map/map_screen_reshape_test.dart
+```
+
+- [ ] **Step 3: Wire `_handlePolygonLongPress` and pass `onPolygonLongPress` to renderer**
+
+In `lib/features/map/presentation/map_screen.dart`:
+
+a. Import:
+```dart
+import 'package:firecheck/features/map/reshape/presentation/reshape_action_sheet.dart';
+```
+
+b. In the `renderer.build(...)` call within `build()`, add the new param after `cameraTarget`:
+
+```dart
+                    onPolygonLongPress: _handlePolygonLongPress,
+```
+
+c. Add the handler method to `_MapScreenState`:
+
+```dart
+  Future<void> _handlePolygonLongPress(Feature feature) async {
+    if (_addModeActive) return;
+    final l = AppLocalizations.of(context)!;
+    final locked = ref.read(isAssignmentLockedProvider);
+    if (locked) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(l.reshapeLockedSnackbar)));
+      return;
+    }
+    if (!mounted) return;
+    final action = await showReshapeActionSheet(context, locked: locked);
+    if (!mounted || action == null) return;
+    switch (action) {
+      case ReshapeAction.openForm:
+        await _handleFeatureTap(feature);
+      case ReshapeAction.reshape:
+        // Distance gate + enterReshape handled in T19.
+        break;
+    }
+  }
+```
+
+- [ ] **Step 4: Run tests; pass**
+
+```bash
+flutter test test/features/map/map_screen_reshape_test.dart
+```
+
+Expected: 2 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/map/presentation/map_screen.dart \
+        test/features/map/map_screen_reshape_test.dart
+git commit -m "feat(map): long-press polygon → reshape action sheet (US-9 T18)"
+```
+
+---
+
+## Task 19: Distance gate + override-reason → enterReshape
+
+**Files:**
+- Modify: `lib/features/map/presentation/map_screen.dart`
+- Modify: `test/features/map/map_screen_reshape_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `test/features/map/map_screen_reshape_test.dart`:
+
+```dart
+  testWidgets('Reshape with GPS within 50m enters edit mode (no dialog)',
+      (tester) async {
+    final fake = FakeMapRenderer();
+    // setup: location provider returns a fix near the feature centroid
+    await tester.pumpWidget(/* _buildMapScreen */(fake));
+    await tester.pumpAndSettle();
+
+    await fake.simulatePolygonLongPress(_seedNearbyBuilding());
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+    await tester.pumpAndSettle();
+
+    // Banner mounted iff edit mode is active.
+    expect(find.byKey(const Key('reshape.banner.save')), findsOneWidget);
+  });
+
+  testWidgets('Reshape with GPS >50m shows override dialog; confirm → enters',
+      (tester) async {
+    final fake = FakeMapRenderer();
+    // setup: location provider returns a fix 80m from the feature centroid
+    await tester.pumpWidget(/* _buildMapScreen with far GPS */(fake));
+    await tester.pumpAndSettle();
+
+    await fake.simulatePolygonLongPress(_seedNearbyBuilding());
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('override.reason')), findsOneWidget);
+    await tester.enterText(find.byKey(const Key('override.reason')), 'visible from sidewalk');
+    await tester.tap(find.text('Continue'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('reshape.banner.save')), findsOneWidget);
+  });
+```
+
+(`_seedNearbyBuilding` returns a `Feature` whose centroid is near the test GPS fix used in `_buildMapScreen`; mirror the existing pattern from `test/features/map/map_screen_test.dart` for the 50 m gate.)
+
+- [ ] **Step 2: Run; confirm fail**
+
+```bash
+flutter test test/features/map/map_screen_reshape_test.dart
+```
+
+- [ ] **Step 3: Implement the distance gate + enterReshape**
+
+In `lib/features/map/presentation/map_screen.dart`:
+
+a. Imports:
+```dart
+import 'package:firecheck/features/map/reshape/presentation/reshape_providers.dart';
+import 'package:firecheck/features/survey/building_form/presentation/override_reason_dialog.dart';
+```
+
+b. Replace the `case ReshapeAction.reshape:` body with:
+
+```dart
+      case ReshapeAction.reshape:
+        await _enterReshape(feature);
+```
+
+c. Add:
+
+```dart
+  Future<void> _enterReshape(Feature feature) async {
+    final l = AppLocalizations.of(context)!;
+
+    // 1. Distance check (mirrors _handleFeatureTap)
+    final pos = ref.read(currentPositionProvider).value;
+    final centroid = computeFeatureCentroid(feature.geometryGeojson);
+    String? overrideReason;
+    if (pos != null && centroid != null) {
+      final distance = haversineMeters(
+        pos.latitude, pos.longitude, centroid.lat, centroid.lng,
+      );
+      if (distance > 50) {
+        if (!mounted) return;
+        overrideReason = await showOverrideReasonDialog(
+          context,
+          distanceMeters: distance,
+        );
+        if (overrideReason == null) return; // user cancelled
+      }
+    }
+
+    if (!mounted) return;
+    ref.read(reshapeModeControllerProvider.notifier).enterReshape(
+          feature: feature,
+          overrideReason: overrideReason,
+        );
+    final analytics = ref.read(analyticsServiceProvider);
+    analytics.track('map.reshape.entered', {
+      'feature_id': feature.id,
+      'vertex_count': _vertexCount(feature.geometryGeojson),
+      'override_used': overrideReason != null,
+    });
+  }
+
+  int _vertexCount(String geojson) {
+    final parsed = jsonDecode(geojson) as Map<String, dynamic>;
+    final coords = parsed['coordinates'] as List;
+    final ring = coords[0] as List;
+    return ring.length - 1; // strip closing duplicate
+  }
+```
+
+(Use the existing helper names — search for `computeFeatureCentroid` and `haversineMeters` already in `lib/core/geo/centroid.dart` and `lib/core/location/distance.dart`. Adjust import paths and function names to whatever the codebase actually exposes; the names above are the conventional ones used by the recenter spec.)
+
+- [ ] **Step 4: Run tests; pass**
+
+```bash
+flutter test test/features/map/map_screen_reshape_test.dart
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/map/presentation/map_screen.dart \
+        test/features/map/map_screen_reshape_test.dart
+git commit -m "feat(map): distance gate + override-reason → enterReshape (US-9 T19)"
+```
+
+---
+
+## Task 20: Mount banner + overlay; hide add-mode pill while reshape active
+
+**Files:**
+- Modify: `lib/features/map/presentation/map_screen.dart`
+- Modify: `test/features/map/map_screen_reshape_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `test/features/map/map_screen_reshape_test.dart`:
+
+```dart
+  testWidgets('add-mode pill hidden while reshape active', (tester) async {
+    final fake = FakeMapRenderer();
+    await tester.pumpWidget(/* _buildMapScreen */(fake));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('map.add-feature-pill')), findsOneWidget);
+
+    await fake.simulatePolygonLongPress(_seedNearbyBuilding());
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('map.add-feature-pill')), findsNothing);
+  });
+
+  testWidgets('Cancel exits reshape and re-shows add pill', (tester) async {
+    final fake = FakeMapRenderer();
+    await tester.pumpWidget(/* _buildMapScreen */(fake));
+    await tester.pumpAndSettle();
+    await fake.simulatePolygonLongPress(_seedNearbyBuilding());
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('reshape.banner.cancel')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('map.add-feature-pill')), findsOneWidget);
+  });
+```
+
+- [ ] **Step 2: Mount banner + overlay**
+
+In `_MapScreenState.build()`, replace the `Stack` body so that:
+
+1. The add-mode pill row is conditionally rendered only when reshape is *not* active.
+2. The banner mounts as a top `Positioned` when reshape *is* active.
+3. The overlay mounts above the map when reshape is active.
+
+Add at the top of the `build` method:
+
+```dart
+    final reshape = ref.watch(reshapeModeControllerProvider);
+    final reshapeActive = reshape.isActive;
+```
+
+Wrap the existing add-mode banner and bottom-pill `Row` with `if (!reshapeActive) ...`.
+
+Add a banner block at the top of the Stack (above other Positioneds):
+
+```dart
+          if (reshapeActive)
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: ReshapeBanner(
+                editCount: reshape.undoStack.length,
+                undoEnabled: reshape.isDirty && !reshape.saving,
+                saveEnabled: reshape.isDirty && !reshape.saving,
+                onCancel: () => _onReshapeCancel(),
+                onUndo: () => ref.read(reshapeModeControllerProvider.notifier).undo(),
+                onSave: () => _onReshapeSave(),
+              ),
+            ),
+```
+
+Add an overlay block (above the bottom buttons but below the banner, by ordering):
+
+```dart
+          if (reshapeActive && _reshapeProjection != null)
+            Positioned.fill(
+              child: ReshapeOverlay(projection: _reshapeProjection!),
+            ),
+```
+
+Add a private field on `_MapScreenState`:
+
+```dart
+  MapProjection? _reshapeProjection;
+```
+
+Pass it to the renderer:
+
+```dart
+                    onProjectionReady: (p) {
+                      if (_reshapeProjection != p) {
+                        setState(() => _reshapeProjection = p);
+                      }
+                    },
+```
+
+Pass `reshapeWorkingPolygonGeojson` to the renderer:
+
+```dart
+                    reshapeWorkingPolygonGeojson: reshapeActive
+                        ? ref
+                            .read(reshapeModeControllerProvider.notifier)
+                            .serializeWorkingPolygon()
+                        : null,
+```
+
+Add cancel handler:
+
+```dart
+  void _onReshapeCancel() {
+    final ops = ref.read(reshapeModeControllerProvider).undoStack.length;
+    ref.read(reshapeModeControllerProvider.notifier).cancel();
+    ref.read(analyticsServiceProvider).track('map.reshape.cancelled', {
+      'feature_id': '', // populated in T21 from captured feature
+      'ops_made': ops,
+    });
+  }
+```
+
+(`_onReshapeSave` lands in Task 21.)
+
+Add imports:
+
+```dart
+import 'package:firecheck/features/map/reshape/presentation/reshape_banner.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_overlay.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_providers.dart';
+```
+
+- [ ] **Step 3: Run tests; pass**
+
+```bash
+flutter test test/features/map/map_screen_reshape_test.dart
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/features/map/presentation/map_screen.dart \
+        test/features/map/map_screen_reshape_test.dart
+git commit -m "feat(map): mount ReshapeBanner + Overlay; hide add-pill while reshape active (US-9 T20)"
+```
+
+---
+
+## Task 21: Save commit flow + analytics
+
+**Files:**
+- Modify: `lib/features/map/presentation/map_screen.dart`
+- Modify: `test/features/map/map_screen_reshape_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `test/features/map/map_screen_reshape_test.dart`:
+
+```dart
+  testWidgets('Save with valid edits writes revision + sync_job, exits mode',
+      (tester) async {
+    final fake = FakeMapRenderer();
+    await tester.pumpWidget(/* _buildMapScreen with in-memory db */(fake));
+    await tester.pumpAndSettle();
+    await fake.simulatePolygonLongPress(_seedNearbyBuilding());
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+    await tester.pumpAndSettle();
+
+    // Drag a vertex to dirty the state. Exact key resolution depends on
+    // ReshapeOverlay rendering — use `find.byKey(const Key('reshape.vertex.0'))`.
+    await tester.drag(find.byKey(const Key('reshape.vertex.0')),
+        const Offset(20, 20));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('reshape.banner.save')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('reshape.banner.save')), findsNothing); // exited
+    // Revision row visible via repository or db query in the harness.
+  });
+
+  testWidgets('Save with self-intersecting polygon shows snackbar; stays in mode',
+      (tester) async {
+    final fake = FakeMapRenderer();
+    await tester.pumpWidget(/* _buildMapScreen */(fake));
+    await tester.pumpAndSettle();
+    await fake.simulatePolygonLongPress(_seedNearbyBuilding());
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+    await tester.pumpAndSettle();
+
+    // Drive the controller into a bowtie state directly (bypass UI):
+    // (use ProviderContainer override or expose via test helper)
+
+    await tester.tap(find.byKey(const Key('reshape.banner.save')));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Edges cannot cross'), findsOneWidget);
+    expect(find.byKey(const Key('reshape.banner.save')), findsOneWidget); // still active
+  });
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+```bash
+flutter test test/features/map/map_screen_reshape_test.dart
+```
+
+- [ ] **Step 3: Implement `_onReshapeSave`**
+
+Add to `_MapScreenState`:
+
+```dart
+  Future<void> _onReshapeSave() async {
+    final l = AppLocalizations.of(context)!;
+    final ctrl = ref.read(reshapeModeControllerProvider.notifier);
+    final s = ref.read(reshapeModeControllerProvider);
+    final assignment = ref.read(currentAssignmentProvider).value;
+    if (s.originalFeature == null || assignment == null) return;
+
+    final res = validateBuildingPolygon(
+      s.workingRings,
+      boundaryGeojson: assignment.boundaryPolygonGeojson,
+    );
+    if (!res.valid) {
+      final msg = _validationMessage(res.error!, l);
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+      ref.read(analyticsServiceProvider).track('map.reshape.validation_failed', {
+        'feature_id': s.originalFeature!.id,
+        'rule': res.error!.name,
+      });
+      return;
+    }
+
+    ctrl.markSaving(true);
+    final user = ref.read(currentUserProvider).value;
+    final repo = ref.read(reshapeRepositoryProvider);
+    final newGeojson = ctrl.serializeWorkingPolygon();
+    final revisionId = const Uuid().v4();
+
+    final start = DateTime.now();
+    try {
+      await repo.saveReshape(
+        revisionId: revisionId,
+        featureId: s.originalFeature!.id,
+        prevGeojson: s.originalFeature!.geometryGeojson,
+        newGeojson: newGeojson,
+        editedBy: user?.id ?? '',
+        editedAt: DateTime.now(),
+        overrideReason: s.overrideReason,
+      );
+      ref.read(analyticsServiceProvider).track('map.reshape.completed', {
+        'feature_id': s.originalFeature!.id,
+        'vertex_count_before': _vertexCount(s.originalFeature!.geometryGeojson),
+        'vertex_count_after': s.workingRings[0].length,
+        'vertex_moves': s.undoStack.whereType<Move>().length,
+        'vertex_adds': s.undoStack.whereType<Add>().length,
+        'vertex_removes': s.undoStack.whereType<Remove>().length,
+        'override_used': s.overrideReason != null,
+        'duration_ms': DateTime.now().difference(start).inMilliseconds,
+      });
+      ctrl.cancel(); // exit edit mode
+    } on Object catch (e) {
+      ctrl.markSaving(false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Could not save reshape: $e')),
+      );
+    }
+  }
+
+  String _validationMessage(PolygonValidationError err, AppLocalizations l) {
+    return switch (err) {
+      PolygonValidationError.tooFewVertices       => l.reshapeErrorTooFewVertices,
+      PolygonValidationError.zeroOrNegativeArea   => l.reshapeErrorZeroArea,
+      PolygonValidationError.selfIntersection     => l.reshapeErrorSelfIntersection,
+      PolygonValidationError.vertexOutsideBoundary=> l.reshapeErrorOutsideBoundary,
+      PolygonValidationError.zeroLengthEdge       => l.reshapeErrorZeroLengthEdge,
+    };
+  }
+```
+
+Imports to add:
+
+```dart
+import 'dart:convert';
+import 'package:firecheck/core/geo/polygon_validator.dart';
+import 'package:firecheck/features/map/reshape/domain/reshape_op.dart';
+import 'package:uuid/uuid.dart';
+```
+
+(If `uuid` is not yet a project dep, add `uuid: ^4.0.0` to `pubspec.yaml` under `dependencies` and run `flutter pub get`. Check `pubspec.yaml` first — if `uuid` already appears, skip.)
+
+- [ ] **Step 4: Run tests; pass**
+
+```bash
+flutter test test/features/map/map_screen_reshape_test.dart
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/map/presentation/map_screen.dart \
+        test/features/map/map_screen_reshape_test.dart \
+        pubspec.yaml pubspec.lock
+git commit -m "feat(map): reshape Save commit + 3 analytics events (US-9 T21)"
+```
+
+---
+
+## Task 22: Lock-while-dirty UX
+
+**Files:**
+- Modify: `lib/features/map/presentation/map_screen.dart`
+- Modify: `test/features/map/map_screen_reshape_test.dart`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `test/features/map/map_screen_reshape_test.dart`:
+
+```dart
+  testWidgets('lock-while-dirty shows non-dismissable banner; Exit discards',
+      (tester) async {
+    final fake = FakeMapRenderer();
+    final lockNotifier = ValueNotifier<bool>(false);
+    // Override isAssignmentLockedProvider to return lockNotifier.value
+    await tester.pumpWidget(/* _buildMapScreen with lockNotifier */(fake));
+    await tester.pumpAndSettle();
+    await fake.simulatePolygonLongPress(_seedNearbyBuilding());
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+    await tester.pumpAndSettle();
+
+    // Make at least one edit
+    await tester.drag(find.byKey(const Key('reshape.vertex.0')),
+        const Offset(10, 10));
+    await tester.pumpAndSettle();
+
+    // Trigger lock
+    lockNotifier.value = true;
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Assignment was closed'), findsOneWidget);
+    await tester.tap(find.text('Exit'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('reshape.banner.save')), findsNothing); // exited
+  });
+```
+
+- [ ] **Step 2: Implement**
+
+In `_MapScreenState.build()` add after the `final reshape = ref.watch(...)` line:
+
+```dart
+    final isLocked = ref.watch(isAssignmentLockedProvider);
+    if (reshapeActive && isLocked && reshape.isDirty && !_lockBlockerShown) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _showLockWhileDirtyBlocker();
+      });
+    }
+```
+
+Add the field:
+
+```dart
+  bool _lockBlockerShown = false;
+```
+
+Add the method:
+
+```dart
+  Future<void> _showLockWhileDirtyBlocker() async {
+    if (!mounted) return;
+    setState(() => _lockBlockerShown = true);
+    final l = AppLocalizations.of(context)!;
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => AlertDialog(
+        content: Text(l.reshapeLockWhileDirtyBanner),
+        actions: [
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: Text(l.reshapeLockExit),
+          ),
+        ],
+      ),
+    );
+    if (!mounted) return;
+    ref.read(reshapeModeControllerProvider.notifier).cancel();
+    setState(() => _lockBlockerShown = false);
+  }
+```
+
+Also handle the clean-state lock case: in the same `if` chain just below the dirty check, add:
+
+```dart
+    if (reshapeActive && isLocked && !reshape.isDirty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        ref.read(reshapeModeControllerProvider.notifier).cancel();
+      });
+    }
+```
+
+- [ ] **Step 3: Run tests; pass**
+
+```bash
+flutter test test/features/map/map_screen_reshape_test.dart
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/features/map/presentation/map_screen.dart \
+        test/features/map/map_screen_reshape_test.dart
+git commit -m "feat(map): reshape lock-while-dirty blocker + clean-state silent exit (US-9 T22)"
+```
+
+---
+
+## Task 23: Server migration `011_feature_geometry_updates.sql`
+
+**Files:**
+- Create: `supabase/migrations/011_feature_geometry_updates.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+Create `supabase/migrations/011_feature_geometry_updates.sql` exactly as the spec §4 dictates. Copy verbatim:
+
+```sql
+-- US-9 reshape: feature_geometry_revisions table + update_feature_geometry RPC
+
+create table public.feature_geometry_revisions (
+  id              uuid primary key,
+  feature_id      uuid not null references public.features(id) on delete cascade,
+  edited_by       uuid references public.enumerators(id) on delete set null,
+  prev_geometry   geography(Geometry, 4326) not null,
+  new_geometry    geography(Geometry, 4326) not null,
+  edited_at       timestamptz not null,
+  override_reason text,
+  created_at      timestamptz not null default now()
+);
+
+create index on public.feature_geometry_revisions (feature_id);
+create index on public.feature_geometry_revisions (edited_by);
+
+alter table public.feature_geometry_revisions enable row level security;
+
+create policy fgr_enum_insert on public.feature_geometry_revisions
+  for insert with check (
+    exists (
+      select 1 from public.features f
+      join public.assignments a on a.id = f.assignment_id
+      where f.id = feature_id and a.enumerator_id = auth.uid()
+    )
+  );
+create policy fgr_enum_select on public.feature_geometry_revisions
+  for select using (
+    exists (
+      select 1 from public.features f
+      join public.assignments a on a.id = f.assignment_id
+      where f.id = feature_id and a.enumerator_id = auth.uid()
+    )
+  );
+
+create or replace function public.update_feature_geometry(
+  p_revision_id    uuid,
+  p_feature_id     uuid,
+  p_prev_geojson   text,
+  p_new_geojson    text,
+  p_edited_at      timestamptz,
+  p_override_reason text
+) returns void
+language plpgsql
+security definer
+as $$
+declare
+  v_current geography;
+  v_prev    geography;
+  v_new     geography;
+begin
+  if not exists (
+    select 1 from public.features f
+    join public.assignments a on a.id = f.assignment_id
+    where f.id = p_feature_id and a.enumerator_id = auth.uid()
+  ) then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  v_prev := st_geogfromgeojson(p_prev_geojson);
+  v_new  := st_geogfromgeojson(p_new_geojson);
+
+  select geometry into v_current from public.features
+    where id = p_feature_id for update;
+
+  if not st_equals(v_current::geometry, v_prev::geometry) then
+    raise exception 'geometry_conflict' using errcode = 'P0001';
+  end if;
+
+  insert into public.feature_geometry_revisions
+    (id, feature_id, edited_by, prev_geometry, new_geometry, edited_at, override_reason)
+  values
+    (p_revision_id, p_feature_id, auth.uid(), v_prev, v_new, p_edited_at, p_override_reason);
+
+  update public.features set geometry = v_new where id = p_feature_id;
+end;
+$$;
+
+grant execute on function public.update_feature_geometry to authenticated;
+```
+
+- [ ] **Step 2: Apply locally with the Supabase CLI**
+
+```bash
+supabase db reset --linked
+```
+
+Or if running against a local docker stack:
+
+```bash
+supabase db reset
+```
+
+Expected: migrations 001..011 apply cleanly with no errors. Inspect the new function:
+
+```bash
+supabase db sql "SELECT proname FROM pg_proc WHERE proname = 'update_feature_geometry';"
+```
+
+Expected: one row.
+
+- [ ] **Step 3: Smoke-test the RPC end-to-end**
+
+In the Supabase SQL editor (or CLI) on the dev project:
+1. Insert a synthetic enumerator + assignment + feature.
+2. As that enumerator (`set role authenticated; set request.jwt.claims.sub = '<uuid>';` if running as superuser; otherwise via the JWT-aware client), call:
+   ```sql
+   select update_feature_geometry(
+     gen_random_uuid(),
+     '<feature-uuid>',
+     '<feature.geometry::geojson>',
+     '{"type":"Polygon","coordinates":[[[0,0],[2,0],[0,2],[0,0]]]}',
+     now(),
+     null
+   );
+   ```
+3. Verify a revision row was inserted and `features.geometry` was updated.
+4. Re-run the same call with the original `prev_geojson` (now stale): expect `P0001 geometry_conflict`.
+
+Document the smoke result in the PR description.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/011_feature_geometry_updates.sql
+git commit -m "feat(supabase): migration 011 — feature_geometry_revisions + update_feature_geometry RPC (US-9 T23)"
+```
+
+---
+
+## Task 24: Final regression sweep + manual happy-path
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run full analyze**
+
+```bash
+flutter analyze
+```
+
+Expected: no errors. (`info`-level lints are acceptable; `warning` and `error` are not.)
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+flutter test
+```
+
+Expected: all tests pass. Capture the count for the PR description (`X/X tests passing`).
+
+- [ ] **Step 3: Manual happy-path on a real device**
+
+Build a debug APK and walk through the full flow on an Android device with mapbox tiles:
+
+```bash
+flutter build apk --debug
+flutter install --debug
+```
+
+Walk the full happy path from spec §9:
+
+1. Open app, open assignment, open map.
+2. Long-press a red polygon → action sheet shows three items.
+3. `Reshape` → banner appears; handles render at all corners.
+4. Drag a corner; release; banner shows "Reshape • 1 edits"; Save active.
+5. Drag a midpoint outward; verify the new vertex stays under the finger; release.
+6. Long-press a corner; confirm; vertex disappears.
+7. Tap Undo three times; banner returns to "0 edits".
+8. Reshape into a bowtie; verify red live edges (or that Save will reject — the live render may be deferred per the implementation note in T13).
+9. Save → snackbar self-intersection error; stay in mode.
+10. Fix the polygon; Save → exits to map; polygon shows new shape.
+11. Force-quit and relaunch → polygon still has new shape.
+12. Go offline; reshape and Save → sync indicator shows pending; back online → uploads cleanly.
+13. Repeat the happy path on three real-world test buildings (DoD requirement). Note buildings used in the PR.
+
+- [ ] **Step 4: Open PR**
+
+```bash
+git push -u origin 9-as-an-enumerator-i-want-to-reshape-an-existing-building-polygon-by-moving-adding-or-removing-vertices-so-that-i-can-correct-footprints-that-are-inaccurate-on-the-ground
+```
+
+Then create the PR via `gh pr create` with a body covering: AC mapping, architecture summary, test plan (`X/X passing, flutter analyze clean`), three real-world buildings tested, server migration smoke result, and any deferred open questions from spec §14 (per-vertex `pixelForCoordinate` precision being the main one).
+
+---
+
+## Self-review checklist (run after writing all 24 tasks)
+
+**Spec coverage**
+- §1 Summary — all 8 "after this ships" bullets covered: long-press (T18), distance gate (T19), banner+handles (T20), gestures (T14, T11), live red-edges (T13/T14 — partial; full live render deferred per implementation note), save validation (T21), lock interactions (T22), server RPC (T16, T23). ✓
+- §2 Scope — all "in scope" items mapped (controller T8, UI T9–T12, validator T1–T3, repo T5, RPC T23, sync T15–T17, locks T22, mutex T20, analytics T19/T21, i18n T6). ✓
+- §3 Architecture — every file in "added" and "changed" lists is touched. ✓
+- §4 Data model — Drift table T4, server SQL T23. ✓
+- §5 Validation — 5 rules T1–T3, error mapping T21 (`_validationMessage`). ✓
+- §6 Orchestration — long-press T18, distance gate T19, gestures T14, save T21. ✓
+- §7 Sync — T15–T17, T23. ✓
+- §8 Edge cases — locked T18 (snackbar), lock-while-dirty T22, GPS-OK T19, GPS-far T19, conflict T17. ✓
+- §9 Testing — every test file referenced has a creating task. ✓
+- §10 Analytics — entered T19, completed/cancelled/validation_failed T20+T21. ✓
+- §11 AC mapping — covered. ✓
+
+**Placeholder scan:** No `TBD`, `TODO`, `FIXME`, or "implement later" markers in the executable steps. The `_MapboxProjection` in T13 ships a real linear-corner calibration (refreshed per camera change). Future precision improvement is captured by spec §14 as a deferred open question, not as a code TODO.
+
+**Type consistency:** `LngLat` is consistently `({double lng, double lat})` from T1 onward. `EdgeIndex` defined T2, used T3 / T8. `ReshapeOp` and its subclasses (`Move`, `Add`, `Remove`) defined T7, used T8 / T21. `PolygonValidationError` enum defined T1, extended T2, T3; consumed T21. `MapProjection` interface defined T13, consumed T14, T20. `ReshapeAction` enum defined T12, consumed T18.
+
+**Naming:** Repository method `saveReshape` consistent T5 / T17 / T21. `markSynced` / `markFailed` consistent T5 / T17. `serializeWorkingPolygon` consistent T8 / T20 / T21.
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-29-reshape-building-polygon.md`.**

--- a/docs/superpowers/specs/2026-04-29-flat-file-sync-design.md
+++ b/docs/superpowers/specs/2026-04-29-flat-file-sync-design.md
@@ -41,8 +41,36 @@ architecture (Drift + Supabase) remains for the team's own use.
 
 ## Personas
 
-- **Enumerator (E)** — field worker using the FireCheck app.
-- **Course Supervisor (S)** — uploads input shapefiles to shared storage; downloads and reviews output shapefiles.
+- **Enumerator (E)** — field worker using the FireCheck app. The user stories below are written for this persona.
+- **Course Supervisor (S)** — uploads input shapefiles to shared storage; downloads and reviews output shapefiles. The supervisor uses **their own tools** (Drive web UI, QGIS, etc.) — they do **not** use the FireCheck app. Their workflow is captured below in the Preconditions section, not as user stories.
+
+---
+
+## Preconditions (supervisor responsibilities, outside the app)
+
+These are the things the supervisor must do for the app to have anything to read or write. They are **not features of the app**; they define the contract the app's stories rely on.
+
+**Pre-stage assignment input**
+
+- The supervisor uploads `input.zip` to `/firecheck/inbox/<assignment_id>/` in the shared Google Drive.
+- Zip contains exactly:
+  - `boundary.{shp,dbf,shx,prj}` — assignment polygon.
+  - `buildings.{shp,dbf,shx,prj}` — initial building polygons (attributes may be sparse).
+  - `roads.{shp,dbf,shx,prj}` — initial road polylines.
+- Nothing else inside — no `manifest.json`, no `readme.txt`, no images.
+- CRS = EPSG:32651 (WGS 84 / UTM zone 51N), declared via the `.prj` file. (Eastern-Mindanao assignments: EPSG:32652 instead.)
+- The supervisor uses their own GIS tools (QGIS, ArcGIS, etc.) to produce the bundle; the FireCheck app is **not** involved in this step.
+
+**Drive permissions**
+
+- The shared `/firecheck/inbox/<assignment_id>/` folder grants **read** access to assigned enumerators' Google accounts.
+- The shared `/firecheck/outbox/<assignment_id>/<enumerator_id>/` folder grants **write** access to that enumerator's Google account and **read** to the supervisor.
+
+**Folder & filename layout**
+
+- Documented in `docs/file-conventions.md` for both supervisor and enumerator reference.
+- Inbox: `/firecheck/inbox/<assignment_id>/input.zip`.
+- Outbox: `/firecheck/outbox/<assignment_id>/<enumerator_id>/output_<…>.zip` (+ sibling `photos/` folder).
 
 ---
 
@@ -50,22 +78,7 @@ architecture (Drift + Supabase) remains for the team's own use.
 
 ### Epic 1 — Input distribution
 
-#### FF-1 — Pre-stage assignment input shapefiles
-
-> **As a** Supervisor, **I want to** upload input shapefiles (boundary, buildings, roads) to a shared Google Drive folder, **so that** enumerators can download their assignment.
-
-**Acceptance criteria**
-
-- Drive path: `/firecheck/inbox/<assignment_id>/input.zip`.
-- Zip contains exactly:
-  - `boundary.{shp,dbf,shx,prj}` — assignment polygon.
-  - `buildings.{shp,dbf,shx,prj}` — initial building polygons (attributes may be sparse).
-  - `roads.{shp,dbf,shx,prj}` — initial road polylines.
-- Nothing else — no `manifest.json`, no `readme.txt`, no images.
-- CRS = EPSG:32651 (WGS 84 / UTM zone 51N), verified via the `.prj` file. (Eastern-Mindanao assignments: EPSG:32652 instead.)
-- Opens cleanly in QGIS with no warnings.
-
-#### FF-2 — Download assignment input on "Get Maps"
+#### FF-1 — Download assignment input on "Get Maps"
 
 > **As an** Enumerator, **I want** "Get Maps" to fetch my input shapefiles from Drive, **so that** I can work fully offline afterward.
 
@@ -76,7 +89,7 @@ architecture (Drift + Supabase) remains for the team's own use.
 - Existing Mapbox tile-pack download flow continues alongside this step.
 - Idempotent: re-tapping "Get Maps" while online refreshes only if Drive's `modifiedTime` on `input.zip` is newer than the locally stored value.
 
-#### FF-3 — Reject malformed input shapefiles
+#### FF-2 — Reject malformed input shapefiles
 
 > **As an** Enumerator, **I want** the app to reject a broken input shapefile at download time, **so that** I don't waste a day on an unusable assignment.
 
@@ -91,19 +104,19 @@ architecture (Drift + Supabase) remains for the team's own use.
 
 ### Epic 2 — Attribution (existing app behavior, confirmed)
 
-#### FF-4 — Attribute features offline
+#### FF-3 — Attribute features offline
 
 > **As an** Enumerator, **I want to** fill building, road, and OLP forms while offline, **so that** I can survey without connectivity.
 
 **Acceptance criteria**
 
 - Existing forms (Identity, Construction, Cost, Fire-fighting, Fire load, OLP) keep working unchanged.
-- Photos persist locally during fieldwork. At upload time (FF-7), the first 5 photos per structure are uploaded to Drive and their URLs are written into the shapefile's `.dbf` (see FF-5).
-- Multi-tab structures continue to work; each tab becomes a separate output row in FF-5 with its own photo set.
+- Photos persist locally during fieldwork. At upload time (FF-6), the first 5 photos per structure are uploaded to Drive and their URLs are written into the shapefile's `.dbf` (see FF-4).
+- Multi-tab structures continue to work; each tab becomes a separate output row in FF-4 with its own photo set.
 
 ### Epic 3 — Output packaging
 
-#### FF-5 — Export attributed shapefiles
+#### FF-4 — Export attributed shapefiles
 
 > **As an** Enumerator, **I want** the app to package my completed work as attributed shapefiles, **so that** I can hand it back in the format the course expects.
 
@@ -115,12 +128,12 @@ architecture (Drift + Supabase) remains for the team's own use.
   - `roads.{shp,dbf,shx,prj}` — attributed road polylines.
 - Nothing else inside the zip — no photos, no manifest, no readme.
 - `.dbf` column names ≤ 10 characters (shapefile spec).
-- `.dbf` includes columns `photo_1` … `photo_5` carrying the Drive shareable URL for each uploaded photo (resolved during FF-7). Empty for missing slots.
+- `.dbf` includes columns `photo_1` … `photo_5` carrying the Drive shareable URL for each uploaded photo (resolved during FF-6). Empty for missing slots.
 - All required survey fields populated per row; null values explicitly marked, not blank.
 - CRS = EPSG:32651 (WGS 84 / UTM zone 51N), declared in the `.prj` file. Geometries are reprojected from the in-app EPSG:4326 store to EPSG:32651 at export time. (Eastern-Mindanao assignments emit EPSG:32652 instead.)
-- Photos themselves live alongside the zip in a sibling `photos/` folder in Drive (see FF-7), not inside the zip.
+- Photos themselves live alongside the zip in a sibling `photos/` folder in Drive (see FF-6), not inside the zip.
 
-#### FF-6 — Pre-upload integrity check
+#### FF-5 — Pre-upload integrity check
 
 > **As an** Enumerator, **I want** the app to verify the shapefiles are complete before letting me upload, **so that** I don't deliver a broken submission.
 
@@ -138,7 +151,7 @@ architecture (Drift + Supabase) remains for the team's own use.
 
 ### Epic 4 — Upload
 
-#### FF-7 — Upload photos and attributed shapefiles to shared storage
+#### FF-6 — Upload photos and attributed shapefiles to shared storage
 
 > **As an** Enumerator, **I want to** upload my completed photos and shapefiles to Drive when I have Wi-Fi, **so that** the supervisor can review them in one place.
 
@@ -153,7 +166,7 @@ architecture (Drift + Supabase) remains for the team's own use.
 - Resumable across Wi-Fi drops (chunked upload or full retry — implementer's choice).
 - On both-phase success: assignment locks (existing behavior).
 
-#### FF-8 — Confirm upload landed
+#### FF-7 — Confirm upload landed
 
 > **As an** Enumerator, **I want** a clear confirmation including the remote path, **so that** I know the work is delivered.
 
@@ -164,7 +177,7 @@ architecture (Drift + Supabase) remains for the team's own use.
 
 ### Epic 5 — Cross-cutting
 
-#### FF-9 — Authenticate to shared storage
+#### FF-8 — Authenticate to shared storage
 
 > **As an** Enumerator, **I want to** sign in once with my UP Google account, **so that** all subsequent downloads and uploads are attributed to me.
 
@@ -175,23 +188,24 @@ architecture (Drift + Supabase) remains for the team's own use.
 - Auto-refresh; on refresh failure, prompt re-auth.
 - Sign-out option from settings.
 
-#### FF-10 — Predictable folder & filename convention
+#### FF-9 — Enforce predictable folder & filename convention
 
-> **As a** Supervisor, **I want** every input and output to follow a documented naming convention, **so that** I can locate any enumerator's work without guessing.
+> **As an** Enumerator, **I want** the app to enforce the documented Drive folder and filename convention on every upload, **so that** the supervisor (and any teammate inspecting the bucket) can locate my work without guessing.
 
 **Acceptance criteria**
 
-- `docs/file-conventions.md` documents the inbox / outbox layouts (per FF-1, FF-7).
+- `docs/file-conventions.md` documents the inbox / outbox layouts (cross-references the Preconditions section above and FF-6).
 - App refuses to upload if `assignment_id` or `enumerator_id` is missing or invalid.
+- Upload paths are constructed from the documented template; no free-form folders.
 - Different enumerators never collide — each lives in their own subfolder under the assignment.
 
-#### FF-11 — Open enumerator output directly in QGIS
+#### FF-10 — Produce QGIS-compatible output
 
-> **As a** Supervisor, **I want to** open any uploaded shapefile in QGIS without conversion, **so that** I can spot-check work using standard GIS tooling.
+> **As an** Enumerator, **I want** the app's exported shapefiles to load in QGIS without conversion or warnings, **so that** the supervisor can spot-check my work using standard GIS tooling.
 
 **Acceptance criteria**
 
-- Shapefile loads in QGIS with no warnings.
+- Exported shapefile loads in QGIS with no warnings.
 - Attributes are inspectable via QGIS's standard Attribute Table.
 - Photo URLs in `photo_1` … `photo_5` are clickable from the QGIS attribute form (Open URL action) and resolve to the corresponding JPEG in the sibling `photos/` Drive folder.
 - Geometry is valid (no self-intersections, all polygons closed).
@@ -202,6 +216,7 @@ architecture (Drift + Supabase) remains for the team's own use.
 
 - Photos *inside the zip* — they ride alongside in a sibling `photos/` Drive folder, referenced by URL in the `.dbf`.
 - A manifest or readme file in the deliverable.
+- Any feature for the supervisor to use *inside the FireCheck app* — the supervisor uses their own tools (Drive web, QGIS).
 - Real-time multi-enumerator collaboration on the same assignment.
 - Server-side validation or automated bounce-back of bad uploads — supervisor reviews manually.
 - Re-versioning input shapefiles after enumerators have started (input frozen at download time).
@@ -227,10 +242,10 @@ architecture (Drift + Supabase) remains for the team's own use.
 
 | Story | Touches |
 |---|---|
-| FF-2, FF-3 | `lib/features/assignment/` (Get Maps flow), new `lib/core/sync/shapefile/` for shapefile import |
-| FF-5, FF-6 | `lib/core/sync/` (replaces bundle export), new `lib/core/sync/shapefile/` for shapefile export |
-| FF-7, FF-8 | `lib/core/sync/worker/`, replace Supabase Storage adapter with Google Drive adapter |
-| FF-9 | `lib/core/auth/`, add Google OAuth alongside existing Supabase auth |
-| FF-10 | `docs/file-conventions.md` (new) |
+| FF-1, FF-2 | `lib/features/assignment/` (Get Maps flow), new `lib/core/sync/shapefile/` for shapefile import |
+| FF-4, FF-5 | `lib/core/sync/` (replaces bundle export), new `lib/core/sync/shapefile/` for shapefile export |
+| FF-6, FF-7 | `lib/core/sync/worker/`, replace Supabase Storage adapter with Google Drive adapter |
+| FF-8 | `lib/core/auth/`, add Google OAuth alongside existing Supabase auth |
+| FF-9 | `docs/file-conventions.md` (new) |
 
 The existing **outbox / retry / WorkManager** machinery from Phase 4a is kept — only the upload *destination* and *payload format* change.

--- a/docs/superpowers/specs/2026-04-29-flat-file-sync-design.md
+++ b/docs/superpowers/specs/2026-04-29-flat-file-sync-design.md
@@ -27,8 +27,10 @@ architecture (Drift + Supabase) remains for the team's own use.
 | Topic | Choice | Rationale |
 |---|---|---|
 | Scope | Replace the delivery boundary, not the whole sync engine. | Follows the supervisor's instruction without scrapping working internal infra. |
-| Deliverable contents | **Only shapefile component files** (`.shp/.dbf/.shx/.prj`). No photos, no manifest, no readme in the zip. | Strict reading of the supervisor's instruction: "download the shape files… upload the attributed shape files." |
-| Photos | Stay inside the app (Drift + Supabase Storage) for the team's own records; never part of the deliverable. | Photos can't go inside a shapefile, and the supervisor didn't ask for them. |
+| Deliverable contents (zip) | **Only shapefile component files** (`.shp/.dbf/.shx/.prj`). No photos, no manifest, no readme inside the zip. | Strict reading of the supervisor's instruction. Keeps the shapefile "pure" — opens cleanly in any GIS tool. |
+| Photos | **Uploaded to a sibling `photos/` folder in Drive** (not inside the zip). The `.dbf` carries the resolved Drive URL in `photo_1` … `photo_5` columns. | Shapefile stays a real shapefile; photos still reach the supervisor; clicking the URL in QGIS opens the photo in a browser. |
+| Photo upload path | `/firecheck/outbox/<assignment_id>/<enumerator_id>/photos/<feature_id>_<n>.jpg`. | Sibling to the output zip — supervisor sees both in one folder; Drive ACL on the parent folder grants photo access automatically. |
+| Photo cap per feature | First **5** photos referenced by URL (`photo_1` … `photo_5`); additional photos kept locally for the team's records but not delivered. | Bounded `.dbf` schema; matches typical fire-survey expectations of front + 4 detail shots. |
 | Storage backend | **Google Drive**. | UP accounts already exist, supervisor familiarity, stable API; FileZilla needs hosted FTP we don't have, GitHub is awkward for >100 MB updates. |
 | Multi-tab buildings | One row per structure with repeated geometry; `struct_idx` column distinguishes them. | Cleaner for GIS analysis than numbered columns; expected by QGIS. |
 | CRS — internal & Mapbox | EPSG:4326 (WGS84 lat/lon). | What GPS and Mapbox use natively; no transformation cost in the live map view. |
@@ -96,8 +98,8 @@ architecture (Drift + Supabase) remains for the team's own use.
 **Acceptance criteria**
 
 - Existing forms (Identity, Construction, Cost, Fire-fighting, Fire load, OLP) keep working unchanged.
-- Photos persist locally for the team's own use; they are **not** included in the shapefile deliverable.
-- Multi-tab structures continue to work; each tab becomes a separate output row in FF-5.
+- Photos persist locally during fieldwork. At upload time (FF-7), the first 5 photos per structure are uploaded to Drive and their URLs are written into the shapefile's `.dbf` (see FF-5).
+- Multi-tab structures continue to work; each tab becomes a separate output row in FF-5 with its own photo set.
 
 ### Epic 3 — Output packaging
 
@@ -111,10 +113,12 @@ architecture (Drift + Supabase) remains for the team's own use.
 - Zip contains exactly:
   - `buildings.{shp,dbf,shx,prj}` — one row per structure (multi-tab → repeated geometry, distinct `struct_idx`).
   - `roads.{shp,dbf,shx,prj}` — attributed road polylines.
-- Nothing else — no photos, no manifest, no readme.
+- Nothing else inside the zip — no photos, no manifest, no readme.
 - `.dbf` column names ≤ 10 characters (shapefile spec).
+- `.dbf` includes columns `photo_1` … `photo_5` carrying the Drive shareable URL for each uploaded photo (resolved during FF-7). Empty for missing slots.
 - All required survey fields populated per row; null values explicitly marked, not blank.
 - CRS = EPSG:32651 (WGS 84 / UTM zone 51N), declared in the `.prj` file. Geometries are reprojected from the in-app EPSG:4326 store to EPSG:32651 at export time. (Eastern-Mindanao assignments emit EPSG:32652 instead.)
+- Photos themselves live alongside the zip in a sibling `photos/` folder in Drive (see FF-7), not inside the zip.
 
 #### FF-6 — Pre-upload integrity check
 
@@ -126,24 +130,28 @@ architecture (Drift + Supabase) remains for the team's own use.
 - **Blockers** (must be zero before upload is enabled):
   - Any feature missing a required attribute.
   - Any feature with invalid geometry (non-closed polygon, self-intersection, etc.).
+  - Any required photo missing locally (file unreadable, deleted, or zero-byte).
 - **Warnings** (non-blocking):
   - Unusual values (e.g. `n_storeys > 50`).
+  - More than 5 photos captured for a feature (extras will not be linked in the deliverable).
 - Upload button is disabled until blockers = 0.
 
 ### Epic 4 — Upload
 
-#### FF-7 — Upload attributed shapefiles to shared storage
+#### FF-7 — Upload photos and attributed shapefiles to shared storage
 
-> **As an** Enumerator, **I want to** upload my completed shapefiles to Drive when I have Wi-Fi, **so that** the supervisor can review them.
+> **As an** Enumerator, **I want to** upload my completed photos and shapefiles to Drive when I have Wi-Fi, **so that** the supervisor can review them in one place.
 
 **Acceptance criteria**
 
 - Triggered from existing Review-screen "Upload Data" button.
 - Biometric gate (existing behavior) intact.
-- Drive path: `/firecheck/outbox/<assignment_id>/<enumerator_id>/output_<…>.zip`.
-- **Idempotent:** re-uploading the same logical output saves a `_v2`, `_v3`, … sibling — never overwrites the previous version.
+- Two-phase upload, executed atomically (failure of either phase rolls back the assignment to its un-uploaded state):
+  1. **Photos phase** — uploads the first 5 photos per structure to `/firecheck/outbox/<assignment_id>/<enumerator_id>/photos/<feature_id>_<n>.jpg` and captures each photo's Drive shareable URL.
+  2. **Shapefile phase** — backfills the captured URLs into the `.dbf` `photo_1` … `photo_5` columns, zips the shapefile components, and uploads `output_<…>.zip` to `/firecheck/outbox/<assignment_id>/<enumerator_id>/`.
+- **Idempotent:** re-running creates `_v2`, `_v3`, … siblings for the zip; photos are uploaded into a versioned subfolder (`photos/`, `photos_v2/`, …) so URLs in old `.dbf` versions remain valid.
 - Resumable across Wi-Fi drops (chunked upload or full retry — implementer's choice).
-- On success: assignment locks (existing behavior).
+- On both-phase success: assignment locks (existing behavior).
 
 #### FF-8 — Confirm upload landed
 
@@ -185,13 +193,14 @@ architecture (Drift + Supabase) remains for the team's own use.
 
 - Shapefile loads in QGIS with no warnings.
 - Attributes are inspectable via QGIS's standard Attribute Table.
+- Photo URLs in `photo_1` … `photo_5` are clickable from the QGIS attribute form (Open URL action) and resolve to the corresponding JPEG in the sibling `photos/` Drive folder.
 - Geometry is valid (no self-intersections, all polygons closed).
 
 ---
 
 ## Out of scope
 
-- Photos in the deliverable — they stay inside the app.
+- Photos *inside the zip* — they ride alongside in a sibling `photos/` Drive folder, referenced by URL in the `.dbf`.
 - A manifest or readme file in the deliverable.
 - Real-time multi-enumerator collaboration on the same assignment.
 - Server-side validation or automated bounce-back of bad uploads — supervisor reviews manually.
@@ -209,6 +218,8 @@ architecture (Drift + Supabase) remains for the team's own use.
 4. **Re-upload semantics** — confirm `_v2/_v3` suffixed sibling files (this design's choice) vs. timestamp-only filenames vs. overwriting.
 5. **Boundary in output** — confirm whether the supervisor wants `boundary.shp` echoed back in the output zip, or only `buildings` and `roads`.
 6. **CRS** — confirm EPSG:32651 (WGS 84 / UTM zone 51N) for the deliverable. Alternative for stricter government-style work: EPSG:3124 (PRS92 / Philippines zone 4) — the official Philippine national datum for the Cebu/Visayas area, but introduces a ~150 m datum-shift transformation from GPS source.
+7. **Photo cap (5 per structure)** — confirm 5 is enough, or set to a different limit (e.g. 3, or 10).
+8. **Drive permissions for photos** — confirm "anyone with the outbox folder access can read photos" is acceptable, vs. restricting photos to a smaller group.
 
 ---
 

--- a/docs/superpowers/specs/2026-04-29-flat-file-sync-design.md
+++ b/docs/superpowers/specs/2026-04-29-flat-file-sync-design.md
@@ -31,7 +31,8 @@ architecture (Drift + Supabase) remains for the team's own use.
 | Photos | Stay inside the app (Drift + Supabase Storage) for the team's own records; never part of the deliverable. | Photos can't go inside a shapefile, and the supervisor didn't ask for them. |
 | Storage backend | **Google Drive**. | UP accounts already exist, supervisor familiarity, stable API; FileZilla needs hosted FTP we don't have, GitHub is awkward for >100 MB updates. |
 | Multi-tab buildings | One row per structure with repeated geometry; `struct_idx` column distinguishes them. | Cleaner for GIS analysis than numbered columns; expected by QGIS. |
-| CRS | EPSG:4326 (WGS84) end-to-end. | Mapbox already operates here; no projection conversion needed. |
+| CRS — internal & Mapbox | EPSG:4326 (WGS84 lat/lon). | What GPS and Mapbox use natively; no transformation cost in the live map view. |
+| CRS — shapefile deliverable | **EPSG:32651 (WGS 84 / UTM zone 51N)**. | Projected to meters, so building footprints and road lengths measure correctly out of the box. Same WGS84 datum as GPS — no datum-shift error. Covers Cebu, Manila, Palawan, most of the Philippines (120°–126° E). PRS92 zones (3123–3125) considered but rejected: ~150 m datum offset from WGS84 introduces transformation uncertainty for a GPS-driven survey app. Assignments east of 126° E should switch to EPSG:32652 (UTM zone 52N) — implementation should make this configurable per assignment. |
 | Zip | Used only as transport for the multi-file shapefile set. Nothing else inside. | Convenience — Drive doesn't preserve directory grouping for loose `.shp/.dbf/.shx/.prj` uploads. |
 
 ---
@@ -59,7 +60,7 @@ architecture (Drift + Supabase) remains for the team's own use.
   - `buildings.{shp,dbf,shx,prj}` — initial building polygons (attributes may be sparse).
   - `roads.{shp,dbf,shx,prj}` — initial road polylines.
 - Nothing else — no `manifest.json`, no `readme.txt`, no images.
-- CRS = EPSG:4326 (verified via `.prj`).
+- CRS = EPSG:32651 (WGS 84 / UTM zone 51N), verified via the `.prj` file. (Eastern-Mindanao assignments: EPSG:32652 instead.)
 - Opens cleanly in QGIS with no warnings.
 
 #### FF-2 — Download assignment input on "Get Maps"
@@ -81,8 +82,9 @@ architecture (Drift + Supabase) remains for the team's own use.
 
 - Pre-import validation checks:
   - All required `.shp/.dbf/.shx/.prj` files present for each layer.
-  - CRS = EPSG:4326.
+  - CRS matches the configured assignment CRS (default EPSG:32651). Mismatched CRS is rejected — supervisor must reproject before re-uploading.
   - Required attribute columns present in `buildings.dbf` and `roads.dbf`.
+- On import, geometries are reprojected from the file CRS to EPSG:4326 (WGS84) for in-app storage and Mapbox display.
 - On any failure: clear error citing what's missing; no partial import.
 
 ### Epic 2 — Attribution (existing app behavior, confirmed)
@@ -112,7 +114,7 @@ architecture (Drift + Supabase) remains for the team's own use.
 - Nothing else — no photos, no manifest, no readme.
 - `.dbf` column names ≤ 10 characters (shapefile spec).
 - All required survey fields populated per row; null values explicitly marked, not blank.
-- CRS = EPSG:4326.
+- CRS = EPSG:32651 (WGS 84 / UTM zone 51N), declared in the `.prj` file. Geometries are reprojected from the in-app EPSG:4326 store to EPSG:32651 at export time. (Eastern-Mindanao assignments emit EPSG:32652 instead.)
 
 #### FF-6 — Pre-upload integrity check
 
@@ -206,6 +208,7 @@ architecture (Drift + Supabase) remains for the team's own use.
 3. **Required attribute columns** — confirm the supervisor's expected column list. The app currently captures dozens of fields; the supervisor may only want a subset.
 4. **Re-upload semantics** — confirm `_v2/_v3` suffixed sibling files (this design's choice) vs. timestamp-only filenames vs. overwriting.
 5. **Boundary in output** — confirm whether the supervisor wants `boundary.shp` echoed back in the output zip, or only `buildings` and `roads`.
+6. **CRS** — confirm EPSG:32651 (WGS 84 / UTM zone 51N) for the deliverable. Alternative for stricter government-style work: EPSG:3124 (PRS92 / Philippines zone 4) — the official Philippine national datum for the Cebu/Visayas area, but introduces a ~150 m datum-shift transformation from GPS source.
 
 ---
 

--- a/docs/superpowers/specs/2026-04-29-flat-file-sync-design.md
+++ b/docs/superpowers/specs/2026-04-29-flat-file-sync-design.md
@@ -1,0 +1,226 @@
+# Flat-File Sync — User Stories & Design
+
+**Date:** 2026-04-29
+**Status:** Draft, awaiting review
+**Author:** John Lester Escarlan (with brainstorming assistance)
+
+---
+
+## Background
+
+The original FireCheck spec referenced a "server" for retrieving maps. The course
+supervisor (Dulaca, R.C.) clarified on 2026-04-29 that no such API server exists
+or is intended. The supervisor's actual model is **flat file storage**: a shared
+repository where input shapefiles are placed for download, and attributed
+shapefiles are uploaded back. Acceptable storage media include a GitHub repo,
+Google Drive, or FileZilla/FTP.
+
+This document scopes a small set of user stories to bring the FireCheck mobile
+app into compliance with that instruction by replacing the **delivery boundary**
+(currently Supabase REST + Storage) with a flat-file workflow built on
+shapefile bundles. Internal app architecture (Drift + Supabase) remains.
+
+---
+
+## Decisions
+
+| Topic | Choice | Rationale |
+|---|---|---|
+| Scope | Replace the delivery boundary, not the whole sync engine. | Follows the supervisor's instruction without scrapping working internal infra. |
+| Photos | Filename in .dbf column, photos in sibling `photos/` folder, zipped together. | Standard GIS convention; opens in QGIS; keeps the deliverable a real shapefile. |
+| Storage backend | **Google Drive**. | UP accounts already exist, supervisor familiarity, stable API; FileZilla needs hosted FTP we don't have, GitHub is awkward for >100 MB photo bundles. |
+| Multi-tab buildings | One row per structure with repeated geometry; `struct_idx` column distinguishes them. | Cleaner for GIS analysis than numbered columns. |
+| CRS | EPSG:4326 (WGS84) end-to-end. | Mapbox already operates here; no projection conversion needed. |
+
+---
+
+## Personas
+
+- **Enumerator (E)** — field worker using the FireCheck app.
+- **Course Supervisor (S)** — uploads input bundles to shared storage; downloads and reviews output.
+
+---
+
+## User Stories
+
+### Epic 1 — Input distribution
+
+#### FF-1 — Pre-stage assignment input as a shapefile bundle
+
+> **As a** Supervisor, **I want to** upload an input bundle (boundary + buildings + roads shapefiles) to a shared Google Drive folder, **so that** enumerators can download their assignment.
+
+**Acceptance criteria**
+
+- Bundle is `input.zip` containing:
+  - `boundary.{shp,dbf,shx,prj}` — the assignment polygon
+  - `buildings.{shp,dbf,shx,prj}` — initial building polygons (may be empty attributes)
+  - `roads.{shp,dbf,shx,prj}` — initial road polylines
+  - `manifest.json` — `{ assignment_id, area_name, supervisor, generated_at }`
+- Drive path: `/firecheck/inbox/<assignment_id>/input.zip`.
+- CRS = EPSG:4326 (verified via `.prj`).
+- Bundle opens cleanly in QGIS with no warnings.
+
+#### FF-2 — Download assignment input on "Get Maps"
+
+> **As an** Enumerator, **I want** "Get Maps" to fetch my input bundle from Drive, **so that** I can work fully offline afterward.
+
+**Acceptance criteria**
+
+- Authenticates to Drive, lists assignments visible to the signed-in account.
+- Downloads `input.zip`, extracts, imports features into Drift, preserving original `feature_id` from `.dbf`.
+- Existing Mapbox tile-pack download flow continues to run alongside this step.
+- Idempotent: re-tapping "Get Maps" while online refreshes only if remote `manifest.json:generated_at` is newer than the locally stored value.
+
+#### FF-3 — Reject malformed input bundles
+
+> **As an** Enumerator, **I want** the app to reject a broken input bundle at download time, **so that** I don't waste a day on an unusable assignment.
+
+**Acceptance criteria**
+
+- Pre-import validation checks:
+  - All required `.shp/.dbf/.shx/.prj` files present.
+  - CRS = EPSG:4326.
+  - `manifest.json` parseable and complete.
+  - Required attribute columns present in `buildings.dbf` and `roads.dbf`.
+- On any failure: clear error citing what's missing; no partial import.
+
+### Epic 2 — Attribution (existing app behavior, confirmed)
+
+#### FF-4 — Attribute features offline
+
+> **As an** Enumerator, **I want to** fill building, road, and OLP forms while offline, **so that** I can survey without connectivity.
+
+**Acceptance criteria**
+
+- Existing forms (Identity, Construction, Cost, Fire-fighting, Fire load, OLP) keep working unchanged.
+- Photos persist locally and are tagged with `feature_id` + `structure_idx`.
+- Multi-tab structures continue to work; each tab becomes a separate output row in FF-5.
+
+### Epic 3 — Output packaging
+
+#### FF-5 — Export attributed features as a shapefile bundle
+
+> **As an** Enumerator, **I want** the app to package my completed work as a shapefile bundle, **so that** I can hand it back in the format the course expects.
+
+**Acceptance criteria**
+
+- Output zip layout:
+  ```
+  output_<assignment_id>_<enumerator_id>_<yyyymmdd-hhmm>.zip
+    ├── buildings.{shp,dbf,shx,prj}   one row per structure (multi-tab → repeated geometry, distinct struct_idx)
+    ├── roads.{shp,dbf,shx,prj}       attributed road polylines
+    ├── photos/<feature_id>_<n>.jpg   photos referenced from .dbf
+    ├── manifest.json                  assignment_id, enumerator_id, completed_at, feature counts
+    └── readme.txt                     column dictionary mapping 10-char .dbf names → human-readable
+  ```
+- `.dbf` column names capped at 10 characters (shapefile spec).
+- `readme.txt` provides the short-name → long-name mapping.
+- Photo columns `photo_1`…`photo_n` hold filenames that resolve inside `photos/`.
+- All required survey fields present per row; null values explicitly marked, not blank.
+
+#### FF-6 — Pre-upload integrity check
+
+> **As an** Enumerator, **I want** the app to verify the bundle is complete before letting me upload, **so that** I don't deliver a broken submission.
+
+**Acceptance criteria**
+
+- Runs automatically on the Review screen.
+- **Blockers** (must be zero before upload is enabled):
+  - Any feature missing a required attribute.
+  - Any photo column referencing a file not in `photos/`.
+- **Warnings** (non-blocking):
+  - Unusual values (e.g. `n_storeys > 50`).
+- Upload button is disabled until blockers = 0.
+
+### Epic 4 — Upload
+
+#### FF-7 — Upload attributed bundle to shared storage
+
+> **As an** Enumerator, **I want to** upload my completed bundle to Drive when I have Wi-Fi, **so that** the supervisor can review it.
+
+**Acceptance criteria**
+
+- Triggered from existing Review-screen "Upload Data" button.
+- Biometric gate (existing behavior) intact.
+- Drive path: `/firecheck/outbox/<assignment_id>/<enumerator_id>/output_<…>.zip`.
+- **Idempotent:** re-uploading the same logical bundle saves a `_v2`, `_v3`, … sibling — it never overwrites the previous version.
+- Resumable across Wi-Fi drops (chunked upload or full retry — implementer's choice).
+- On success: assignment locks (existing behavior).
+
+#### FF-8 — Confirm upload landed
+
+> **As an** Enumerator, **I want** a clear confirmation including the remote path, **so that** I know the work is delivered.
+
+**Acceptance criteria**
+
+- After successful upload, the app shows the Drive file path / shareable link with a "Copy" action.
+- On failure, the error message and a "Retry" affordance are shown.
+
+### Epic 5 — Cross-cutting
+
+#### FF-9 — Authenticate to shared storage
+
+> **As an** Enumerator, **I want to** sign in once with my UP Google account, **so that** all subsequent downloads and uploads are attributed to me.
+
+**Acceptance criteria**
+
+- Google sign-in on first launch.
+- Refresh tokens persisted in `FlutterSecureStorage`.
+- Auto-refresh; on refresh failure, prompt re-auth.
+- Sign-out option from settings.
+
+#### FF-10 — Predictable folder & filename convention
+
+> **As a** Supervisor, **I want** every input and output to follow a documented naming convention, **so that** I can locate any enumerator's work without guessing.
+
+**Acceptance criteria**
+
+- `docs/file-conventions.md` documents the inbox / outbox layouts (per FF-1, FF-7).
+- App refuses to upload if `assignment_id` or `enumerator_id` is missing or invalid.
+- Different enumerators never collide — each lives in their own subfolder under the assignment.
+
+#### FF-11 — Open enumerator output directly in QGIS
+
+> **As a** Supervisor, **I want to** open any uploaded bundle in QGIS without conversion, **so that** I can spot-check work using standard GIS tooling.
+
+**Acceptance criteria**
+
+- Bundle loads in QGIS with no warnings.
+- A QGIS attribute-form action wired to the `photo_1` column previews the photo from `photos/`.
+- `manifest.json` counts let the supervisor sanity-check against the survey area.
+
+---
+
+## Out of scope
+
+- Real-time multi-enumerator collaboration on the same assignment.
+- Server-side validation or automated bounce-back of bad uploads — supervisor reviews manually.
+- Re-versioning input bundles after enumerators have started (input is frozen at download time).
+- Migrating the rest of the app off Supabase — internal storage stays Drift + Supabase; only the **delivery boundary** changes.
+- Switching to GeoPackage or KMZ — supervisor explicitly mentioned shapefiles.
+
+---
+
+## Open questions to confirm with supervisor
+
+These are flagged for explicit confirmation before implementation begins:
+
+1. **Photo handling convention** — confirm sibling `photos/` folder + filename in `.dbf` column is acceptable (vs. embedded GeoPackage).
+2. **Storage backend** — confirm Google Drive (vs. FileZilla / GitHub repo).
+3. **Multi-tab buildings** — confirm "one row per structure with repeated geometry" is the expected GIS shape (vs. numbered columns on a single row).
+4. **Required attribute fields** — confirm the supervisor's expected column list, not the app's internal field list. The `readme.txt` dictionary should match what the supervisor wants to see.
+5. **Re-upload semantics** — confirm `_v2/_v3` suffixed sibling files (this design's choice) vs. timestamp-only filenames vs. overwriting the previous version.
+
+---
+
+## Mapping to existing FireCheck modules
+
+| Story | Touches |
+|---|---|
+| FF-2, FF-3 | `lib/features/assignment/` (Get Maps flow), new `lib/core/sync/shapefile/` for shapefile import |
+| FF-5, FF-6 | `lib/core/sync/` (replaces bundle export), new `lib/core/sync/shapefile/` for shapefile export |
+| FF-7, FF-8 | `lib/core/sync/worker/`, replace Supabase Storage adapter with Google Drive adapter |
+| FF-9 | `lib/core/auth/`, add Google OAuth alongside existing Supabase auth |
+| FF-10 | `docs/file-conventions.md` (new) |
+
+The existing **outbox / retry / WorkManager** machinery from Phase 4a should be kept — only the upload *destination* and *payload format* change.

--- a/docs/superpowers/specs/2026-04-29-flat-file-sync-design.md
+++ b/docs/superpowers/specs/2026-04-29-flat-file-sync-design.md
@@ -31,7 +31,9 @@ architecture (Drift + Supabase) remains for the team's own use.
 | Photos | **Uploaded to a sibling `photos/` folder in Drive** (not inside the zip). The `.dbf` carries the resolved Drive URL in `photo_1` … `photo_5` columns. | Shapefile stays a real shapefile; photos still reach the supervisor; clicking the URL in QGIS opens the photo in a browser. |
 | Photo upload path | `/firecheck/outbox/<assignment_id>/<enumerator_id>/photos/<feature_id>_<n>.jpg`. | Sibling to the output zip — supervisor sees both in one folder; Drive ACL on the parent folder grants photo access automatically. |
 | Photo cap per feature | First **5** photos referenced by URL (`photo_1` … `photo_5`); additional photos kept locally for the team's records but not delivered. | Bounded `.dbf` schema; matches typical fire-survey expectations of front + 4 detail shots. |
-| Storage backend | **Google Drive**. | UP accounts already exist, supervisor familiarity, stable API; FileZilla needs hosted FTP we don't have, GitHub is awkward for >100 MB updates. |
+| Storage backend | **Google Drive**. | UP accounts already exist, supervisor familiarity, stable API. FileZilla considered and rejected: the client is free but needs an FTP *server* somewhere (dorm machine kept always-on, or paid VPS), which is operational overhead the team doesn't have. GitHub is awkward for >100 MB photo+shapefile bundles. |
+| Assignment discovery | App lists subfolders of `/firecheck/inbox/` that the signed-in user has been **shared on** in Drive. Each folder name *is* the `assignment_id`. | Uses Drive's native sharing model — supervisor shares the folder with the student's Google account (or a class Google Group); the app sees what Drive lets it see. No manifest file needed. |
+| Enumerator identity | `enumerator_id` = local-part of the signed-in Google email (`jlescarlan11@gmail.com` → `jlescarlan11`). | Deterministic across devices and reinstalls; stable Drive output paths; doesn't require a separate enrollment system. |
 | Multi-tab buildings | One row per structure with repeated geometry; `struct_idx` column distinguishes them. | Cleaner for GIS analysis than numbered columns; expected by QGIS. |
 | CRS — internal & Mapbox | EPSG:4326 (WGS84 lat/lon). | What GPS and Mapbox use natively; no transformation cost in the live map view. |
 | CRS — shapefile deliverable | **EPSG:32651 (WGS 84 / UTM zone 51N)**. | Projected to meters, so building footprints and road lengths measure correctly out of the box. Same WGS84 datum as GPS — no datum-shift error. Covers Cebu, Manila, Palawan, most of the Philippines (120°–126° E). PRS92 zones (3123–3125) considered but rejected: ~150 m datum offset from WGS84 introduces transformation uncertainty for a GPS-driven survey app. Assignments east of 126° E should switch to EPSG:32652 (UTM zone 52N) — implementation should make this configurable per assignment. |
@@ -61,10 +63,11 @@ These are the things the supervisor must do for the app to have anything to read
 - CRS = EPSG:32651 (WGS 84 / UTM zone 51N), declared via the `.prj` file. (Eastern-Mindanao assignments: EPSG:32652 instead.)
 - The supervisor uses their own GIS tools (QGIS, ArcGIS, etc.) to produce the bundle; the FireCheck app is **not** involved in this step.
 
-**Drive permissions**
+**Drive permissions** (this is how the app *discovers* assignments — see FF-1)
 
-- The shared `/firecheck/inbox/<assignment_id>/` folder grants **read** access to assigned enumerators' Google accounts.
-- The shared `/firecheck/outbox/<assignment_id>/<enumerator_id>/` folder grants **write** access to that enumerator's Google account and **read** to the supervisor.
+- For each assignment, the supervisor right-clicks the `/firecheck/inbox/<assignment_id>/` folder in Drive → **Share** → adds the assigned enumerator's Google account (or a class Google Group) with **Viewer** (read) permission.
+- The supervisor creates `/firecheck/outbox/<assignment_id>/<enumerator_id>/` (or accepts that the app creates it on first upload) and grants the enumerator **Editor** (write) permission and themselves **Viewer**.
+- The app does *not* maintain its own roster of who has which assignment. Drive's sharing list **is** the roster — that's how the app's "Get Maps" knows what to show.
 
 **Folder & filename layout**
 
@@ -84,8 +87,10 @@ These are the things the supervisor must do for the app to have anything to read
 
 **Acceptance criteria**
 
-- Authenticates to Drive, lists assignments visible to the signed-in account.
-- Downloads `input.zip`, extracts, imports features into Drift, preserving original `feature_id` from the `.dbf`.
+- **Discovery:** the app calls Drive's `files.list` API for subfolders of `/firecheck/inbox/` that the signed-in user can read. Each returned folder's name is treated as an `assignment_id`. Result is shown as a pick-list (folder name + last-modified date).
+- **Empty state:** if no assignment folders are visible, the app shows *"No assignments shared with you yet — ask your supervisor to share the assignment folder with your UP Google account."* — not a generic error.
+- **Selection:** if multiple assignments are visible, the user picks one before download begins.
+- Downloads `input.zip` from the selected folder, extracts, imports features into Drift, preserving original `feature_id` from the `.dbf`.
 - Existing Mapbox tile-pack download flow continues alongside this step.
 - Idempotent: re-tapping "Get Maps" while online refreshes only if Drive's `modifiedTime` on `input.zip` is newer than the locally stored value.
 

--- a/docs/superpowers/specs/2026-04-29-flat-file-sync-design.md
+++ b/docs/superpowers/specs/2026-04-29-flat-file-sync-design.md
@@ -31,7 +31,7 @@ architecture (Drift + Supabase) remains for the team's own use.
 | Photos | **Uploaded to a sibling `photos/` folder in Drive** (not inside the zip). The `.dbf` carries the resolved Drive URL in `photo_1` … `photo_5` columns. | Shapefile stays a real shapefile; photos still reach the supervisor; clicking the URL in QGIS opens the photo in a browser. |
 | Photo upload path | `/firecheck/outbox/<assignment_id>/<enumerator_id>/photos/<feature_id>_<n>.jpg`. | Sibling to the output zip — supervisor sees both in one folder; Drive ACL on the parent folder grants photo access automatically. |
 | Photo cap per feature | First **5** photos referenced by URL (`photo_1` … `photo_5`); additional photos kept locally for the team's records but not delivered. | Bounded `.dbf` schema; matches typical fire-survey expectations of front + 4 detail shots. |
-| Storage backend | **Google Drive**. | UP accounts already exist, supervisor familiarity, stable API. FileZilla considered and rejected: the client is free but needs an FTP *server* somewhere (dorm machine kept always-on, or paid VPS), which is operational overhead the team doesn't have. GitHub is awkward for >100 MB photo+shapefile bundles. |
+| Storage backend | **Google Drive**. | Free for any Google account (15 GB), zero server maintenance, supervisor familiarity, stable API. UP accounts work but are not required — personal Gmail is fine. FileZilla considered and rejected: the client is free but needs an FTP *server* somewhere (dorm machine kept always-on, or paid VPS), which is operational overhead the team doesn't have. GitHub is awkward for >100 MB photo+shapefile bundles. |
 | Assignment discovery | App lists subfolders of `/firecheck/inbox/` that the signed-in user has been **shared on** in Drive. Each folder name *is* the `assignment_id`. | Uses Drive's native sharing model — supervisor shares the folder with the student's Google account (or a class Google Group); the app sees what Drive lets it see. No manifest file needed. |
 | Enumerator identity | `enumerator_id` = local-part of the signed-in Google email (`jlescarlan11@gmail.com` → `jlescarlan11`). | Deterministic across devices and reinstalls; stable Drive output paths; doesn't require a separate enrollment system. |
 | Multi-tab buildings | One row per structure with repeated geometry; `struct_idx` column distinguishes them. | Cleaner for GIS analysis than numbered columns; expected by QGIS. |
@@ -88,7 +88,7 @@ These are the things the supervisor must do for the app to have anything to read
 **Acceptance criteria**
 
 - **Discovery:** the app calls Drive's `files.list` API for subfolders of `/firecheck/inbox/` that the signed-in user can read. Each returned folder's name is treated as an `assignment_id`. Result is shown as a pick-list (folder name + last-modified date).
-- **Empty state:** if no assignment folders are visible, the app shows *"No assignments shared with you yet — ask your supervisor to share the assignment folder with your UP Google account."* — not a generic error.
+- **Empty state:** if no assignment folders are visible, the app shows *"No assignments shared with you yet — ask your supervisor to share the assignment folder with the Google account you signed in with."* — not a generic error.
 - **Selection:** if multiple assignments are visible, the user picks one before download begins.
 - Downloads `input.zip` from the selected folder, extracts, imports features into Drift, preserving original `feature_id` from the `.dbf`.
 - Existing Mapbox tile-pack download flow continues alongside this step.
@@ -184,7 +184,7 @@ These are the things the supervisor must do for the app to have anything to read
 
 #### FF-8 — Authenticate to shared storage
 
-> **As an** Enumerator, **I want to** sign in once with my UP Google account, **so that** all subsequent downloads and uploads are attributed to me.
+> **As an** Enumerator, **I want to** sign in once with a Google account, **so that** all subsequent downloads and uploads are attributed to me.
 
 **Acceptance criteria**
 

--- a/docs/superpowers/specs/2026-04-29-flat-file-sync-design.md
+++ b/docs/superpowers/specs/2026-04-29-flat-file-sync-design.md
@@ -12,13 +12,13 @@ The original FireCheck spec referenced a "server" for retrieving maps. The cours
 supervisor (Dulaca, R.C.) clarified on 2026-04-29 that no such API server exists
 or is intended. The supervisor's actual model is **flat file storage**: a shared
 repository where input shapefiles are placed for download, and attributed
-shapefiles are uploaded back. Acceptable storage media include a GitHub repo,
-Google Drive, or FileZilla/FTP.
+shapefiles are uploaded back. Acceptable storage media: GitHub repo, Google
+Drive, or FileZilla/FTP.
 
-This document scopes a small set of user stories to bring the FireCheck mobile
-app into compliance with that instruction by replacing the **delivery boundary**
-(currently Supabase REST + Storage) with a flat-file workflow built on
-shapefile bundles. Internal app architecture (Drift + Supabase) remains.
+This document scopes a small set of user stories that bring the FireCheck mobile
+app into compliance by replacing the **delivery boundary** (currently Supabase
+upload) with a strict shapefile in / shapefile out workflow. Internal app
+architecture (Drift + Supabase) remains for the team's own use.
 
 ---
 
@@ -27,17 +27,19 @@ shapefile bundles. Internal app architecture (Drift + Supabase) remains.
 | Topic | Choice | Rationale |
 |---|---|---|
 | Scope | Replace the delivery boundary, not the whole sync engine. | Follows the supervisor's instruction without scrapping working internal infra. |
-| Photos | Filename in .dbf column, photos in sibling `photos/` folder, zipped together. | Standard GIS convention; opens in QGIS; keeps the deliverable a real shapefile. |
-| Storage backend | **Google Drive**. | UP accounts already exist, supervisor familiarity, stable API; FileZilla needs hosted FTP we don't have, GitHub is awkward for >100 MB photo bundles. |
-| Multi-tab buildings | One row per structure with repeated geometry; `struct_idx` column distinguishes them. | Cleaner for GIS analysis than numbered columns. |
+| Deliverable contents | **Only shapefile component files** (`.shp/.dbf/.shx/.prj`). No photos, no manifest, no readme in the zip. | Strict reading of the supervisor's instruction: "download the shape files… upload the attributed shape files." |
+| Photos | Stay inside the app (Drift + Supabase Storage) for the team's own records; never part of the deliverable. | Photos can't go inside a shapefile, and the supervisor didn't ask for them. |
+| Storage backend | **Google Drive**. | UP accounts already exist, supervisor familiarity, stable API; FileZilla needs hosted FTP we don't have, GitHub is awkward for >100 MB updates. |
+| Multi-tab buildings | One row per structure with repeated geometry; `struct_idx` column distinguishes them. | Cleaner for GIS analysis than numbered columns; expected by QGIS. |
 | CRS | EPSG:4326 (WGS84) end-to-end. | Mapbox already operates here; no projection conversion needed. |
+| Zip | Used only as transport for the multi-file shapefile set. Nothing else inside. | Convenience — Drive doesn't preserve directory grouping for loose `.shp/.dbf/.shx/.prj` uploads. |
 
 ---
 
 ## Personas
 
 - **Enumerator (E)** — field worker using the FireCheck app.
-- **Course Supervisor (S)** — uploads input bundles to shared storage; downloads and reviews output.
+- **Course Supervisor (S)** — uploads input shapefiles to shared storage; downloads and reviews output shapefiles.
 
 ---
 
@@ -45,42 +47,41 @@ shapefile bundles. Internal app architecture (Drift + Supabase) remains.
 
 ### Epic 1 — Input distribution
 
-#### FF-1 — Pre-stage assignment input as a shapefile bundle
+#### FF-1 — Pre-stage assignment input shapefiles
 
-> **As a** Supervisor, **I want to** upload an input bundle (boundary + buildings + roads shapefiles) to a shared Google Drive folder, **so that** enumerators can download their assignment.
+> **As a** Supervisor, **I want to** upload input shapefiles (boundary, buildings, roads) to a shared Google Drive folder, **so that** enumerators can download their assignment.
 
 **Acceptance criteria**
 
-- Bundle is `input.zip` containing:
-  - `boundary.{shp,dbf,shx,prj}` — the assignment polygon
-  - `buildings.{shp,dbf,shx,prj}` — initial building polygons (may be empty attributes)
-  - `roads.{shp,dbf,shx,prj}` — initial road polylines
-  - `manifest.json` — `{ assignment_id, area_name, supervisor, generated_at }`
 - Drive path: `/firecheck/inbox/<assignment_id>/input.zip`.
+- Zip contains exactly:
+  - `boundary.{shp,dbf,shx,prj}` — assignment polygon.
+  - `buildings.{shp,dbf,shx,prj}` — initial building polygons (attributes may be sparse).
+  - `roads.{shp,dbf,shx,prj}` — initial road polylines.
+- Nothing else — no `manifest.json`, no `readme.txt`, no images.
 - CRS = EPSG:4326 (verified via `.prj`).
-- Bundle opens cleanly in QGIS with no warnings.
+- Opens cleanly in QGIS with no warnings.
 
 #### FF-2 — Download assignment input on "Get Maps"
 
-> **As an** Enumerator, **I want** "Get Maps" to fetch my input bundle from Drive, **so that** I can work fully offline afterward.
+> **As an** Enumerator, **I want** "Get Maps" to fetch my input shapefiles from Drive, **so that** I can work fully offline afterward.
 
 **Acceptance criteria**
 
 - Authenticates to Drive, lists assignments visible to the signed-in account.
-- Downloads `input.zip`, extracts, imports features into Drift, preserving original `feature_id` from `.dbf`.
-- Existing Mapbox tile-pack download flow continues to run alongside this step.
-- Idempotent: re-tapping "Get Maps" while online refreshes only if remote `manifest.json:generated_at` is newer than the locally stored value.
+- Downloads `input.zip`, extracts, imports features into Drift, preserving original `feature_id` from the `.dbf`.
+- Existing Mapbox tile-pack download flow continues alongside this step.
+- Idempotent: re-tapping "Get Maps" while online refreshes only if Drive's `modifiedTime` on `input.zip` is newer than the locally stored value.
 
-#### FF-3 — Reject malformed input bundles
+#### FF-3 — Reject malformed input shapefiles
 
-> **As an** Enumerator, **I want** the app to reject a broken input bundle at download time, **so that** I don't waste a day on an unusable assignment.
+> **As an** Enumerator, **I want** the app to reject a broken input shapefile at download time, **so that** I don't waste a day on an unusable assignment.
 
 **Acceptance criteria**
 
 - Pre-import validation checks:
-  - All required `.shp/.dbf/.shx/.prj` files present.
+  - All required `.shp/.dbf/.shx/.prj` files present for each layer.
   - CRS = EPSG:4326.
-  - `manifest.json` parseable and complete.
   - Required attribute columns present in `buildings.dbf` and `roads.dbf`.
 - On any failure: clear error citing what's missing; no partial import.
 
@@ -93,57 +94,52 @@ shapefile bundles. Internal app architecture (Drift + Supabase) remains.
 **Acceptance criteria**
 
 - Existing forms (Identity, Construction, Cost, Fire-fighting, Fire load, OLP) keep working unchanged.
-- Photos persist locally and are tagged with `feature_id` + `structure_idx`.
+- Photos persist locally for the team's own use; they are **not** included in the shapefile deliverable.
 - Multi-tab structures continue to work; each tab becomes a separate output row in FF-5.
 
 ### Epic 3 — Output packaging
 
-#### FF-5 — Export attributed features as a shapefile bundle
+#### FF-5 — Export attributed shapefiles
 
-> **As an** Enumerator, **I want** the app to package my completed work as a shapefile bundle, **so that** I can hand it back in the format the course expects.
+> **As an** Enumerator, **I want** the app to package my completed work as attributed shapefiles, **so that** I can hand it back in the format the course expects.
 
 **Acceptance criteria**
 
-- Output zip layout:
-  ```
-  output_<assignment_id>_<enumerator_id>_<yyyymmdd-hhmm>.zip
-    ├── buildings.{shp,dbf,shx,prj}   one row per structure (multi-tab → repeated geometry, distinct struct_idx)
-    ├── roads.{shp,dbf,shx,prj}       attributed road polylines
-    ├── photos/<feature_id>_<n>.jpg   photos referenced from .dbf
-    ├── manifest.json                  assignment_id, enumerator_id, completed_at, feature counts
-    └── readme.txt                     column dictionary mapping 10-char .dbf names → human-readable
-  ```
-- `.dbf` column names capped at 10 characters (shapefile spec).
-- `readme.txt` provides the short-name → long-name mapping.
-- Photo columns `photo_1`…`photo_n` hold filenames that resolve inside `photos/`.
-- All required survey fields present per row; null values explicitly marked, not blank.
+- Output zip name: `output_<assignment_id>_<enumerator_id>_<yyyymmdd-hhmm>.zip`.
+- Zip contains exactly:
+  - `buildings.{shp,dbf,shx,prj}` — one row per structure (multi-tab → repeated geometry, distinct `struct_idx`).
+  - `roads.{shp,dbf,shx,prj}` — attributed road polylines.
+- Nothing else — no photos, no manifest, no readme.
+- `.dbf` column names ≤ 10 characters (shapefile spec).
+- All required survey fields populated per row; null values explicitly marked, not blank.
+- CRS = EPSG:4326.
 
 #### FF-6 — Pre-upload integrity check
 
-> **As an** Enumerator, **I want** the app to verify the bundle is complete before letting me upload, **so that** I don't deliver a broken submission.
+> **As an** Enumerator, **I want** the app to verify the shapefiles are complete before letting me upload, **so that** I don't deliver a broken submission.
 
 **Acceptance criteria**
 
 - Runs automatically on the Review screen.
 - **Blockers** (must be zero before upload is enabled):
   - Any feature missing a required attribute.
-  - Any photo column referencing a file not in `photos/`.
+  - Any feature with invalid geometry (non-closed polygon, self-intersection, etc.).
 - **Warnings** (non-blocking):
   - Unusual values (e.g. `n_storeys > 50`).
 - Upload button is disabled until blockers = 0.
 
 ### Epic 4 — Upload
 
-#### FF-7 — Upload attributed bundle to shared storage
+#### FF-7 — Upload attributed shapefiles to shared storage
 
-> **As an** Enumerator, **I want to** upload my completed bundle to Drive when I have Wi-Fi, **so that** the supervisor can review it.
+> **As an** Enumerator, **I want to** upload my completed shapefiles to Drive when I have Wi-Fi, **so that** the supervisor can review them.
 
 **Acceptance criteria**
 
 - Triggered from existing Review-screen "Upload Data" button.
 - Biometric gate (existing behavior) intact.
 - Drive path: `/firecheck/outbox/<assignment_id>/<enumerator_id>/output_<…>.zip`.
-- **Idempotent:** re-uploading the same logical bundle saves a `_v2`, `_v3`, … sibling — it never overwrites the previous version.
+- **Idempotent:** re-uploading the same logical output saves a `_v2`, `_v3`, … sibling — never overwrites the previous version.
 - Resumable across Wi-Fi drops (chunked upload or full retry — implementer's choice).
 - On success: assignment locks (existing behavior).
 
@@ -181,21 +177,23 @@ shapefile bundles. Internal app architecture (Drift + Supabase) remains.
 
 #### FF-11 — Open enumerator output directly in QGIS
 
-> **As a** Supervisor, **I want to** open any uploaded bundle in QGIS without conversion, **so that** I can spot-check work using standard GIS tooling.
+> **As a** Supervisor, **I want to** open any uploaded shapefile in QGIS without conversion, **so that** I can spot-check work using standard GIS tooling.
 
 **Acceptance criteria**
 
-- Bundle loads in QGIS with no warnings.
-- A QGIS attribute-form action wired to the `photo_1` column previews the photo from `photos/`.
-- `manifest.json` counts let the supervisor sanity-check against the survey area.
+- Shapefile loads in QGIS with no warnings.
+- Attributes are inspectable via QGIS's standard Attribute Table.
+- Geometry is valid (no self-intersections, all polygons closed).
 
 ---
 
 ## Out of scope
 
+- Photos in the deliverable — they stay inside the app.
+- A manifest or readme file in the deliverable.
 - Real-time multi-enumerator collaboration on the same assignment.
 - Server-side validation or automated bounce-back of bad uploads — supervisor reviews manually.
-- Re-versioning input bundles after enumerators have started (input is frozen at download time).
+- Re-versioning input shapefiles after enumerators have started (input frozen at download time).
 - Migrating the rest of the app off Supabase — internal storage stays Drift + Supabase; only the **delivery boundary** changes.
 - Switching to GeoPackage or KMZ — supervisor explicitly mentioned shapefiles.
 
@@ -203,13 +201,11 @@ shapefile bundles. Internal app architecture (Drift + Supabase) remains.
 
 ## Open questions to confirm with supervisor
 
-These are flagged for explicit confirmation before implementation begins:
-
-1. **Photo handling convention** — confirm sibling `photos/` folder + filename in `.dbf` column is acceptable (vs. embedded GeoPackage).
-2. **Storage backend** — confirm Google Drive (vs. FileZilla / GitHub repo).
-3. **Multi-tab buildings** — confirm "one row per structure with repeated geometry" is the expected GIS shape (vs. numbered columns on a single row).
-4. **Required attribute fields** — confirm the supervisor's expected column list, not the app's internal field list. The `readme.txt` dictionary should match what the supervisor wants to see.
-5. **Re-upload semantics** — confirm `_v2/_v3` suffixed sibling files (this design's choice) vs. timestamp-only filenames vs. overwriting the previous version.
+1. **Storage backend** — confirm Google Drive (vs. FileZilla / GitHub repo).
+2. **Multi-tab buildings** — confirm "one row per structure with repeated geometry" is the expected GIS shape (vs. numbered columns on a single row).
+3. **Required attribute columns** — confirm the supervisor's expected column list. The app currently captures dozens of fields; the supervisor may only want a subset.
+4. **Re-upload semantics** — confirm `_v2/_v3` suffixed sibling files (this design's choice) vs. timestamp-only filenames vs. overwriting.
+5. **Boundary in output** — confirm whether the supervisor wants `boundary.shp` echoed back in the output zip, or only `buildings` and `roads`.
 
 ---
 
@@ -223,4 +219,4 @@ These are flagged for explicit confirmation before implementation begins:
 | FF-9 | `lib/core/auth/`, add Google OAuth alongside existing Supabase auth |
 | FF-10 | `docs/file-conventions.md` (new) |
 
-The existing **outbox / retry / WorkManager** machinery from Phase 4a should be kept — only the upload *destination* and *payload format* change.
+The existing **outbox / retry / WorkManager** machinery from Phase 4a is kept — only the upload *destination* and *payload format* change.

--- a/docs/superpowers/specs/2026-04-29-reshape-building-polygon-design.md
+++ b/docs/superpowers/specs/2026-04-29-reshape-building-polygon-design.md
@@ -1,0 +1,578 @@
+# FireCheck Mobile — Reshape Building Polygon Design Spec
+
+**Date:** 2026-04-29
+**Status:** Draft v1 (brainstorming output)
+**Story:** US-9 — As an enumerator, I want to reshape an existing building polygon by moving, adding, or removing vertices, so that I can correct footprints that are inaccurate on the ground.
+**Parent spec:** `docs/superpowers/specs/2026-04-24-firecheck-mobile-design.md`
+**Related:**
+- `docs/superpowers/specs/2026-04-24-firecheck-phase-1-design.md` (map screen architecture)
+- `docs/superpowers/specs/2026-04-28-recenter-map-design.md` (sibling story; established `CameraTarget`, `MapRenderer` interface, analytics plumbing, override-reason dialog reuse pattern)
+- `docs/superpowers/specs/2026-04-28-map-zoom-buttons-design.md` (sibling story; established `onCameraChanged` test seam, button-stack layout)
+
+This story expands map-editing scope. Master spec §15 and Phase 4a/4b explicitly defer polygon reshape to "v2+"; this spec implements that capability while preserving the documented limitation that reshape is **building polygons only** (roads/LineStrings remain out of scope).
+
+## 1. Summary
+
+Add a **reshape building polygon** flow to the FireCheck map. An enumerator long-presses an existing building polygon to open an action sheet with `Open form / Reshape / Cancel`. Tapping `Reshape` triggers the existing 50 m distance check (with the existing override-reason dialog), then enters a dedicated edit mode: a top banner replaces normal chrome, vertex handles + midpoint indicators render over the polygon, and the user can move, add, and remove vertices with live validation feedback. Save commits the new geometry locally with an audit revision row and queues a sync job; cancel discards everything in memory.
+
+After this ships:
+
+1. Long-press on any building polygon shows a `Open form / Reshape / Cancel` action sheet (when add-mode is off).
+2. `Reshape` runs the same 50 m distance gate as form-open, with override-reason support.
+3. Edit mode shows a blue top banner (`Cancel | Reshape • N edits | Save`) above the map and white circular handles on every vertex with hollow blue midpoint dots between vertices.
+4. Drag a handle to move a vertex; touch-and-drag a midpoint to pull a new vertex out of an edge; long-press a handle → confirm dialog → vertex removed.
+5. Self-intersecting edges render red live during drag.
+6. Save validates (≥3 unique vertices, non-zero area, non-self-intersecting, all vertices inside boundary, no zero-length edges); rejects with a snackbar if any rule fails; commits + queues sync if all pass.
+7. Edits cannot be made when the assignment is locked. Edits are allowed even if the building's submission has already uploaded — geometry corrections are independent of survey state.
+8. Server applies the update via a new RPC with optimistic concurrency on the previous geometry; revision row written for audit (with optional override reason).
+
+## 2. Scope
+
+### In scope
+
+- **`ReshapeModeController`** — Riverpod `Notifier` holding the in-memory working copy, undo stack, dirty flag, and live `selfIntersects` state. Lives at `lib/features/map/reshape/presentation/reshape_mode_controller.dart`.
+- **Reshape UI** — top banner, vertex handles (14×14 white circle, blue ring; 44×44 hit area), midpoint handles (10×10 hollow blue dot; 44×44 hit area), action sheet, remove-confirm dialog. All under `lib/features/map/reshape/presentation/`.
+- **Reshape overlay** — absolute-positioned `Stack` of handles, projected to screen pixels via new lat/lng ↔ screen-px helpers exposed by `MapRenderer`.
+- **`MapRenderer.build()` signature additions** — `onPolygonLongPress(Feature)` callback, `reshapeWorkingPolygonGeojson?` (overrides the persisted polygon during edit), `reshapeInvalidEdgeGeojson?` (red overlay for live self-intersection), and projection helpers exposed via callback so the overlay can position handles. `MapboxMapRenderer` implements via the native long-press hit-test + `coordinateForPixel`/`pixelForCoordinate`. `FakeMapRenderer` adds `simulatePolygonLongPress` and a fake projection (identity within bounds).
+- **`PolygonValidator`** — pure-Dart validator with five rules (`tooFewVertices`, `zeroOrNegativeArea`, `selfIntersection`, `vertexOutsideBoundary`, `zeroLengthEdge`). Lives at `lib/core/geo/polygon_validator.dart`. Returns `intersectingEdges` for live red-edge feedback.
+- **`FeatureGeometryRevisions` Drift table** — append-only audit + outbox. Same shape on the server.
+- **`update_feature_geometry` RPC** (Supabase migration `011`) — applies the geometry update with optimistic concurrency on the prior geometry (`ST_Equals`); inserts a server-side revision row in the same transaction. RLS scoped to assignment ownership.
+- **Sync** — new `entity_type='feature_geometry_update'`. New `SyncApi.uploadFeatureGeometryUpdate`. Wired into `SyncWorker` with the existing retry/backoff/dead-letter machinery.
+- **Lock interactions** — assignment locked → reshape entry blocked (action sheet item disabled). Building has uploaded submissions → reshape allowed. Locked-while-dirty → "Assignment was closed" non-dismissable banner; edits discarded.
+- **Mutual exclusion with add-mode** — entry is gated on `!_addModeActive`. The bottom add-feature pill is hidden while reshape is active.
+- **Analytics** — four events: `map.reshape.entered`, `map.reshape.cancelled`, `map.reshape.completed`, `map.reshape.validation_failed`. Routed through the existing `analyticsServiceProvider`.
+- **i18n** — ~12 new ARB keys (action sheet ×3, banner ×2, remove dialog ×3, error snackbars ×4) in `app_en.arb` and `app_tl.arb`.
+
+### Out of scope
+
+- Reshape on `is_new` point-pin features (those aren't polygons yet — separate story when they become polygons).
+- Reshape on roads (LineStrings). Same architecture would apply; separate story.
+- Splitting one polygon into multiple polygons.
+- Merging multiple polygons into one.
+- Bulk reshape across multiple buildings.
+- Snapping (to GPS, to nearby vertices, to orthogonal angles) — premature without field feedback; can be added without changing this design.
+- Real-time multi-enumerator collaboration on the same polygon (master spec §15 confirms v2+).
+- "Save draft" of an in-progress reshape across app kills — geometry edits are short atomic operations; persisting partial state would complicate the undo stack and surface stale half-edits. Explicit AC choice.
+- Showing revision history on the device — supervisor sees it server-side.
+- Pessimistic locking (server marks feature "in edit"). Only one writer (mobile) per assignment by data model.
+- Auto-merge on `geometry_conflict` — fail loud and force the user to start a new reshape session.
+
+## 3. Architecture
+
+### Files added
+
+```
+lib/features/map/reshape/
+  presentation/
+    reshape_mode_controller.dart       # in-memory working copy, undo stack, dirty flag,
+                                       # live selfIntersects flag
+    reshape_providers.dart             # Riverpod providers wiring the controller
+    reshape_banner.dart                # top banner: Cancel | "Reshape • N edits" | Save
+                                       # plus an Undo chip below
+    reshape_action_sheet.dart          # showReshapeActionSheet() — Open form / Reshape /
+                                       # Cancel; "Reshape" disabled when assignment locked
+    reshape_remove_confirm_dialog.dart # showReshapeRemoveConfirm() — native AlertDialog;
+                                       # confirm disabled when ring would drop below 3
+    vertex_handle.dart                 # 14×14 white circle, blue ring; 44×44 hit area
+    midpoint_handle.dart               # 10×10 hollow blue dot; 44×44 hit area
+    reshape_overlay.dart               # absolute-positioned Stack of handles, projected
+                                       # via the renderer's lat/lng → screen-px helper
+
+  data/
+    feature_geometry_revisions_repository.dart
+                                       # writes revision row + corresponding sync_jobs row
+                                       # in a single Drift transaction; provides the
+                                       # row-by-id lookup SyncWorker uses to fetch the
+                                       # payload for the 'feature_geometry_update' branch
+
+lib/core/geo/
+  polygon_validator.dart               # 5 rules; pure Dart; O(n²) self-intersection
+
+lib/core/db/tables/
+  feature_geometry_revisions.dart      # Drift table
+
+supabase/migrations/
+  011_feature_geometry_updates.sql     # feature_geometry_revisions table +
+                                       # update_feature_geometry RPC + RLS policies
+
+test/features/map/reshape/...          # widget tests (Section 9)
+test/core/geo/polygon_validator_test.dart
+test/core/db/feature_geometry_revisions_test.dart
+test/core/sync/feature_geometry_update_sync_test.dart
+```
+
+### Files changed
+
+```
+lib/features/map/presentation/
+  map_screen.dart                      # add long-press-on-polygon path → action sheet;
+                                       # mount ReshapeBanner + ReshapeOverlay when
+                                       # ReshapeMode is active; hide add-mode pill while
+                                       # reshape is active
+  map_renderer.dart                    # MapRenderer.build() gains:
+                                       #   - onPolygonLongPress(Feature) callback
+                                       #   - reshapeWorkingPolygonGeojson?
+                                       #   - reshapeInvalidEdgeGeojson?
+                                       #   - projectionListener? (lat/lng ↔ screen-px)
+                                       # FakeMapRenderer adds simulatePolygonLongPress
+                                       # and an identity-within-bounds projection
+
+lib/core/db/database.dart              # register FeatureGeometryRevisions; bump
+                                       # schemaVersion + onUpgrade migration
+
+lib/core/sync/data/sync_api.dart       # add uploadFeatureGeometryUpdate(revision)
+lib/core/sync/data/supabase_sync_api.dart
+                                       # implement RPC call with prev_geometry param;
+                                       # 409 + 'geometry_conflict' → permanent failure
+lib/core/sync/data/fake_sync_api.dart  # in-memory recording for tests
+lib/core/sync/worker/sync_worker.dart  # new entity_type='feature_geometry_update' branch
+
+lib/core/i18n/
+  app_en.arb, app_tl.arb               # ~12 new keys (action sheet ×3, banner ×2,
+                                       # remove dialog ×3, error snackbars ×4)
+```
+
+### State machine — `ReshapeModeController`
+
+```
+       ┌──────────┐
+       │ inactive │ ◄─── default
+       └─────┬────┘
+             │ enterReshape(feature, overrideReason?)
+             ▼
+       ┌──────────┐  edit (move/add/remove)   ┌──────────┐
+       │  clean   │ ─────────────────────────▶│  dirty   │
+       └─────┬────┘                            └────┬─────┘
+             │ cancel                               │ undo→clean OR more edits
+             ▼                                      ▼ save
+       ┌──────────┐                            ┌──────────────┐
+       │ inactive │                            │  validating  │
+       └──────────┘                            └─────┬────────┘
+                                                     │ pass→commit→inactive
+                                                     │ fail→stay dirty + snackbar
+```
+
+`LngLat` throughout this spec is the value type `({double lng, double lat})` (Dart 3 named record). No new class file is required.
+
+```dart
+class ReshapeModeState {
+  final Feature? originalFeature;        // captured at enterReshape; never mutated
+  final List<List<LngLat>> workingRings; // mutable working copy (outer + holes)
+  final List<ReshapeOp> undoStack;       // for the Undo chip in the banner
+  final bool selfIntersects;             // live validity flag for red-edge rendering
+  final bool saving;                     // disables Save button during commit
+  final String? overrideReason;          // captured at the 50m gate, written into
+                                         // feature_geometry_revisions on save
+}
+
+sealed class ReshapeOp {
+  const ReshapeOp();
+}
+class Move   extends ReshapeOp { final int ringIdx, vertexIdx; final LngLat prev, next; }
+class Add    extends ReshapeOp { final int ringIdx, vertexIdx; final LngLat lngLat; }
+class Remove extends ReshapeOp { final int ringIdx, vertexIdx; final LngLat removed; }
+```
+
+Undo replays the inverse op and pops the stack. The undo stack is unbounded in memory (≤100 vertices × a single session ≈ a few hundred bytes per op).
+
+### Mutual exclusion
+
+While reshape is active:
+- The bottom add-feature pill is **hidden** (banner takes the spotlight). Reshape and add-mode are mutually exclusive.
+- Recenter / zoom buttons stay visible — reshape needs them; pinch + button zoom both still work.
+- Polygon tap handlers are **disabled** for all polygons; the polygon being reshaped is non-tappable (handles take all gestures).
+
+## 4. Data model
+
+### Local Drift table — `feature_geometry_revisions`
+
+```dart
+@TableIndex(name: 'fgr_feature_id_idx',  columns: {#featureId})
+@TableIndex(name: 'fgr_sync_status_idx', columns: {#syncStatus})
+class FeatureGeometryRevisions extends Table {
+  TextColumn     get id              => text()();           // uuid v4 (client-side)
+  TextColumn     get featureId       => text()();           // FK → features.id
+  TextColumn     get prevGeojson     => text()();           // captured at enterReshape
+  TextColumn     get newGeojson      => text()();           // committed working copy
+  TextColumn     get editedBy        => text()();           // enumerator id
+  DateTimeColumn get editedAt        => dateTime()();       // client wall clock
+  TextColumn     get overrideReason  => text().nullable()();// non-null iff 50m gate overridden
+  TextColumn     get syncStatus      => text().withDefault(const Constant('pending'))();
+                                                            // pending|ready_to_upload|uploaded|failed
+  DateTimeColumn get createdAt       => dateTime()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+```
+
+`syncStatus` mirrors `submissions.sync_status` semantics. The `sync_jobs` row created in the same transaction carries `entity_type='feature_geometry_update'`, `entity_id=revision.id`. `features.geometry_geojson` is updated to `newGeojson` in the same transaction so the map reflects the change immediately.
+
+### Server-side schema — `011_feature_geometry_updates.sql`
+
+```sql
+create table public.feature_geometry_revisions (
+  id              uuid primary key,
+  feature_id      uuid not null references public.features(id) on delete cascade,
+  edited_by       uuid references public.enumerators(id) on delete set null,
+  prev_geometry   geography(Geometry, 4326) not null,
+  new_geometry    geography(Geometry, 4326) not null,
+  edited_at       timestamptz not null,
+  override_reason text,
+  created_at      timestamptz not null default now()
+);
+
+create index on public.feature_geometry_revisions (feature_id);
+create index on public.feature_geometry_revisions (edited_by);
+
+alter table public.feature_geometry_revisions enable row level security;
+
+create policy fgr_enum_insert on public.feature_geometry_revisions
+  for insert with check (
+    exists (
+      select 1 from public.features f
+      join public.assignments a on a.id = f.assignment_id
+      where f.id = feature_id and a.enumerator_id = auth.uid()
+    )
+  );
+create policy fgr_enum_select on public.feature_geometry_revisions
+  for select using (
+    exists (
+      select 1 from public.features f
+      join public.assignments a on a.id = f.assignment_id
+      where f.id = feature_id and a.enumerator_id = auth.uid()
+    )
+  );
+
+create or replace function public.update_feature_geometry(
+  p_revision_id    uuid,
+  p_feature_id     uuid,
+  p_prev_geojson   text,
+  p_new_geojson    text,
+  p_edited_at      timestamptz,
+  p_override_reason text
+) returns void
+language plpgsql
+security definer
+as $$
+declare
+  v_current geography;
+  v_prev    geography;
+  v_new     geography;
+begin
+  if not exists (
+    select 1 from public.features f
+    join public.assignments a on a.id = f.assignment_id
+    where f.id = p_feature_id and a.enumerator_id = auth.uid()
+  ) then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  v_prev := st_geogfromgeojson(p_prev_geojson);
+  v_new  := st_geogfromgeojson(p_new_geojson);
+
+  select geometry into v_current from public.features
+    where id = p_feature_id for update;
+
+  -- Optimistic concurrency: server's current geometry must match the prev_geometry
+  -- the client based its edit on. ST_Equals is exact equality; a future story can
+  -- relax to ST_Within with epsilon if false-conflicts surface.
+  if not st_equals(v_current::geometry, v_prev::geometry) then
+    raise exception 'geometry_conflict' using errcode = 'P0001';
+  end if;
+
+  insert into public.feature_geometry_revisions
+    (id, feature_id, edited_by, prev_geometry, new_geometry, edited_at, override_reason)
+  values
+    (p_revision_id, p_feature_id, auth.uid(), v_prev, v_new, p_edited_at, p_override_reason);
+
+  update public.features set geometry = v_new where id = p_feature_id;
+end;
+$$;
+```
+
+Client mapping for the RPC's PostgreSQL error codes:
+- `geometry_conflict` (`P0001`) → permanent sync failure (`syncStatus='failed'`, `sync_job.status='dead'`); UI surfaces "Reshape was rejected — geometry was changed by supervisor. Re-open and reshape again to retry."
+- `forbidden` (`42501`) → permanent failure (auth went stale or RLS denied); same dead-letter path with a different message.
+- `22023` / `XX000` (malformed geometry from `ST_GeogFromGeoJSON`) → permanent failure. Should not happen — Drift transaction validates serializability — but if it does, fail loud, not silent.
+
+### Working-copy GeoJSON conventions
+
+- Outer ring stored CCW; holes CW. We don't enforce on input (the existing seed and Mapbox both produce both orderings); we **do** normalize on commit so `prev_geometry` and `new_geometry` are comparable for `ST_Equals`.
+- First and last vertex always coincident (closed ring). Working copy stores the open form (no duplicate end vertex) and serializes the close on commit.
+- Coordinates: `[lng, lat]` order (GeoJSON standard, matches existing `geometryGeojson` storage).
+
+## 5. Validation
+
+`lib/core/geo/polygon_validator.dart`. Pure Dart, no dependencies. One public function:
+
+```dart
+PolygonValidationResult validateBuildingPolygon(
+  List<List<LngLat>> rings, {
+  required String boundaryGeojson,
+});
+
+class PolygonValidationResult {
+  final bool valid;
+  final PolygonValidationError? error;        // null when valid
+  final List<EdgeIndex>? intersectingEdges;   // populated when error == selfIntersection
+}
+
+// Identifies a pair of edges in the working outer ring that mutually intersect.
+// `aStart` and `bStart` index into workingRings[0]; the edge runs from index N
+// to (N+1) % ringLength.
+typedef EdgeIndex = ({int aStart, int bStart});
+
+enum PolygonValidationError {
+  tooFewVertices,        // <3 unique vertices on outer ring
+  zeroOrNegativeArea,    // shoelace area ≈ 0 (1e-12 sq-degrees)
+  selfIntersection,      // any non-adjacent edges intersect (open segments only)
+  vertexOutsideBoundary, // any vertex fails pointInPolygonGeojson(boundary)
+  zeroLengthEdge,        // adjacent vertices coincident (epsilon ≈ 1e-9 degrees)
+}
+```
+
+Rules run in declared order; first failure short-circuits.
+
+**Self-intersection algorithm:** O(n²) pairwise non-adjacent segment intersection using the standard CCW orientation test. At ≤100 vertices, ≤4,950 pair tests per validation tick. Easily runs at 60 fps on a mid-tier Android device. The validator returns the indices of all intersecting edge pairs so the renderer can paint them red.
+
+**Live vs save-time:**
+- During drag (every frame the dragged vertex moves): only run rule 3 (`selfIntersection`). Cheap; gives instant red-edge feedback.
+- On Save: run all five rules in order. Failure → snackbar with rule-specific i18n message; mode stays open.
+
+**Boundary failure is a hard block.** No override path for `vertexOutsideBoundary` — the boundary defines what data the enumerator is authorized to capture. The 50 m distance gate (an authorization-adjacent UX rule) has an override; the boundary check (a data-integrity rule) does not.
+
+## 6. Orchestration & gestures
+
+### Long-press hit-test entry
+
+`MapRenderer.build()` gains an `onPolygonLongPress(Feature)` callback. `MapboxMapRenderer` wires this through:
+- `onLongTapListener` checks `addModeActive` first (existing path); if true, the long-press is consumed by add-mode placement.
+- If `addModeActive` is false, the renderer queries the feature manager for any polygon under the tap point. If a hit, `onPolygonLongPress(feature)` fires. If a miss, no-op.
+
+`_MapScreenState._handlePolygonLongPress` then:
+1. If assignment locked → show snackbar "Assignment is closed; reshape unavailable." and exit.
+2. Show action sheet via `showReshapeActionSheet(feature)`. Three items: `Open form`, `Reshape`, `Cancel`.
+3. On `Open form` → existing `_handleFeatureTap` path.
+4. On `Reshape` → enter reshape flow (next).
+
+### Distance gate on `Reshape`
+
+Mirrors the existing `_handleFeatureTap` path:
+1. Compute haversine distance from current GPS to feature centroid.
+2. If <30 m accuracy → show weak-GPS banner (existing `override_reason_dialog.dart` pattern).
+3. If >50 m → open override-reason dialog. Cancel exits flow; confirm captures the reason string.
+4. On pass (or override), call `ReshapeModeController.enterReshape(feature, overrideReason)`.
+
+### Edit-mode gestures
+
+| Gesture | Outcome |
+|---|---|
+| Tap-and-drag a vertex handle | `Move` op; live `selfIntersects` recheck per drag tick; release commits the op to the working ring + undo stack. |
+| Touch-and-drag a midpoint handle | `Add` op fires immediately at touch-down, inserting a new vertex at the midpoint position; vertex enters drag mode in the same gesture (one continuous touch). Release commits. |
+| Long-press a vertex handle | `showReshapeRemoveConfirm` (native AlertDialog). Confirm button **disabled** when working ring has 3 vertices. Confirm → `Remove` op. Cancel → no-op. |
+| Tap Undo chip in banner | Pop one op from undo stack; replay inverse. |
+| Tap Cancel in banner | Discard `ReshapeModeController` state; return to inactive. No DB write. |
+| Tap Save in banner | Run all five rules. Pass → commit transaction + sync job + analytics + exit. Fail → snackbar; stay in mode. |
+
+### Save commit — Drift transaction
+
+```dart
+Future<void> saveReshape(ReshapeModeState state) async {
+  await _db.transaction(() async {
+    final revisionId = const Uuid().v4();
+    final newGeojson = serializeRings(state.workingRings);
+    final prevGeojson = state.originalFeature!.geometryGeojson;
+
+    await _db.update(_db.features)
+      ..where((t) => t.id.equals(state.originalFeature!.id))
+      ..write(FeaturesCompanion(geometryGeojson: Value(newGeojson)));
+
+    await _db.into(_db.featureGeometryRevisions).insert(
+      FeatureGeometryRevisionsCompanion.insert(
+        id: revisionId,
+        featureId: state.originalFeature!.id,
+        prevGeojson: prevGeojson,
+        newGeojson: newGeojson,
+        editedBy: editedBy,
+        editedAt: DateTime.now(),
+        overrideReason: Value(state.overrideReason),
+        syncStatus: const Value('ready_to_upload'),
+        createdAt: DateTime.now(),
+      ),
+    );
+
+    await _db.into(_db.syncJobs).insert(
+      SyncJobsCompanion.insert(
+        id: const Uuid().v4(),
+        entityType: 'feature_geometry_update',
+        entityId: revisionId,
+        createdAt: DateTime.now(),
+      ),
+    );
+  });
+}
+```
+
+## 7. Sync mechanics
+
+```
+[Save tap]
+   │
+   ▼
+[Drift transaction, atomic]
+   │   - update features.geometry_geojson = newGeojson
+   │   - insert feature_geometry_revisions row (syncStatus='ready_to_upload')
+   │   - insert sync_jobs row (entity_type='feature_geometry_update',
+   │                           entity_id=revision.id, status='pending')
+   ▼
+[SyncWorker picks up job]
+   │
+   ▼
+[SyncApi.uploadFeatureGeometryUpdate(revision)]
+   │   POST /rpc/update_feature_geometry
+   │   body: { p_revision_id, p_feature_id, p_prev_geojson, p_new_geojson,
+   │           p_edited_at, p_override_reason }
+   │
+   ├─ 2xx          → revision.syncStatus='uploaded'; sync_jobs.status='success'
+   ├─ 401          → reauth path (existing) → retry
+   ├─ 409 + 'geometry_conflict'
+   │                → sync_jobs.status='dead'; revision.syncStatus='failed';
+   │                  surfaces via existing sync-error surfacer
+   ├─ 4xx (other)  → permanent failure (dead-letter)
+   └─ 5xx / network → transient; existing exponential backoff
+```
+
+## 8. Edge cases
+
+- **App killed mid-edit (no Save).** Working copy lives only in `ReshapeModeController` memory. Drift untouched. Restart → polygon unchanged. **No "draft" preservation by design** — explicit AC choice.
+- **App killed after Save, before sync.** Local DB has new geometry + revision row + pending `sync_job`. Map renders the new geometry. `SyncWorker` picks up the job on next launch / next connectivity window.
+- **Connectivity drops mid-upload.** Standard `SyncWorker` retry path; revision row stays at `syncStatus='ready_to_upload'`.
+- **User long-presses a polygon while in add-mode.** Action sheet does *not* open; long-press is consumed by add-mode placement (existing path at `map_screen.dart:193-207`). Reshape entry is gated on `!_addModeActive`.
+- **User long-presses an `is_new` point pin (blue).** Action sheet does not open — no polygon under the press. No-op.
+- **User long-presses outside any polygon.** No-op.
+- **Assignment becomes locked while in edit mode.** `ReshapeModeController` watches `isAssignmentLockedProvider`. On lock event: if `clean`, exit silently to inactive. If `dirty`, show a non-dismissable banner ("Assignment was closed by supervisor — your edits cannot be saved") with an `Exit` button. Edits are discarded.
+- **GPS deteriorates between `Reshape` tap and Save.** No re-check; the 50 m gate is one-shot at entry. Aligns with the form flow.
+- **User reshapes, saves, then reshapes again before sync.** Two revision rows + two sync jobs, both pending. Server applies them in order; the second's `prev_geometry` matches the first's `new_geometry`, so optimistic concurrency holds.
+- **Underlying Drift row stream emit during edit (e.g., status flips `in_progress → complete`).** `originalFeature` reference is captured at `enterReshape` time. Working copy is unaffected. Save still uses the *captured* `prevGeojson`. Status updates flow through normally because the controller tracks geometry only.
+- **User pinches/zooms while a vertex is mid-drag.** Renderer reprojects all handles every camera change. Drag continues — the in-flight handle's underlying lat/lng is preserved; only its screen position is recomputed.
+- **Save with vertices outside the assignment boundary.** `vertexOutsideBoundary` returned. Snackbar: "Some vertices are outside the assignment area." Edit mode stays open. No override path.
+- **Many edits in one session.** Undo stack is unbounded in memory. ≤100 vertices in a single session ≈ a few hundred bytes per op. No persistence.
+- **Server returns `geometry_conflict`.** Sync job dies; revision row marked `failed`. UI surfacer shows "Reshape was rejected — geometry was changed by supervisor. Re-open and reshape again to retry." User starts a fresh reshape session; the failed revision row is dropped from the active set (its `prev_geojson` is no longer accurate). No auto-merge.
+- **Malformed GeoJSON at the server.** Permanent failure, dead-letter. Should not happen — Drift transaction validates serializability — but if it does, fail loud, not silent.
+
+## 9. Testing strategy
+
+Tests follow the existing FireCheck pattern: pure-Dart unit tests for logic, widget tests for UI with `FakeMapRenderer`, no integration tests against a real GL context. The Mapbox plugin does not render in `flutter_tester`.
+
+### Unit tests (pure Dart, no Flutter)
+
+- **`polygon_validator_test.dart`**
+  - Each rule: minimal failing case + minimal passing case.
+  - Self-intersection: bowtie (4 vertices), figure-eight (8 vertices), almost-touching (no intersection at epsilon).
+  - Inside-boundary: vertex on boundary edge (passes), vertex outside hole (passes — only outer ring vs assignment boundary), vertex outside assignment (fails).
+  - Zero-length edge: two coincident vertices (fails); two vertices 1 cm apart (passes).
+  - Order-of-failure: a polygon failing rules 1 and 3 → returns rule 1 only (short-circuit).
+  - Self-intersection edge index reporting: reports exactly the offending edge pairs, not adjacent neighbors.
+
+- **`feature_geometry_revisions_repository_test.dart`** — Drift in-memory: insert revision + sync_job in one transaction; rollback on simulated failure leaves both untouched.
+
+- **`reshape_mode_controller_test.dart`** — state transitions, undo stack correctness, `selfIntersects` flag updates per drag tick, lock-while-dirty discards.
+
+### Widget tests (`FakeMapRenderer`, `FakeLocationService`, `FakeSyncApi`, `RecordingAnalyticsService`)
+
+- **`map_screen_reshape_test.dart`**
+  - Long-press polygon (add-mode off) → action sheet shows three items.
+  - Long-press polygon (add-mode on) → no action sheet; long-press consumed by add-mode.
+  - Action-sheet `Reshape` → distance-OK path → enters edit mode (banner appears, handles render).
+  - Action-sheet `Reshape` → distance-too-far path → override-reason dialog → entered-with-reason; reason persisted into revision row on save.
+  - Cancel discards edits; map polygon unchanged.
+  - Save with valid edits commits one revision row + one sync_job.
+  - Save with invalid edits (each rule) shows rule-specific snackbar; stays in edit mode.
+  - Assignment-locked-while-dirty → "Assignment was closed" banner; Exit discards.
+  - `Reshape` action item disabled when assignment is locked at long-press time.
+  - Reshape on a polygon while a different polygon's `is_new=true` point pin is also on screen → point pin still renders normally; reshape limited to the long-pressed polygon.
+
+- **`reshape_overlay_test.dart`**
+  - 4-vertex polygon → 4 vertex handles + 4 midpoint handles render at projected positions.
+  - Drag a vertex handle → working ring updates; renderer receives new working geojson.
+  - Drag from a midpoint → vertex inserted; second drag-tick moves the inserted vertex.
+  - Long-press a vertex → confirm dialog; confirm removes; cancel preserves.
+  - Long-press blocked at 3-vertex minimum: dialog opens with confirm **disabled**.
+  - Camera change reprojects handle positions; drag continues without flicker.
+
+- **`reshape_banner_test.dart`**
+  - "Reshape • 0 edits" → "Reshape • 3 edits" after three ops; Save enabled when dirty.
+  - Undo decrements counter and inverts the last op.
+
+### Sync tests
+
+- **`feature_geometry_update_sync_test.dart`** — `FakeSyncApi` records call shape; success → revision marked uploaded + sync_job success; 409 + `geometry_conflict` → revision failed + sync_job dead.
+
+### Analytics tests
+
+- `RecordingAnalyticsService` captures all four events; assert payload shape per scenario (entered, cancelled with ops_made, completed with full op breakdown, validation_failed per rule).
+
+### Manual happy path (final task in plan)
+
+1. Open app, open assignment, open map.
+2. Long-press a red polygon → action sheet shows three items.
+3. `Reshape` → banner appears; handles render at all corners.
+4. Drag a corner; release; banner shows "Reshape • 1 edit"; Save active.
+5. Drag a midpoint outward; verify the new vertex stays under the finger; release.
+6. Long-press a corner; confirm; vertex disappears.
+7. Tap Undo three times; banner returns to "0 edits".
+8. Reshape into a bowtie; verify red live edges.
+9. Save → snackbar self-intersection error; stay in mode.
+10. Fix the polygon; Save → exits to map; polygon shows new shape.
+11. Force-quit and relaunch → polygon still has new shape.
+12. Go offline; reshape and Save → sync indicator shows pending; back online → uploads cleanly.
+13. Repeat the happy path on three real-world test buildings (DoD requirement).
+
+## 10. Analytics
+
+```
+map.reshape.entered            { feature_id, vertex_count, override_used: bool }
+map.reshape.cancelled          { feature_id, ops_made: int, duration_ms }
+map.reshape.completed          { feature_id, vertex_count_before, vertex_count_after,
+                                 vertex_moves: int, vertex_adds: int, vertex_removes: int,
+                                 override_used: bool, duration_ms }
+map.reshape.validation_failed  { feature_id, rule: string, attempt_index: int }
+```
+
+All four go through the existing `analyticsServiceProvider`. `NoopAnalyticsService` in production; `ConsoleAnalyticsService` in `kDebugMode`; `RecordingAnalyticsService` in tests.
+
+## 11. AC mapping
+
+| AC story scenario | How it's met |
+|---|---|
+| **Scenario 1** — move vertex by drag | `ReshapeOverlay` vertex handles are draggable; `ReshapeModeController.moveVertex(ringIdx, vertexIdx, lngLat)` updates the working ring; renderer receives `reshapeWorkingPolygonGeojson` and re-renders the polygon every frame; Save commits. |
+| **Scenario 2** — add new vertex via midpoint indicator | Midpoint handles render between every vertex pair; touch-and-drag inserts a new vertex (A2 gesture pattern), entering drag immediately. |
+| **Scenario 3** — remove vertex (long-press + confirm; ≥3 enforced) | Long-press handle → `showReshapeRemoveConfirm`. Confirm button is **disabled** when the working ring has 3 vertices. Confirm → `Remove` op pushed to undo stack. |
+| **Scenario 4** — validate at save; show error; allow continue | `validateBuildingPolygon` runs all 5 rules at Save; failure → snackbar with rule-specific message; mode stays open. Live red-edge feedback for self-intersection during drag. |
+| **Scenario 5** — Cancel reverts | Cancel discards `ReshapeModeController` state; original Drift row never touched; map re-renders from persisted geometry. |
+| **Scenario 6** — preserve building metadata | Drift transaction touches only `features.geometry_geojson` and `feature_geometry_revisions`. `submissions`, `building_attributes`, `photos` untouched. |
+
+## 12. Definition-of-done coverage
+
+- **Automated tests:** unit + widget + sync + analytics, covered above.
+- **Android:** target platform; iOS not supported by this codebase yet.
+- **Sync correctness:** sync tests + manual happy-path step 12.
+- **Audit trail:** `feature_geometry_revisions` rows on both client and server, with `edited_by`, `edited_at`, optional `override_reason`.
+- **Documentation:** enumerator field guide updated post-merge (separate doc PR; not gated by this story but called out in PR description).
+- **QA sign-off on 3 real-world test buildings:** manual happy-path step 13 makes this explicit; PR description carries the checklist.
+
+## 13. Dependencies and migration order
+
+1. Database migration (`011_feature_geometry_updates.sql`) **must ship before** the mobile build that contains this code can be released. No backfill needed (revisions are append-only).
+2. Drift schema bump (local DB) ships with the app; `onUpgrade` adds the `FeatureGeometryRevisions` table.
+3. No new pub dependencies. All work is pure Dart + existing Mapbox + existing Supabase + existing Drift.
+
+## 14. Open questions deferred to implementation
+
+These are intentionally not specified here — they're judgment calls best made with code in hand:
+
+- Exact handle stroke width / color tokens (matches `RecenterButton` / `ZoomButton` design language).
+- Banner exact pixel padding and icon set (uses existing app theme tokens).
+- Live red-edge rendering implementation: PolygonAnnotation overlay vs. dedicated `LineLayer`. The first is simpler; the second is more flexible. Implementer's call based on what works cleanly with mapbox_maps_flutter 2.22.
+- Whether the live `selfIntersects` recheck runs on every pointer-move event or is throttled to ~30 fps. Validator is fast enough that throttling may be unnecessary; profile during implementation.

--- a/lib/core/db/database.dart
+++ b/lib/core/db/database.dart
@@ -5,6 +5,7 @@ import 'package:drift/native.dart';
 import 'package:firecheck/core/db/tables/assignments.dart';
 import 'package:firecheck/core/db/tables/building_attributes.dart';
 import 'package:firecheck/core/db/tables/enumerators.dart';
+import 'package:firecheck/core/db/tables/feature_geometry_revisions.dart';
 import 'package:firecheck/core/db/tables/features.dart';
 import 'package:firecheck/core/db/tables/household_surveys.dart';
 import 'package:firecheck/core/db/tables/offline_tile_packs.dart';
@@ -23,6 +24,7 @@ part 'database.g.dart';
     Enumerators,
     Assignments,
     Features,
+    FeatureGeometryRevisions,
     Submissions,
     BuildingAttributes,
     RoadAttributes,
@@ -40,7 +42,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 5;
+  int get schemaVersion => 6;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -72,6 +74,12 @@ class AppDatabase extends _$AppDatabase {
           }
           if (from < 5) {
             await m.addColumn(assignments, assignments.closedRemotely);
+          }
+          if (from < 6) {
+            // v5 → v6: feature_geometry_revisions table for US-9 reshape.
+            await m.createTable(featureGeometryRevisions);
+            await m.createIndex(fgrFeatureIdIdx);
+            await m.createIndex(fgrSyncStatusIdx);
           }
         },
         beforeOpen: (details) async {

--- a/lib/core/db/database.g.dart
+++ b/lib/core/db/database.g.dart
@@ -1182,6 +1182,492 @@ class FeaturesCompanion extends UpdateCompanion<Feature> {
   }
 }
 
+class $FeatureGeometryRevisionsTable extends FeatureGeometryRevisions
+    with TableInfo<$FeatureGeometryRevisionsTable, FeatureGeometryRevision> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $FeatureGeometryRevisionsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+      'id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _featureIdMeta =
+      const VerificationMeta('featureId');
+  @override
+  late final GeneratedColumn<String> featureId = GeneratedColumn<String>(
+      'feature_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _prevGeojsonMeta =
+      const VerificationMeta('prevGeojson');
+  @override
+  late final GeneratedColumn<String> prevGeojson = GeneratedColumn<String>(
+      'prev_geojson', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _newGeojsonMeta =
+      const VerificationMeta('newGeojson');
+  @override
+  late final GeneratedColumn<String> newGeojson = GeneratedColumn<String>(
+      'new_geojson', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _editedByMeta =
+      const VerificationMeta('editedBy');
+  @override
+  late final GeneratedColumn<String> editedBy = GeneratedColumn<String>(
+      'edited_by', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _editedAtMeta =
+      const VerificationMeta('editedAt');
+  @override
+  late final GeneratedColumn<DateTime> editedAt = GeneratedColumn<DateTime>(
+      'edited_at', aliasedName, false,
+      type: DriftSqlType.dateTime, requiredDuringInsert: true);
+  static const VerificationMeta _overrideReasonMeta =
+      const VerificationMeta('overrideReason');
+  @override
+  late final GeneratedColumn<String> overrideReason = GeneratedColumn<String>(
+      'override_reason', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _syncStatusMeta =
+      const VerificationMeta('syncStatus');
+  @override
+  late final GeneratedColumn<String> syncStatus = GeneratedColumn<String>(
+      'sync_status', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('pending'));
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+      'created_at', aliasedName, false,
+      type: DriftSqlType.dateTime, requiredDuringInsert: true);
+  @override
+  List<GeneratedColumn> get $columns => [
+        id,
+        featureId,
+        prevGeojson,
+        newGeojson,
+        editedBy,
+        editedAt,
+        overrideReason,
+        syncStatus,
+        createdAt
+      ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'feature_geometry_revisions';
+  @override
+  VerificationContext validateIntegrity(
+      Insertable<FeatureGeometryRevision> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('feature_id')) {
+      context.handle(_featureIdMeta,
+          featureId.isAcceptableOrUnknown(data['feature_id']!, _featureIdMeta));
+    } else if (isInserting) {
+      context.missing(_featureIdMeta);
+    }
+    if (data.containsKey('prev_geojson')) {
+      context.handle(
+          _prevGeojsonMeta,
+          prevGeojson.isAcceptableOrUnknown(
+              data['prev_geojson']!, _prevGeojsonMeta));
+    } else if (isInserting) {
+      context.missing(_prevGeojsonMeta);
+    }
+    if (data.containsKey('new_geojson')) {
+      context.handle(
+          _newGeojsonMeta,
+          newGeojson.isAcceptableOrUnknown(
+              data['new_geojson']!, _newGeojsonMeta));
+    } else if (isInserting) {
+      context.missing(_newGeojsonMeta);
+    }
+    if (data.containsKey('edited_by')) {
+      context.handle(_editedByMeta,
+          editedBy.isAcceptableOrUnknown(data['edited_by']!, _editedByMeta));
+    } else if (isInserting) {
+      context.missing(_editedByMeta);
+    }
+    if (data.containsKey('edited_at')) {
+      context.handle(_editedAtMeta,
+          editedAt.isAcceptableOrUnknown(data['edited_at']!, _editedAtMeta));
+    } else if (isInserting) {
+      context.missing(_editedAtMeta);
+    }
+    if (data.containsKey('override_reason')) {
+      context.handle(
+          _overrideReasonMeta,
+          overrideReason.isAcceptableOrUnknown(
+              data['override_reason']!, _overrideReasonMeta));
+    }
+    if (data.containsKey('sync_status')) {
+      context.handle(
+          _syncStatusMeta,
+          syncStatus.isAcceptableOrUnknown(
+              data['sync_status']!, _syncStatusMeta));
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  FeatureGeometryRevision map(Map<String, dynamic> data,
+      {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return FeatureGeometryRevision(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}id'])!,
+      featureId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}feature_id'])!,
+      prevGeojson: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}prev_geojson'])!,
+      newGeojson: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}new_geojson'])!,
+      editedBy: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}edited_by'])!,
+      editedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}edited_at'])!,
+      overrideReason: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}override_reason']),
+      syncStatus: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}sync_status'])!,
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+    );
+  }
+
+  @override
+  $FeatureGeometryRevisionsTable createAlias(String alias) {
+    return $FeatureGeometryRevisionsTable(attachedDatabase, alias);
+  }
+}
+
+class FeatureGeometryRevision extends DataClass
+    implements Insertable<FeatureGeometryRevision> {
+  final String id;
+  final String featureId;
+  final String prevGeojson;
+  final String newGeojson;
+  final String editedBy;
+  final DateTime editedAt;
+  final String? overrideReason;
+  final String syncStatus;
+  final DateTime createdAt;
+  const FeatureGeometryRevision(
+      {required this.id,
+      required this.featureId,
+      required this.prevGeojson,
+      required this.newGeojson,
+      required this.editedBy,
+      required this.editedAt,
+      this.overrideReason,
+      required this.syncStatus,
+      required this.createdAt});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['feature_id'] = Variable<String>(featureId);
+    map['prev_geojson'] = Variable<String>(prevGeojson);
+    map['new_geojson'] = Variable<String>(newGeojson);
+    map['edited_by'] = Variable<String>(editedBy);
+    map['edited_at'] = Variable<DateTime>(editedAt);
+    if (!nullToAbsent || overrideReason != null) {
+      map['override_reason'] = Variable<String>(overrideReason);
+    }
+    map['sync_status'] = Variable<String>(syncStatus);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    return map;
+  }
+
+  FeatureGeometryRevisionsCompanion toCompanion(bool nullToAbsent) {
+    return FeatureGeometryRevisionsCompanion(
+      id: Value(id),
+      featureId: Value(featureId),
+      prevGeojson: Value(prevGeojson),
+      newGeojson: Value(newGeojson),
+      editedBy: Value(editedBy),
+      editedAt: Value(editedAt),
+      overrideReason: overrideReason == null && nullToAbsent
+          ? const Value.absent()
+          : Value(overrideReason),
+      syncStatus: Value(syncStatus),
+      createdAt: Value(createdAt),
+    );
+  }
+
+  factory FeatureGeometryRevision.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return FeatureGeometryRevision(
+      id: serializer.fromJson<String>(json['id']),
+      featureId: serializer.fromJson<String>(json['featureId']),
+      prevGeojson: serializer.fromJson<String>(json['prevGeojson']),
+      newGeojson: serializer.fromJson<String>(json['newGeojson']),
+      editedBy: serializer.fromJson<String>(json['editedBy']),
+      editedAt: serializer.fromJson<DateTime>(json['editedAt']),
+      overrideReason: serializer.fromJson<String?>(json['overrideReason']),
+      syncStatus: serializer.fromJson<String>(json['syncStatus']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'featureId': serializer.toJson<String>(featureId),
+      'prevGeojson': serializer.toJson<String>(prevGeojson),
+      'newGeojson': serializer.toJson<String>(newGeojson),
+      'editedBy': serializer.toJson<String>(editedBy),
+      'editedAt': serializer.toJson<DateTime>(editedAt),
+      'overrideReason': serializer.toJson<String?>(overrideReason),
+      'syncStatus': serializer.toJson<String>(syncStatus),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+    };
+  }
+
+  FeatureGeometryRevision copyWith(
+          {String? id,
+          String? featureId,
+          String? prevGeojson,
+          String? newGeojson,
+          String? editedBy,
+          DateTime? editedAt,
+          Value<String?> overrideReason = const Value.absent(),
+          String? syncStatus,
+          DateTime? createdAt}) =>
+      FeatureGeometryRevision(
+        id: id ?? this.id,
+        featureId: featureId ?? this.featureId,
+        prevGeojson: prevGeojson ?? this.prevGeojson,
+        newGeojson: newGeojson ?? this.newGeojson,
+        editedBy: editedBy ?? this.editedBy,
+        editedAt: editedAt ?? this.editedAt,
+        overrideReason:
+            overrideReason.present ? overrideReason.value : this.overrideReason,
+        syncStatus: syncStatus ?? this.syncStatus,
+        createdAt: createdAt ?? this.createdAt,
+      );
+  FeatureGeometryRevision copyWithCompanion(
+      FeatureGeometryRevisionsCompanion data) {
+    return FeatureGeometryRevision(
+      id: data.id.present ? data.id.value : this.id,
+      featureId: data.featureId.present ? data.featureId.value : this.featureId,
+      prevGeojson:
+          data.prevGeojson.present ? data.prevGeojson.value : this.prevGeojson,
+      newGeojson:
+          data.newGeojson.present ? data.newGeojson.value : this.newGeojson,
+      editedBy: data.editedBy.present ? data.editedBy.value : this.editedBy,
+      editedAt: data.editedAt.present ? data.editedAt.value : this.editedAt,
+      overrideReason: data.overrideReason.present
+          ? data.overrideReason.value
+          : this.overrideReason,
+      syncStatus:
+          data.syncStatus.present ? data.syncStatus.value : this.syncStatus,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('FeatureGeometryRevision(')
+          ..write('id: $id, ')
+          ..write('featureId: $featureId, ')
+          ..write('prevGeojson: $prevGeojson, ')
+          ..write('newGeojson: $newGeojson, ')
+          ..write('editedBy: $editedBy, ')
+          ..write('editedAt: $editedAt, ')
+          ..write('overrideReason: $overrideReason, ')
+          ..write('syncStatus: $syncStatus, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, featureId, prevGeojson, newGeojson,
+      editedBy, editedAt, overrideReason, syncStatus, createdAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is FeatureGeometryRevision &&
+          other.id == this.id &&
+          other.featureId == this.featureId &&
+          other.prevGeojson == this.prevGeojson &&
+          other.newGeojson == this.newGeojson &&
+          other.editedBy == this.editedBy &&
+          other.editedAt == this.editedAt &&
+          other.overrideReason == this.overrideReason &&
+          other.syncStatus == this.syncStatus &&
+          other.createdAt == this.createdAt);
+}
+
+class FeatureGeometryRevisionsCompanion
+    extends UpdateCompanion<FeatureGeometryRevision> {
+  final Value<String> id;
+  final Value<String> featureId;
+  final Value<String> prevGeojson;
+  final Value<String> newGeojson;
+  final Value<String> editedBy;
+  final Value<DateTime> editedAt;
+  final Value<String?> overrideReason;
+  final Value<String> syncStatus;
+  final Value<DateTime> createdAt;
+  final Value<int> rowid;
+  const FeatureGeometryRevisionsCompanion({
+    this.id = const Value.absent(),
+    this.featureId = const Value.absent(),
+    this.prevGeojson = const Value.absent(),
+    this.newGeojson = const Value.absent(),
+    this.editedBy = const Value.absent(),
+    this.editedAt = const Value.absent(),
+    this.overrideReason = const Value.absent(),
+    this.syncStatus = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  FeatureGeometryRevisionsCompanion.insert({
+    required String id,
+    required String featureId,
+    required String prevGeojson,
+    required String newGeojson,
+    required String editedBy,
+    required DateTime editedAt,
+    this.overrideReason = const Value.absent(),
+    this.syncStatus = const Value.absent(),
+    required DateTime createdAt,
+    this.rowid = const Value.absent(),
+  })  : id = Value(id),
+        featureId = Value(featureId),
+        prevGeojson = Value(prevGeojson),
+        newGeojson = Value(newGeojson),
+        editedBy = Value(editedBy),
+        editedAt = Value(editedAt),
+        createdAt = Value(createdAt);
+  static Insertable<FeatureGeometryRevision> custom({
+    Expression<String>? id,
+    Expression<String>? featureId,
+    Expression<String>? prevGeojson,
+    Expression<String>? newGeojson,
+    Expression<String>? editedBy,
+    Expression<DateTime>? editedAt,
+    Expression<String>? overrideReason,
+    Expression<String>? syncStatus,
+    Expression<DateTime>? createdAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (featureId != null) 'feature_id': featureId,
+      if (prevGeojson != null) 'prev_geojson': prevGeojson,
+      if (newGeojson != null) 'new_geojson': newGeojson,
+      if (editedBy != null) 'edited_by': editedBy,
+      if (editedAt != null) 'edited_at': editedAt,
+      if (overrideReason != null) 'override_reason': overrideReason,
+      if (syncStatus != null) 'sync_status': syncStatus,
+      if (createdAt != null) 'created_at': createdAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  FeatureGeometryRevisionsCompanion copyWith(
+      {Value<String>? id,
+      Value<String>? featureId,
+      Value<String>? prevGeojson,
+      Value<String>? newGeojson,
+      Value<String>? editedBy,
+      Value<DateTime>? editedAt,
+      Value<String?>? overrideReason,
+      Value<String>? syncStatus,
+      Value<DateTime>? createdAt,
+      Value<int>? rowid}) {
+    return FeatureGeometryRevisionsCompanion(
+      id: id ?? this.id,
+      featureId: featureId ?? this.featureId,
+      prevGeojson: prevGeojson ?? this.prevGeojson,
+      newGeojson: newGeojson ?? this.newGeojson,
+      editedBy: editedBy ?? this.editedBy,
+      editedAt: editedAt ?? this.editedAt,
+      overrideReason: overrideReason ?? this.overrideReason,
+      syncStatus: syncStatus ?? this.syncStatus,
+      createdAt: createdAt ?? this.createdAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (featureId.present) {
+      map['feature_id'] = Variable<String>(featureId.value);
+    }
+    if (prevGeojson.present) {
+      map['prev_geojson'] = Variable<String>(prevGeojson.value);
+    }
+    if (newGeojson.present) {
+      map['new_geojson'] = Variable<String>(newGeojson.value);
+    }
+    if (editedBy.present) {
+      map['edited_by'] = Variable<String>(editedBy.value);
+    }
+    if (editedAt.present) {
+      map['edited_at'] = Variable<DateTime>(editedAt.value);
+    }
+    if (overrideReason.present) {
+      map['override_reason'] = Variable<String>(overrideReason.value);
+    }
+    if (syncStatus.present) {
+      map['sync_status'] = Variable<String>(syncStatus.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('FeatureGeometryRevisionsCompanion(')
+          ..write('id: $id, ')
+          ..write('featureId: $featureId, ')
+          ..write('prevGeojson: $prevGeojson, ')
+          ..write('newGeojson: $newGeojson, ')
+          ..write('editedBy: $editedBy, ')
+          ..write('editedAt: $editedAt, ')
+          ..write('overrideReason: $overrideReason, ')
+          ..write('syncStatus: $syncStatus, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 class $SubmissionsTable extends Submissions
     with TableInfo<$SubmissionsTable, Submission> {
   @override
@@ -4875,6 +5361,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $EnumeratorsTable enumerators = $EnumeratorsTable(this);
   late final $AssignmentsTable assignments = $AssignmentsTable(this);
   late final $FeaturesTable features = $FeaturesTable(this);
+  late final $FeatureGeometryRevisionsTable featureGeometryRevisions =
+      $FeatureGeometryRevisionsTable(this);
   late final $SubmissionsTable submissions = $SubmissionsTable(this);
   late final $BuildingAttributesTable buildingAttributes =
       $BuildingAttributesTable(this);
@@ -4888,6 +5376,10 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       $OfflineTilePacksTable(this);
   late final Index featuresAssignmentIdIdx = Index('features_assignment_id_idx',
       'CREATE INDEX features_assignment_id_idx ON features (assignment_id)');
+  late final Index fgrFeatureIdIdx = Index('fgr_feature_id_idx',
+      'CREATE INDEX fgr_feature_id_idx ON feature_geometry_revisions (feature_id)');
+  late final Index fgrSyncStatusIdx = Index('fgr_sync_status_idx',
+      'CREATE INDEX fgr_sync_status_idx ON feature_geometry_revisions (sync_status)');
   late final Index submissionsFeatureIdIdx = Index('submissions_feature_id_idx',
       'CREATE INDEX submissions_feature_id_idx ON submissions (feature_id)');
   late final Index buildingAttrsRa9514TypeIdx = Index(
@@ -4905,6 +5397,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
         enumerators,
         assignments,
         features,
+        featureGeometryRevisions,
         submissions,
         buildingAttributes,
         roadAttributes,
@@ -4914,6 +5407,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
         syncJobs,
         offlineTilePacks,
         featuresAssignmentIdIdx,
+        fgrFeatureIdIdx,
+        fgrSyncStatusIdx,
         submissionsFeatureIdIdx,
         buildingAttrsRa9514TypeIdx,
         photosSubmissionIdIdx,
@@ -5504,6 +5999,248 @@ typedef $$FeaturesTableProcessedTableManager = ProcessedTableManager<
     (Feature, BaseReferences<_$AppDatabase, $FeaturesTable, Feature>),
     Feature,
     PrefetchHooks Function()>;
+typedef $$FeatureGeometryRevisionsTableCreateCompanionBuilder
+    = FeatureGeometryRevisionsCompanion Function({
+  required String id,
+  required String featureId,
+  required String prevGeojson,
+  required String newGeojson,
+  required String editedBy,
+  required DateTime editedAt,
+  Value<String?> overrideReason,
+  Value<String> syncStatus,
+  required DateTime createdAt,
+  Value<int> rowid,
+});
+typedef $$FeatureGeometryRevisionsTableUpdateCompanionBuilder
+    = FeatureGeometryRevisionsCompanion Function({
+  Value<String> id,
+  Value<String> featureId,
+  Value<String> prevGeojson,
+  Value<String> newGeojson,
+  Value<String> editedBy,
+  Value<DateTime> editedAt,
+  Value<String?> overrideReason,
+  Value<String> syncStatus,
+  Value<DateTime> createdAt,
+  Value<int> rowid,
+});
+
+class $$FeatureGeometryRevisionsTableFilterComposer
+    extends Composer<_$AppDatabase, $FeatureGeometryRevisionsTable> {
+  $$FeatureGeometryRevisionsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get featureId => $composableBuilder(
+      column: $table.featureId, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get prevGeojson => $composableBuilder(
+      column: $table.prevGeojson, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get newGeojson => $composableBuilder(
+      column: $table.newGeojson, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get editedBy => $composableBuilder(
+      column: $table.editedBy, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get editedAt => $composableBuilder(
+      column: $table.editedAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get overrideReason => $composableBuilder(
+      column: $table.overrideReason,
+      builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get syncStatus => $composableBuilder(
+      column: $table.syncStatus, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+      column: $table.createdAt, builder: (column) => ColumnFilters(column));
+}
+
+class $$FeatureGeometryRevisionsTableOrderingComposer
+    extends Composer<_$AppDatabase, $FeatureGeometryRevisionsTable> {
+  $$FeatureGeometryRevisionsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get featureId => $composableBuilder(
+      column: $table.featureId, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get prevGeojson => $composableBuilder(
+      column: $table.prevGeojson, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get newGeojson => $composableBuilder(
+      column: $table.newGeojson, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get editedBy => $composableBuilder(
+      column: $table.editedBy, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get editedAt => $composableBuilder(
+      column: $table.editedAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get overrideReason => $composableBuilder(
+      column: $table.overrideReason,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get syncStatus => $composableBuilder(
+      column: $table.syncStatus, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+      column: $table.createdAt, builder: (column) => ColumnOrderings(column));
+}
+
+class $$FeatureGeometryRevisionsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $FeatureGeometryRevisionsTable> {
+  $$FeatureGeometryRevisionsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get featureId =>
+      $composableBuilder(column: $table.featureId, builder: (column) => column);
+
+  GeneratedColumn<String> get prevGeojson => $composableBuilder(
+      column: $table.prevGeojson, builder: (column) => column);
+
+  GeneratedColumn<String> get newGeojson => $composableBuilder(
+      column: $table.newGeojson, builder: (column) => column);
+
+  GeneratedColumn<String> get editedBy =>
+      $composableBuilder(column: $table.editedBy, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get editedAt =>
+      $composableBuilder(column: $table.editedAt, builder: (column) => column);
+
+  GeneratedColumn<String> get overrideReason => $composableBuilder(
+      column: $table.overrideReason, builder: (column) => column);
+
+  GeneratedColumn<String> get syncStatus => $composableBuilder(
+      column: $table.syncStatus, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+}
+
+class $$FeatureGeometryRevisionsTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $FeatureGeometryRevisionsTable,
+    FeatureGeometryRevision,
+    $$FeatureGeometryRevisionsTableFilterComposer,
+    $$FeatureGeometryRevisionsTableOrderingComposer,
+    $$FeatureGeometryRevisionsTableAnnotationComposer,
+    $$FeatureGeometryRevisionsTableCreateCompanionBuilder,
+    $$FeatureGeometryRevisionsTableUpdateCompanionBuilder,
+    (
+      FeatureGeometryRevision,
+      BaseReferences<_$AppDatabase, $FeatureGeometryRevisionsTable,
+          FeatureGeometryRevision>
+    ),
+    FeatureGeometryRevision,
+    PrefetchHooks Function()> {
+  $$FeatureGeometryRevisionsTableTableManager(
+      _$AppDatabase db, $FeatureGeometryRevisionsTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$FeatureGeometryRevisionsTableFilterComposer(
+                  $db: db, $table: table),
+          createOrderingComposer: () =>
+              $$FeatureGeometryRevisionsTableOrderingComposer(
+                  $db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$FeatureGeometryRevisionsTableAnnotationComposer(
+                  $db: db, $table: table),
+          updateCompanionCallback: ({
+            Value<String> id = const Value.absent(),
+            Value<String> featureId = const Value.absent(),
+            Value<String> prevGeojson = const Value.absent(),
+            Value<String> newGeojson = const Value.absent(),
+            Value<String> editedBy = const Value.absent(),
+            Value<DateTime> editedAt = const Value.absent(),
+            Value<String?> overrideReason = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              FeatureGeometryRevisionsCompanion(
+            id: id,
+            featureId: featureId,
+            prevGeojson: prevGeojson,
+            newGeojson: newGeojson,
+            editedBy: editedBy,
+            editedAt: editedAt,
+            overrideReason: overrideReason,
+            syncStatus: syncStatus,
+            createdAt: createdAt,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String id,
+            required String featureId,
+            required String prevGeojson,
+            required String newGeojson,
+            required String editedBy,
+            required DateTime editedAt,
+            Value<String?> overrideReason = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            required DateTime createdAt,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              FeatureGeometryRevisionsCompanion.insert(
+            id: id,
+            featureId: featureId,
+            prevGeojson: prevGeojson,
+            newGeojson: newGeojson,
+            editedBy: editedBy,
+            editedAt: editedAt,
+            overrideReason: overrideReason,
+            syncStatus: syncStatus,
+            createdAt: createdAt,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$FeatureGeometryRevisionsTableProcessedTableManager
+    = ProcessedTableManager<
+        _$AppDatabase,
+        $FeatureGeometryRevisionsTable,
+        FeatureGeometryRevision,
+        $$FeatureGeometryRevisionsTableFilterComposer,
+        $$FeatureGeometryRevisionsTableOrderingComposer,
+        $$FeatureGeometryRevisionsTableAnnotationComposer,
+        $$FeatureGeometryRevisionsTableCreateCompanionBuilder,
+        $$FeatureGeometryRevisionsTableUpdateCompanionBuilder,
+        (
+          FeatureGeometryRevision,
+          BaseReferences<_$AppDatabase, $FeatureGeometryRevisionsTable,
+              FeatureGeometryRevision>
+        ),
+        FeatureGeometryRevision,
+        PrefetchHooks Function()>;
 typedef $$SubmissionsTableCreateCompanionBuilder = SubmissionsCompanion
     Function({
   required String id,
@@ -7289,6 +8026,9 @@ class $AppDatabaseManager {
       $$AssignmentsTableTableManager(_db, _db.assignments);
   $$FeaturesTableTableManager get features =>
       $$FeaturesTableTableManager(_db, _db.features);
+  $$FeatureGeometryRevisionsTableTableManager get featureGeometryRevisions =>
+      $$FeatureGeometryRevisionsTableTableManager(
+          _db, _db.featureGeometryRevisions);
   $$SubmissionsTableTableManager get submissions =>
       $$SubmissionsTableTableManager(_db, _db.submissions);
   $$BuildingAttributesTableTableManager get buildingAttributes =>

--- a/lib/core/db/tables/feature_geometry_revisions.dart
+++ b/lib/core/db/tables/feature_geometry_revisions.dart
@@ -1,0 +1,19 @@
+import 'package:drift/drift.dart';
+
+@TableIndex(name: 'fgr_feature_id_idx',  columns: {#featureId})
+@TableIndex(name: 'fgr_sync_status_idx', columns: {#syncStatus})
+class FeatureGeometryRevisions extends Table {
+  TextColumn     get id              => text()();
+  TextColumn     get featureId       => text()();
+  TextColumn     get prevGeojson     => text()();
+  TextColumn     get newGeojson      => text()();
+  TextColumn     get editedBy        => text()();
+  DateTimeColumn get editedAt        => dateTime()();
+  TextColumn     get overrideReason  => text().nullable()();
+  TextColumn     get syncStatus      => text().withDefault(const Constant('pending'))();
+                                                            // pending|ready_to_upload|uploaded|failed
+  DateTimeColumn get createdAt       => dateTime()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/lib/core/db/tables/sync_jobs.dart
+++ b/lib/core/db/tables/sync_jobs.dart
@@ -4,7 +4,7 @@ import 'package:drift/drift.dart';
 class SyncJobs extends Table {
   TextColumn get id => text()();
   TextColumn get entityType =>
-      text()(); // submission|photo|new_feature|status_update
+      text()(); // submission|photo|new_feature|status_update|feature_geometry_update
   TextColumn get entityId => text()();
   TextColumn get status =>
       text().withDefault(const Constant('pending'))(); // pending|in_progress|success|failed|dead

--- a/lib/core/geo/polygon_validator.dart
+++ b/lib/core/geo/polygon_validator.dart
@@ -52,14 +52,23 @@ PolygonValidationResult validateBuildingPolygon(
     );
   }
 
+  // Rule 3: non-self-intersecting (open segments, ignore adjacent pairs).
+  // Checked before area so a bowtie (zero net area due to self-intersection)
+  // surfaces the more actionable selfIntersection error rather than zeroArea.
+  final intersections = _findSelfIntersections(outer);
+  if (intersections.isNotEmpty) {
+    return PolygonValidationResult.invalid(
+      PolygonValidationError.selfIntersection,
+      intersectingEdges: intersections,
+    );
+  }
+
   // Rule 2: non-zero area (shoelace, in WGS84 sq-degrees; epsilon 1e-12).
   if (_signedArea(outer).abs() < 1e-12) {
     return const PolygonValidationResult.invalid(
       PolygonValidationError.zeroOrNegativeArea,
     );
   }
-
-  // Rules 3, 4, 5 added in subsequent tasks.
 
   return const PolygonValidationResult.valid();
 }
@@ -81,4 +90,45 @@ double _signedArea(List<LngLat> ring) {
     sum += (b.lng - a.lng) * (b.lat + a.lat);
   }
   return sum / 2.0;
+}
+
+List<EdgeIndex> _findSelfIntersections(List<LngLat> ring) {
+  final n = ring.length;
+  final hits = <EdgeIndex>[];
+  for (var i = 0; i < n; i++) {
+    final a1 = ring[i];
+    final a2 = ring[(i + 1) % n];
+    for (var j = i + 1; j < n; j++) {
+      // Skip adjacent edges (share a vertex) and the wraparound pair.
+      if (j == i + 1) continue;
+      if (i == 0 && j == n - 1) continue;
+      final b1 = ring[j];
+      final b2 = ring[(j + 1) % n];
+      if (_segmentsIntersect(a1, a2, b1, b2)) {
+        hits.add((aStart: i, bStart: j));
+      }
+    }
+  }
+  return hits;
+}
+
+// Standard CCW orientation test for open-segment intersection.
+// Returns true iff the open segments (a1,a2) and (b1,b2) cross.
+bool _segmentsIntersect(LngLat a1, LngLat a2, LngLat b1, LngLat b2) {
+  final d1 = _ccw(b1, b2, a1);
+  final d2 = _ccw(b1, b2, a2);
+  final d3 = _ccw(a1, a2, b1);
+  final d4 = _ccw(a1, a2, b2);
+
+  if (((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) &&
+      ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0))) {
+    return true;
+  }
+  // Collinear-touch cases are not considered self-intersection in this app —
+  // only "transverse" crossings.
+  return false;
+}
+
+double _ccw(LngLat p, LngLat q, LngLat r) {
+  return (q.lng - p.lng) * (r.lat - p.lat) - (q.lat - p.lat) * (r.lng - p.lng);
 }

--- a/lib/core/geo/polygon_validator.dart
+++ b/lib/core/geo/polygon_validator.dart
@@ -1,0 +1,84 @@
+typedef LngLat = ({double lng, double lat});
+
+// Identifies an intersecting pair of edges in the working outer ring.
+// `aStart` and `bStart` index into rings[0]; the edge runs from index N to
+// (N+1) % ringLength.
+typedef EdgeIndex = ({int aStart, int bStart});
+
+enum PolygonValidationError {
+  tooFewVertices,
+  zeroOrNegativeArea,
+  selfIntersection,
+  vertexOutsideBoundary,
+  zeroLengthEdge,
+}
+
+class PolygonValidationResult {
+  const PolygonValidationResult.valid()
+      : valid = true,
+        error = null,
+        intersectingEdges = null;
+
+  const PolygonValidationResult.invalid(
+    this.error, {
+    this.intersectingEdges,
+  }) : valid = false;
+
+  final bool valid;
+  final PolygonValidationError? error;
+  final List<EdgeIndex>? intersectingEdges;
+}
+
+/// Validates [rings] against the five reshape rules in declared order.
+/// Short-circuits on the first failure.
+///
+/// `rings[0]` is the outer ring (open form: no duplicated end vertex).
+/// Holes are not validated — building polygons only have an outer ring.
+PolygonValidationResult validateBuildingPolygon(
+  List<List<LngLat>> rings, {
+  required String boundaryGeojson,
+}) {
+  if (rings.isEmpty) {
+    return const PolygonValidationResult.invalid(
+      PolygonValidationError.tooFewVertices,
+    );
+  }
+  final outer = rings[0];
+
+  // Rule 1: at least 3 unique vertices.
+  if (_uniqueVertexCount(outer) < 3) {
+    return const PolygonValidationResult.invalid(
+      PolygonValidationError.tooFewVertices,
+    );
+  }
+
+  // Rule 2: non-zero area (shoelace, in WGS84 sq-degrees; epsilon 1e-12).
+  if (_signedArea(outer).abs() < 1e-12) {
+    return const PolygonValidationResult.invalid(
+      PolygonValidationError.zeroOrNegativeArea,
+    );
+  }
+
+  // Rules 3, 4, 5 added in subsequent tasks.
+
+  return const PolygonValidationResult.valid();
+}
+
+int _uniqueVertexCount(List<LngLat> ring) {
+  final seen = <String>{};
+  for (final v in ring) {
+    seen.add('${v.lng.toStringAsFixed(9)},${v.lat.toStringAsFixed(9)}');
+  }
+  return seen.length;
+}
+
+double _signedArea(List<LngLat> ring) {
+  if (ring.length < 3) return 0;
+  var sum = 0.0;
+  for (var i = 0; i < ring.length; i++) {
+    final a = ring[i];
+    final b = ring[(i + 1) % ring.length];
+    sum += (b.lng - a.lng) * (b.lat + a.lat);
+  }
+  return sum / 2.0;
+}

--- a/lib/core/geo/polygon_validator.dart
+++ b/lib/core/geo/polygon_validator.dart
@@ -1,3 +1,5 @@
+import 'package:firecheck/core/geo/point_in_polygon.dart';
+
 typedef LngLat = ({double lng, double lat});
 
 // Identifies an intersecting pair of edges in the working outer ring.
@@ -68,6 +70,29 @@ PolygonValidationResult validateBuildingPolygon(
     return const PolygonValidationResult.invalid(
       PolygonValidationError.zeroOrNegativeArea,
     );
+  }
+
+  // Rule 4: every vertex inside the assignment boundary.
+  for (final v in outer) {
+    if (!pointInPolygonGeojson(v.lat, v.lng, boundaryGeojson)) {
+      return const PolygonValidationResult.invalid(
+        PolygonValidationError.vertexOutsideBoundary,
+      );
+    }
+  }
+
+  // Rule 5: no zero-length edges (adjacent vertices not coincident).
+  const epsilon = 1e-9;
+  for (var i = 0; i < outer.length; i++) {
+    final a = outer[i];
+    final b = outer[(i + 1) % outer.length];
+    final dLng = (b.lng - a.lng).abs();
+    final dLat = (b.lat - a.lat).abs();
+    if (dLng < epsilon && dLat < epsilon) {
+      return const PolygonValidationResult.invalid(
+        PolygonValidationError.zeroLengthEdge,
+      );
+    }
   }
 
   return const PolygonValidationResult.valid();

--- a/lib/core/i18n/app_en.arb
+++ b/lib/core/i18n/app_en.arb
@@ -344,5 +344,24 @@
   "locationSnackbarOpenSettings": "Open settings",
   "locationSnackbarLowAccuracy": "Location accuracy is low. Showing your approximate position.",
   "zoomInButtonSemanticLabel": "Zoom in",
-  "zoomOutButtonSemanticLabel": "Zoom out"
+  "zoomOutButtonSemanticLabel": "Zoom out",
+  "reshapeActionSheetTitle": "Building polygon",
+  "reshapeActionSheetOpenForm": "Open form",
+  "reshapeActionSheetReshape": "Reshape",
+  "reshapeBannerTitle": "Reshape • {count} edits",
+  "@reshapeBannerTitle": {
+    "placeholders": {"count": {"type": "int"}}
+  },
+  "reshapeBannerSave": "Save",
+  "reshapeRemoveConfirmTitle": "Remove vertex?",
+  "reshapeRemoveConfirmBody": "You can undo this from the banner.",
+  "reshapeRemoveConfirmRemove": "Remove",
+  "reshapeErrorTooFewVertices": "Polygon must have at least 3 vertices",
+  "reshapeErrorZeroArea": "Polygon area is too small",
+  "reshapeErrorSelfIntersection": "Edges cannot cross. Tap Undo or move a corner.",
+  "reshapeErrorOutsideBoundary": "Some vertices are outside the assignment area",
+  "reshapeErrorZeroLengthEdge": "Adjacent corners cannot be on the same spot",
+  "reshapeLockedSnackbar": "Assignment is closed; reshape unavailable",
+  "reshapeLockWhileDirtyBanner": "Assignment was closed by supervisor — your edits cannot be saved",
+  "reshapeLockExit": "Exit"
 }

--- a/lib/core/i18n/app_tl.arb
+++ b/lib/core/i18n/app_tl.arb
@@ -289,5 +289,21 @@
   "locationSnackbarOpenSettings": "Open settings",
   "locationSnackbarLowAccuracy": "Location accuracy is low. Showing your approximate position.",
   "zoomInButtonSemanticLabel": "Zoom in",
-  "zoomOutButtonSemanticLabel": "Zoom out"
+  "zoomOutButtonSemanticLabel": "Zoom out",
+  "reshapeActionSheetTitle": "Building polygon",
+  "reshapeActionSheetOpenForm": "Open form",
+  "reshapeActionSheetReshape": "Reshape",
+  "reshapeBannerTitle": "Reshape • {count} edits",
+  "reshapeBannerSave": "Save",
+  "reshapeRemoveConfirmTitle": "Remove vertex?",
+  "reshapeRemoveConfirmBody": "You can undo this from the banner.",
+  "reshapeRemoveConfirmRemove": "Remove",
+  "reshapeErrorTooFewVertices": "Polygon must have at least 3 vertices",
+  "reshapeErrorZeroArea": "Polygon area is too small",
+  "reshapeErrorSelfIntersection": "Edges cannot cross. Tap Undo or move a corner.",
+  "reshapeErrorOutsideBoundary": "Some vertices are outside the assignment area",
+  "reshapeErrorZeroLengthEdge": "Adjacent corners cannot be on the same spot",
+  "reshapeLockedSnackbar": "Assignment is closed; reshape unavailable",
+  "reshapeLockWhileDirtyBanner": "Assignment was closed by supervisor — your edits cannot be saved",
+  "reshapeLockExit": "Exit"
 }

--- a/lib/core/sync/data/fake_sync_api.dart
+++ b/lib/core/sync/data/fake_sync_api.dart
@@ -11,6 +11,7 @@ class FakeSyncApi implements SyncApi {
   final List<SyncOutcome> _photoUploadResponses = [];
   final List<SyncOutcome> _photoMarkResponses = [];
   final List<SyncOutcome> _newFeatureResponses = [];
+  final List<SyncOutcome> _featureGeometryUpdateResponses = [];
 
   /// Records of every call, in order, for assertions.
   final List<Map<String, dynamic>> uploadSubmissionCalls = [];
@@ -19,12 +20,15 @@ class FakeSyncApi implements SyncApi {
   final List<({String photoId, String storagePath})> markPhotoUploadedCalls =
       [];
   final List<Feature> uploadNewFeatureCalls = [];
+  final List<FeatureGeometryRevision> uploadFeatureGeometryUpdateCalls = [];
 
   /// Configure the next outcome each method should return.
   void enqueueSubmission(SyncOutcome o) => _submissionResponses.add(o);
   void enqueuePhotoUpload(SyncOutcome o) => _photoUploadResponses.add(o);
   void enqueuePhotoMark(SyncOutcome o) => _photoMarkResponses.add(o);
   void enqueueNewFeature(SyncOutcome o) => _newFeatureResponses.add(o);
+  void enqueueFeatureGeometryUpdate(SyncOutcome o) =>
+      _featureGeometryUpdateResponses.add(o);
 
   SyncOutcome _next(List<SyncOutcome> q) =>
       q.isEmpty ? const Success() : q.removeAt(0);
@@ -60,5 +64,13 @@ class FakeSyncApi implements SyncApi {
   Future<SyncOutcome> uploadNewFeature(Feature feature) async {
     uploadNewFeatureCalls.add(feature);
     return _next(_newFeatureResponses);
+  }
+
+  @override
+  Future<SyncOutcome> uploadFeatureGeometryUpdate(
+    FeatureGeometryRevision revision,
+  ) async {
+    uploadFeatureGeometryUpdateCalls.add(revision);
+    return _next(_featureGeometryUpdateResponses);
   }
 }

--- a/lib/core/sync/data/supabase_sync_api.dart
+++ b/lib/core/sync/data/supabase_sync_api.dart
@@ -101,6 +101,13 @@ class SupabaseSyncApi implements SyncApi {
     }
   }
 
+  @override
+  Future<SyncOutcome> uploadFeatureGeometryUpdate(
+    FeatureGeometryRevision revision,
+  ) async {
+    throw UnimplementedError('Implemented in T16');
+  }
+
   SyncOutcome _mapPostgrestException(
     PostgrestException e,
     Map<String, dynamic>? submissionPayload,

--- a/lib/core/sync/data/supabase_sync_api.dart
+++ b/lib/core/sync/data/supabase_sync_api.dart
@@ -105,7 +105,31 @@ class SupabaseSyncApi implements SyncApi {
   Future<SyncOutcome> uploadFeatureGeometryUpdate(
     FeatureGeometryRevision revision,
   ) async {
-    throw UnimplementedError('Implemented in T16');
+    try {
+      await _client.rpc<dynamic>(
+        'update_feature_geometry',
+        params: {
+          'p_revision_id': revision.id,
+          'p_feature_id': revision.featureId,
+          'p_prev_geojson': revision.prevGeojson,
+          'p_new_geojson': revision.newGeojson,
+          'p_edited_at': revision.editedAt.toIso8601String(),
+          'p_override_reason': revision.overrideReason,
+        },
+      );
+      return const Success();
+    } on PostgrestException catch (e) {
+      // P0001 + 'geometry_conflict' → server has newer geometry; permanent.
+      // 42501 'forbidden' (RLS / auth) → permanent.
+      // Other PG codes route through the standard mapper which routes 4xx
+      // to PermanentFailure and 5xx/network to TransientFailure.
+      if (e.code == 'P0001' || e.code == '42501') {
+        return PermanentFailure('${e.code} ${e.message}');
+      }
+      return _mapPostgrestException(e, null);
+    } on Object catch (e) {
+      return TransientFailure(e.toString());
+    }
   }
 
   SyncOutcome _mapPostgrestException(

--- a/lib/core/sync/data/sync_api.dart
+++ b/lib/core/sync/data/sync_api.dart
@@ -22,4 +22,6 @@ abstract class SyncApi {
   });
 
   Future<SyncOutcome> uploadNewFeature(Feature feature);
+
+  Future<SyncOutcome> uploadFeatureGeometryUpdate(FeatureGeometryRevision revision);
 }

--- a/lib/core/sync/domain/sync_entity_type.dart
+++ b/lib/core/sync/domain/sync_entity_type.dart
@@ -4,4 +4,5 @@ class SyncEntityType {
   static const submission = 'submission';
   static const photo = 'photo';
   static const newFeature = 'new_feature';
+  static const featureGeometryUpdate = 'feature_geometry_update';
 }

--- a/lib/core/sync/worker/sync_worker.dart
+++ b/lib/core/sync/worker/sync_worker.dart
@@ -10,6 +10,7 @@ import 'package:firecheck/core/sync/domain/sync_entity_type.dart';
 import 'package:firecheck/core/sync/domain/sync_outcome.dart';
 import 'package:firecheck/core/sync/failure/assignment_lock_repository.dart';
 import 'package:firecheck/core/sync/failure/pending_work_bundle.dart';
+import 'package:firecheck/features/map/reshape/data/feature_geometry_revisions_repository.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' hide AuthState;
 
 class SyncWorker {
@@ -69,6 +70,8 @@ class SyncWorker {
           return await _executePhoto(job.entityId);
         case SyncEntityType.newFeature:
           return await _executeNewFeature(job.entityId);
+        case SyncEntityType.featureGeometryUpdate:
+          return await _executeFeatureGeometryUpdate(job.entityId);
         default:
           return PermanentFailure('unknown entity_type: ${job.entityType}');
       }
@@ -124,6 +127,21 @@ class SyncWorker {
           ..where((t) => t.id.equals(featureId)))
         .getSingle();
     return api.uploadNewFeature(feature);
+  }
+
+  Future<SyncOutcome> _executeFeatureGeometryUpdate(String revisionId) async {
+    final repo = FeatureGeometryRevisionsRepository(db);
+    final rev = await repo.getById(revisionId);
+    if (rev == null) {
+      return const PermanentFailure('revision missing');
+    }
+    final outcome = await api.uploadFeatureGeometryUpdate(rev);
+    if (outcome is Success) {
+      await repo.markSynced(rev.id);
+    } else if (outcome is PermanentFailure) {
+      await repo.markFailed(rev.id);
+    }
+    return outcome;
   }
 
   Future<void> _applyOutcome(SyncJob job, SyncOutcome outcome) async {

--- a/lib/features/map/presentation/map_renderer.dart
+++ b/lib/features/map/presentation/map_renderer.dart
@@ -2,14 +2,17 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/geo/point_in_polygon.dart';
 import 'package:firecheck/features/map/presentation/camera_target.dart';
 import 'package:flutter/material.dart';
 // Hide Feature because the Drift-generated row class (imported above) shares
 // the same name with `mapbox_maps_flutter`'s GeoJSON Feature wrapper.
-import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart' hide Feature;
+// Hide Size because mapbox_maps_flutter ships its own Size class that
+// shadows Flutter's `dart:ui` Size — we use Flutter's everywhere here.
+import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart'
+    hide Feature, Size;
 
-/// Minimal surface the map screen actually needs. Lets tests substitute a
-/// renderer that doesn't require a GL context.
+/// Minimal surface the map screen actually needs.
 // ignore: one_member_abstracts
 abstract class MapRenderer {
   Widget build(
@@ -22,7 +25,18 @@ abstract class MapRenderer {
     bool addModeActive,
     CameraTarget? cameraTarget,
     CameraTarget? initialCameraTarget,
+    // US-9 reshape additions:
+    void Function(Feature)? onPolygonLongPress,
+    String? reshapeWorkingPolygonGeojson,
+    String? reshapeInvalidEdgeGeojson,
+    void Function(MapProjection projection)? onProjectionReady,
   });
+}
+
+/// Lat/lng <-> screen-px projection seam exposed by the renderer to overlays.
+abstract class MapProjection {
+  Offset screenPointFromLngLat(double lng, double lat);
+  ({double lng, double lat}) lngLatFromScreenPoint(Offset point);
 }
 
 /// Fake for widget tests — renders one tappable tile per feature instead of
@@ -30,8 +44,11 @@ abstract class MapRenderer {
 class FakeMapRenderer implements MapRenderer {
   void Function(double, double)? _lastOnLongPress;
   void Function(double, double, double)? _lastOnCameraChanged;
+  void Function(Feature)? _lastOnPolygonLongPress;
   CameraTarget? lastCameraTarget;
   CameraTarget? lastInitialCameraTarget;
+  String? lastReshapeWorkingPolygonGeojson;
+  String? lastReshapeInvalidEdgeGeojson;
   final List<CameraTarget> cameraTargetHistory = [];
 
   /// Test seam: simulates a long-press at the given coordinates. Invokes the
@@ -44,9 +61,19 @@ class FakeMapRenderer implements MapRenderer {
   /// Test seam: simulates a camera-change event from the underlying map.
   /// Invokes the most recently stored onCameraChanged callback; no-op if
   /// none was provided.
-  Future<void> simulateCameraChanged(double zoom, double lat, double lng) async {
+  Future<void> simulateCameraChanged(
+    double zoom,
+    double lat,
+    double lng,
+  ) async {
     final cb = _lastOnCameraChanged;
     if (cb != null) cb(zoom, lat, lng);
+  }
+
+  /// Test seam: simulates a long-press on a polygon feature. Invokes the
+  /// most recently stored onPolygonLongPress callback.
+  Future<void> simulatePolygonLongPress(Feature f) async {
+    _lastOnPolygonLongPress?.call(f);
   }
 
   @override
@@ -60,14 +87,25 @@ class FakeMapRenderer implements MapRenderer {
     bool addModeActive = false,
     CameraTarget? cameraTarget,
     CameraTarget? initialCameraTarget,
+    void Function(Feature)? onPolygonLongPress,
+    String? reshapeWorkingPolygonGeojson,
+    String? reshapeInvalidEdgeGeojson,
+    void Function(MapProjection projection)? onProjectionReady,
   }) {
     _lastOnLongPress = onLongPress;
     _lastOnCameraChanged = onCameraChanged;
+    _lastOnPolygonLongPress = onPolygonLongPress;
     lastInitialCameraTarget = initialCameraTarget;
     if (cameraTarget != null && cameraTarget != lastCameraTarget) {
       cameraTargetHistory.add(cameraTarget);
     }
     lastCameraTarget = cameraTarget;
+    lastReshapeWorkingPolygonGeojson = reshapeWorkingPolygonGeojson;
+    lastReshapeInvalidEdgeGeojson = reshapeInvalidEdgeGeojson;
+
+    // Identity projection: each lng,lat maps to (lng, lat) screen pixels.
+    onProjectionReady?.call(_IdentityProjection());
+
     return ListView(
       shrinkWrap: true,
       children: [
@@ -80,6 +118,8 @@ class FakeMapRenderer implements MapRenderer {
           return GestureDetector(
             key: Key('fake-map-feature-${f.id}'),
             onTap: () => onFeatureTap(f),
+            onLongPress:
+                f.isNew ? null : () => onPolygonLongPress?.call(f),
             child: Container(
               key: f.isNew
                   ? Key('fake-map-new-feature-${f.id}')
@@ -107,6 +147,16 @@ class FakeMapRenderer implements MapRenderer {
   }
 }
 
+/// Identity-degree projection used by FakeMapRenderer for tests.
+class _IdentityProjection implements MapProjection {
+  @override
+  Offset screenPointFromLngLat(double lng, double lat) => Offset(lng, lat);
+
+  @override
+  ({double lng, double lat}) lngLatFromScreenPoint(Offset point) =>
+      (lng: point.dx, lat: point.dy);
+}
+
 // MapboxMapRenderer is exercised via FakeMapRenderer in widget tests and via
 // the manual happy path in plan Task 18. The Mapbox plugin does not render
 // in flutter_tester.
@@ -127,6 +177,10 @@ class MapboxMapRenderer implements MapRenderer {
     bool addModeActive = false,
     CameraTarget? cameraTarget,
     CameraTarget? initialCameraTarget,
+    void Function(Feature)? onPolygonLongPress,
+    String? reshapeWorkingPolygonGeojson,
+    String? reshapeInvalidEdgeGeojson,
+    void Function(MapProjection projection)? onProjectionReady,
   }) {
     return _MapboxMapView(
       features: features,
@@ -137,6 +191,10 @@ class MapboxMapRenderer implements MapRenderer {
       addModeActive: addModeActive,
       cameraTarget: cameraTarget,
       initialCameraTarget: initialCameraTarget,
+      onPolygonLongPress: onPolygonLongPress,
+      reshapeWorkingPolygonGeojson: reshapeWorkingPolygonGeojson,
+      reshapeInvalidEdgeGeojson: reshapeInvalidEdgeGeojson,
+      onProjectionReady: onProjectionReady,
     );
   }
 }
@@ -151,6 +209,10 @@ class _MapboxMapView extends StatefulWidget {
     this.addModeActive = false,
     this.cameraTarget,
     this.initialCameraTarget,
+    this.onPolygonLongPress,
+    this.reshapeWorkingPolygonGeojson,
+    this.reshapeInvalidEdgeGeojson,
+    this.onProjectionReady,
   });
 
   final List<Feature> features;
@@ -161,6 +223,10 @@ class _MapboxMapView extends StatefulWidget {
   final bool addModeActive;
   final CameraTarget? cameraTarget;
   final CameraTarget? initialCameraTarget;
+  final void Function(Feature)? onPolygonLongPress;
+  final String? reshapeWorkingPolygonGeojson;
+  final String? reshapeInvalidEdgeGeojson;
+  final void Function(MapProjection projection)? onProjectionReady;
 
   @override
   State<_MapboxMapView> createState() => _MapboxMapViewState();
@@ -176,37 +242,77 @@ class _MapboxMapViewState extends State<_MapboxMapView> {
   // the tap listener can resolve the Drift row from the tapped annotation.
   final Map<String, Feature> _annotationToFeature = <String, Feature>{};
 
+  // US-9: working-polygon overlay rendered while reshape mode is active.
+  PolygonAnnotation? _reshapeWorkingAnnotation;
+
+  // US-9: lat/lng <-> screen-px projection state. Refreshed on camera change
+  // so ReshapeOverlay can read it synchronously during finger drags.
+  _MapboxProjection? _projection;
+  Size? _viewportSize;
+
   @override
   Widget build(BuildContext context) {
     final initial = widget.initialCameraTarget;
-    return MapWidget(
-      cameraOptions: CameraOptions(
-        center: initial != null
-            ? Point(coordinates: Position(initial.lng, initial.lat))
-            : Point(coordinates: Position(123.88270, 10.31810)),
-        zoom: initial?.zoom ?? 15,
-      ),
-      // Without an explicit styleUri the map renders a black background
-      // because no style is loaded. Streets v12 is the Phase 1 spec choice.
-      styleUri: 'mapbox://styles/mapbox/streets-v12',
-      onMapCreated: _onMapCreated,
-      onLongTapListener: (MapContentGestureContext ctx) {
-        if (widget.addModeActive && widget.onLongPress != null) {
-          final pos = ctx.point.coordinates;
-          widget.onLongPress!(pos.lat.toDouble(), pos.lng.toDouble());
-        }
-      },
-      onCameraChangeListener: (CameraChangedEventData data) {
-        final cb = widget.onCameraChanged;
-        if (cb == null) return;
-        final state = data.cameraState;
-        cb(
-          state.zoom,
-          state.center.coordinates.lat.toDouble(),
-          state.center.coordinates.lng.toDouble(),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        _viewportSize = Size(constraints.maxWidth, constraints.maxHeight);
+        return MapWidget(
+          cameraOptions: CameraOptions(
+            center: initial != null
+                ? Point(coordinates: Position(initial.lng, initial.lat))
+                : Point(coordinates: Position(123.88270, 10.31810)),
+            zoom: initial?.zoom ?? 15,
+          ),
+          // Without an explicit styleUri the map renders a black background
+          // because no style is loaded. Streets v12 is the Phase 1 spec choice.
+          styleUri: 'mapbox://styles/mapbox/streets-v12',
+          onMapCreated: _onMapCreated,
+          onLongTapListener: (MapContentGestureContext ctx) async {
+            // Add-mode placement remains unchanged.
+            if (widget.addModeActive && widget.onLongPress != null) {
+              final pos = ctx.point.coordinates;
+              widget.onLongPress!(pos.lat.toDouble(), pos.lng.toDouble());
+              return;
+            }
+            // Reshape entry: hit-test all rendered polygons against the
+            // long-press point.
+            final cb = widget.onPolygonLongPress;
+            if (cb == null) return;
+            final hit = _hitTestPolygon(
+              ctx.point.coordinates.lat.toDouble(),
+              ctx.point.coordinates.lng.toDouble(),
+            );
+            if (hit != null) cb(hit);
+          },
+          onCameraChangeListener: (CameraChangedEventData data) {
+            final cb = widget.onCameraChanged;
+            final state = data.cameraState;
+            cb?.call(
+              state.zoom,
+              state.center.coordinates.lat.toDouble(),
+              state.center.coordinates.lng.toDouble(),
+            );
+            final projection = _projection;
+            final size = _viewportSize;
+            if (projection != null && size != null) {
+              unawaited(
+                projection.refresh(size.width, size.height).then((_) {
+                  widget.onProjectionReady?.call(projection);
+                }),
+              );
+            }
+          },
         );
       },
     );
+  }
+
+  Feature? _hitTestPolygon(double lat, double lng) {
+    for (final f in widget.features) {
+      if (f.isNew) continue;
+      if (pointInPolygonGeojson(lat, lng, f.geometryGeojson)) return f;
+    }
+    return null;
   }
 
   Future<void> _onMapCreated(MapboxMap map) async {
@@ -264,6 +370,28 @@ class _MapboxMapViewState extends State<_MapboxMapView> {
       initialState.center.coordinates.lat.toDouble(),
       initialState.center.coordinates.lng.toDouble(),
     );
+
+    // US-9: instantiate the projection now that the map is alive and run
+    // an initial refresh so ReshapeOverlay has correct screen-px math
+    // before the user's first drag.
+    final projection = _MapboxProjection(map);
+    _projection = projection;
+    final size = _viewportSize;
+    if (size != null) {
+      try {
+        await projection.refresh(size.width, size.height);
+        widget.onProjectionReady?.call(projection);
+      } on Object {
+        // Refresh failures are non-fatal; ReshapeOverlay tolerates a
+        // not-yet-ready projection (returns Offset.zero).
+      }
+    }
+
+    // Render any working polygon supplied before the map booted.
+    if (widget.reshapeWorkingPolygonGeojson != null &&
+        widget.reshapeWorkingPolygonGeojson!.isNotEmpty) {
+      unawaited(_rerenderReshapeWorkingPolygon());
+    }
   }
 
   @override
@@ -281,10 +409,34 @@ class _MapboxMapViewState extends State<_MapboxMapView> {
     if (boundaryChanged && _boundaryManager != null) {
       unawaited(_rerenderBoundary());
     }
+    if (oldWidget.reshapeWorkingPolygonGeojson !=
+        widget.reshapeWorkingPolygonGeojson) {
+      unawaited(_rerenderReshapeWorkingPolygon());
+    }
     final target = widget.cameraTarget;
     if (target != null && target != oldWidget.cameraTarget) {
       unawaited(_flyToCameraTarget(target));
     }
+  }
+
+  Future<void> _rerenderReshapeWorkingPolygon() async {
+    final manager = _featureManager;
+    if (manager == null) return;
+    if (_reshapeWorkingAnnotation != null) {
+      await manager.delete(_reshapeWorkingAnnotation!);
+      _reshapeWorkingAnnotation = null;
+    }
+    final geojson = widget.reshapeWorkingPolygonGeojson;
+    if (geojson == null || geojson.isEmpty) return;
+    final polygon = _decodePolygon(geojson);
+    if (polygon == null) return;
+    _reshapeWorkingAnnotation = await manager.create(
+      PolygonAnnotationOptions(
+        geometry: polygon,
+        fillColor: 0xFF3182CE,
+        fillOpacity: 0.3,
+      ),
+    );
   }
 
   Future<void> _flyToCameraTarget(CameraTarget t) async {
@@ -459,5 +611,68 @@ class _FeatureClickHandler extends OnPolygonAnnotationClickListener {
   void onPolygonAnnotationClick(PolygonAnnotation annotation) {
     final feature = annotationToFeature[annotation.id];
     if (feature != null) onTap(feature);
+  }
+}
+
+/// Caches lat/lng <-> screen-px projections via async `coordinateForPixel`
+/// and exposes a synchronous linear interpolation. Refreshed on each camera
+/// change so ReshapeOverlay (which rebuilds on every Riverpod tick during
+/// drags) can read sync without an async hop.
+///
+/// The linear-corner calibration is approximate near map edges and at very
+/// low zoom. At reshape working zoom (>=17) it is sub-pixel inside the
+/// visible viewport — acceptable for finger-drag UX.
+class _MapboxProjection implements MapProjection {
+  _MapboxProjection(this._map);
+  final MapboxMap _map;
+
+  Offset? _topLeftPx;
+  Position? _topLeftLngLat;
+  Offset? _bottomRightPx;
+  Position? _bottomRightLngLat;
+
+  Future<void> refresh(double viewportWidth, double viewportHeight) async {
+    final tl = await _map.coordinateForPixel(ScreenCoordinate(x: 0, y: 0));
+    final br = await _map.coordinateForPixel(
+      ScreenCoordinate(x: viewportWidth, y: viewportHeight),
+    );
+    _topLeftPx = Offset.zero;
+    _topLeftLngLat = tl.coordinates;
+    _bottomRightPx = Offset(viewportWidth, viewportHeight);
+    _bottomRightLngLat = br.coordinates;
+  }
+
+  @override
+  Offset screenPointFromLngLat(double lng, double lat) {
+    final tlP = _topLeftPx;
+    final brP = _bottomRightPx;
+    final tlC = _topLeftLngLat;
+    final brC = _bottomRightLngLat;
+    if (tlP == null || brP == null || tlC == null || brC == null) {
+      return Offset.zero;
+    }
+    final tx = (lng - tlC.lng) / (brC.lng - tlC.lng);
+    final ty = (lat - tlC.lat) / (brC.lat - tlC.lat);
+    return Offset(
+      tlP.dx + tx * (brP.dx - tlP.dx),
+      tlP.dy + ty * (brP.dy - tlP.dy),
+    );
+  }
+
+  @override
+  ({double lng, double lat}) lngLatFromScreenPoint(Offset p) {
+    final tlP = _topLeftPx;
+    final brP = _bottomRightPx;
+    final tlC = _topLeftLngLat;
+    final brC = _bottomRightLngLat;
+    if (tlP == null || brP == null || tlC == null || brC == null) {
+      return (lng: 0.0, lat: 0.0);
+    }
+    final tx = (p.dx - tlP.dx) / (brP.dx - tlP.dx);
+    final ty = (p.dy - tlP.dy) / (brP.dy - tlP.dy);
+    return (
+      lng: tlC.lng + tx * (brC.lng - tlC.lng),
+      lat: tlC.lat + ty * (brC.lat - tlC.lat),
+    );
   }
 }

--- a/lib/features/map/presentation/map_renderer.dart
+++ b/lib/features/map/presentation/map_renderer.dart
@@ -250,12 +250,28 @@ class _MapboxMapViewState extends State<_MapboxMapView> {
   _MapboxProjection? _projection;
   Size? _viewportSize;
 
+  // US-9 T13: set to true when _onMapCreated runs before the first
+  // LayoutBuilder pass so we can defer projection init until the viewport
+  // size is known.
+  bool _projectionReadyPending = false;
+
   @override
   Widget build(BuildContext context) {
     final initial = widget.initialCameraTarget;
     return LayoutBuilder(
       builder: (context, constraints) {
         _viewportSize = Size(constraints.maxWidth, constraints.maxHeight);
+
+        // If _onMapCreated ran before the first layout pass, finish projection
+        // initialization now that we have a viewport.
+        if (_projectionReadyPending && _projection != null) {
+          _projectionReadyPending = false;
+          final s = Size(constraints.maxWidth, constraints.maxHeight);
+          unawaited(_projection!.refresh(s.width, s.height).then((_) {
+            if (mounted) widget.onProjectionReady?.call(_projection!);
+          }),);
+        }
+
         return MapWidget(
           cameraOptions: CameraOptions(
             center: initial != null
@@ -327,6 +343,10 @@ class _MapboxMapViewState extends State<_MapboxMapView> {
       // Swallow — location is a nice-to-have here.
     }
 
+    // GL context reset (e.g., app evicted from background): null any
+    // annotation references from a prior context so they're not double-deleted.
+    _reshapeWorkingAnnotation = null;
+
     // Boundary manager FIRST so it sits BENEATH features in the layer stack.
     // Mapbox stacks annotation managers by creation order: later managers
     // render on top. Features must be on top so polygon taps hit them
@@ -385,6 +405,9 @@ class _MapboxMapViewState extends State<_MapboxMapView> {
         // Refresh failures are non-fatal; ReshapeOverlay tolerates a
         // not-yet-ready projection (returns Offset.zero).
       }
+    } else {
+      // Layout hasn't run yet. Defer to the next LayoutBuilder pass.
+      _projectionReadyPending = true;
     }
 
     // Render any working polygon supplied before the map booted.
@@ -409,8 +432,9 @@ class _MapboxMapViewState extends State<_MapboxMapView> {
     if (boundaryChanged && _boundaryManager != null) {
       unawaited(_rerenderBoundary());
     }
-    if (oldWidget.reshapeWorkingPolygonGeojson !=
-        widget.reshapeWorkingPolygonGeojson) {
+    if (!featuresChanged &&
+        oldWidget.reshapeWorkingPolygonGeojson !=
+            widget.reshapeWorkingPolygonGeojson) {
       unawaited(_rerenderReshapeWorkingPolygon());
     }
     final target = widget.cameraTarget;
@@ -457,6 +481,7 @@ class _MapboxMapViewState extends State<_MapboxMapView> {
     final manager = _featureManager;
     if (manager == null) return;
     await manager.deleteAll();
+    _reshapeWorkingAnnotation = null; // deleteAll() destroyed it too
     _annotationToFeature.clear();
     await _renderFeatures();
     final pointManager = _pointManager;
@@ -475,6 +500,14 @@ class _MapboxMapViewState extends State<_MapboxMapView> {
         onTap: widget.onFeatureTap,
       ),
     );
+
+    // Re-render the in-progress reshape polygon if one is active. Doing this
+    // inside _rerenderFeatures serializes it after deleteAll() instead of
+    // racing it via a parallel unawaited call from didUpdateWidget.
+    if (widget.reshapeWorkingPolygonGeojson != null &&
+        widget.reshapeWorkingPolygonGeojson!.isNotEmpty) {
+      await _rerenderReshapeWorkingPolygon();
+    }
   }
 
   Future<void> _rerenderBoundary() async {

--- a/lib/features/map/presentation/map_renderer.dart
+++ b/lib/features/map/presentation/map_renderer.dart
@@ -343,6 +343,19 @@ class _MapboxMapViewState extends State<_MapboxMapView> {
       // Swallow — location is a nice-to-have here.
     }
 
+    // Disable rotation and pitch globally. The reshape overlay's
+    // _MapboxProjection uses a north-up linear corner-calibration (spec §14
+    // first pass); rotated or pitched maps would make handle positions drift
+    // away from their polygon corners. The app UI is also designed top-down
+    // (no compass, no pitch indicator), so this matches the visual model.
+    try {
+      await map.gestures.updateSettings(
+        GesturesSettings(rotateEnabled: false, pitchEnabled: false),
+      );
+    } on Object {
+      // Non-fatal — gesture settings are a hardening measure, not load-bearing.
+    }
+
     // GL context reset (e.g., app evicted from background): null any
     // annotation references from a prior context so they're not double-deleted.
     _reshapeWorkingAnnotation = null;

--- a/lib/features/map/presentation/map_screen.dart
+++ b/lib/features/map/presentation/map_screen.dart
@@ -236,7 +236,10 @@ class _MapScreenState extends ConsumerState<MapScreen> {
                 editCount: reshape.undoStack.length,
                 undoEnabled: reshape.isDirty && !reshape.saving,
                 saveEnabled: reshape.isDirty && !reshape.saving,
-                onCancel: _onReshapeCancel,
+                // Disable Cancel while saving — the async commit transaction
+                // would otherwise still complete in the background after the
+                // UI exits edit mode, producing surprising state transitions.
+                onCancel: reshape.saving ? null : _onReshapeCancel,
                 onUndo: () => ref
                     .read(reshapeModeControllerProvider.notifier)
                     .undo(),

--- a/lib/features/map/presentation/map_screen.dart
+++ b/lib/features/map/presentation/map_screen.dart
@@ -6,6 +6,7 @@ import 'package:firecheck/core/db/database.dart';
 import 'package:firecheck/core/geo/centroid.dart';
 import 'package:firecheck/core/geo/point_in_polygon.dart';
 import 'package:firecheck/core/geo/polygon_bounds.dart';
+import 'package:firecheck/core/geo/polygon_validator.dart';
 import 'package:firecheck/core/geo/polyline_midpoint.dart';
 import 'package:firecheck/core/location/distance.dart';
 import 'package:firecheck/core/location/location_providers.dart';
@@ -20,6 +21,7 @@ import 'package:firecheck/features/map/presentation/recenter_button_state.dart';
 import 'package:firecheck/features/map/presentation/zoom_button.dart';
 import 'package:firecheck/features/map/presentation/zoom_button_state.dart';
 import 'package:firecheck/features/map/presentation/zoom_direction.dart';
+import 'package:firecheck/features/map/reshape/domain/reshape_op.dart';
 import 'package:firecheck/features/map/reshape/presentation/reshape_action_sheet.dart';
 import 'package:firecheck/features/map/reshape/presentation/reshape_banner.dart';
 import 'package:firecheck/features/map/reshape/presentation/reshape_overlay.dart';
@@ -32,6 +34,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:go_router/go_router.dart';
+import 'package:uuid/uuid.dart';
 
 class MapScreen extends ConsumerStatefulWidget {
   const MapScreen({super.key});
@@ -240,7 +243,82 @@ class _MapScreenState extends ConsumerState<MapScreen> {
   }
 
   Future<void> _onReshapeSave() async {
-    // Implemented in T21.
+    final l = AppLocalizations.of(context)!;
+    final ctrl = ref.read(reshapeModeControllerProvider.notifier);
+    final s = ref.read(reshapeModeControllerProvider);
+    final assignment = ref.read(currentAssignmentProvider).value;
+    if (s.originalFeature == null || assignment == null) return;
+
+    final res = validateBuildingPolygon(
+      s.workingRings,
+      boundaryGeojson: assignment.boundaryPolygonGeojson,
+    );
+    if (!res.valid) {
+      final msg = _validationMessage(res.error!, l);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(msg)));
+      ref.read(analyticsServiceProvider).track(
+        'map.reshape.validation_failed',
+        properties: {
+          'feature_id': s.originalFeature!.id,
+          'rule': res.error!.name,
+        },
+      );
+      return;
+    }
+
+    ctrl.markSaving(saving: true);
+    final userId = ref.read(currentUserIdProvider) ?? '';
+    final repo = ref.read(reshapeRepositoryProvider);
+    final newGeojson = ctrl.serializeWorkingPolygon();
+    final revisionId = const Uuid().v4();
+    final start = DateTime.now();
+
+    try {
+      await repo.saveReshape(
+        revisionId: revisionId,
+        featureId: s.originalFeature!.id,
+        prevGeojson: s.originalFeature!.geometryGeojson,
+        newGeojson: newGeojson,
+        editedBy: userId,
+        editedAt: DateTime.now(),
+        overrideReason: s.overrideReason,
+      );
+      ref.read(analyticsServiceProvider).track(
+        'map.reshape.completed',
+        properties: {
+          'feature_id': s.originalFeature!.id,
+          'vertex_count_before':
+              _vertexCount(s.originalFeature!.geometryGeojson),
+          'vertex_count_after': s.workingRings[0].length,
+          'vertex_moves': s.undoStack.whereType<Move>().length,
+          'vertex_adds': s.undoStack.whereType<Add>().length,
+          'vertex_removes': s.undoStack.whereType<Remove>().length,
+          'override_used': s.overrideReason != null,
+          'duration_ms': DateTime.now().difference(start).inMilliseconds,
+        },
+      );
+      ctrl.cancel(); // exits edit mode
+    } on Object catch (e) {
+      ctrl.markSaving(saving: false);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Could not save reshape: $e')),
+      );
+    }
+  }
+
+  String _validationMessage(PolygonValidationError err, AppLocalizations l) {
+    return switch (err) {
+      PolygonValidationError.tooFewVertices => l.reshapeErrorTooFewVertices,
+      PolygonValidationError.zeroOrNegativeArea => l.reshapeErrorZeroArea,
+      PolygonValidationError.selfIntersection =>
+        l.reshapeErrorSelfIntersection,
+      PolygonValidationError.vertexOutsideBoundary =>
+        l.reshapeErrorOutsideBoundary,
+      PolygonValidationError.zeroLengthEdge => l.reshapeErrorZeroLengthEdge,
+    };
   }
 
   Future<void> _handleLongPress(double lat, double lng) async {

--- a/lib/features/map/presentation/map_screen.dart
+++ b/lib/features/map/presentation/map_screen.dart
@@ -19,6 +19,7 @@ import 'package:firecheck/features/map/presentation/recenter_button_state.dart';
 import 'package:firecheck/features/map/presentation/zoom_button.dart';
 import 'package:firecheck/features/map/presentation/zoom_button_state.dart';
 import 'package:firecheck/features/map/presentation/zoom_direction.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_action_sheet.dart';
 import 'package:firecheck/features/new_feature/presentation/feature_type_picker.dart';
 import 'package:firecheck/features/survey/building_form/presentation/building_form_providers.dart';
 import 'package:firecheck/features/survey/building_form/presentation/override_reason_dialog.dart';
@@ -100,6 +101,7 @@ class _MapScreenState extends ConsumerState<MapScreen> {
                     addModeActive: _addModeActive,
                     initialCameraTarget: initialCameraTarget,
                     cameraTarget: _cameraTarget,
+                    onPolygonLongPress: _handlePolygonLongPress,
                   ),
           ),
           if (_addModeActive)
@@ -216,6 +218,27 @@ class _MapScreenState extends ConsumerState<MapScreen> {
     if (!mounted) return;
     setState(() => _addModeActive = false);
     context.go('/feature/${feature.id}');
+  }
+
+  Future<void> _handlePolygonLongPress(Feature feature) async {
+    if (_addModeActive) return;
+    final l = AppLocalizations.of(context)!;
+    final locked = ref.read(isAssignmentLockedProvider);
+    if (locked) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(l.reshapeLockedSnackbar)));
+      return;
+    }
+    if (!mounted) return;
+    final action = await showReshapeActionSheet(context, locked: locked);
+    if (!mounted || action == null) return;
+    switch (action) {
+      case ReshapeAction.openForm:
+        await _handleFeatureTap(feature);
+      case ReshapeAction.reshape:
+        // Distance gate + enterReshape handled in T19.
+        break;
+    }
   }
 
   Future<void> _handleFeatureTap(Feature f) async {

--- a/lib/features/map/presentation/map_screen.dart
+++ b/lib/features/map/presentation/map_screen.dart
@@ -14,12 +14,15 @@ import 'package:firecheck/features/assignment/presentation/assignment_lock_provi
 import 'package:firecheck/features/assignment/presentation/assignment_providers.dart';
 import 'package:firecheck/features/map/presentation/camera_target.dart';
 import 'package:firecheck/features/map/presentation/map_providers.dart';
+import 'package:firecheck/features/map/presentation/map_renderer.dart';
 import 'package:firecheck/features/map/presentation/recenter_button.dart';
 import 'package:firecheck/features/map/presentation/recenter_button_state.dart';
 import 'package:firecheck/features/map/presentation/zoom_button.dart';
 import 'package:firecheck/features/map/presentation/zoom_button_state.dart';
 import 'package:firecheck/features/map/presentation/zoom_direction.dart';
 import 'package:firecheck/features/map/reshape/presentation/reshape_action_sheet.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_banner.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_overlay.dart';
 import 'package:firecheck/features/map/reshape/presentation/reshape_providers.dart';
 import 'package:firecheck/features/new_feature/presentation/feature_type_picker.dart';
 import 'package:firecheck/features/survey/building_form/presentation/building_form_providers.dart';
@@ -52,12 +55,16 @@ class _MapScreenState extends ConsumerState<MapScreen> {
   double? _commandedZoom;
   Timer? _animationSettleTimer;
 
+  MapProjection? _reshapeProjection;
+
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context)!;
     final renderer = ref.watch(mapRendererProvider);
     final featuresAsync = ref.watch(currentFeaturesProvider);
     final assignmentAsync = ref.watch(currentAssignmentProvider);
+    final reshape = ref.watch(reshapeModeControllerProvider);
+    final reshapeActive = reshape.isActive;
     // Subscribe so the GPS stream is hot from mount, not first tap.
     ref.watch(currentPositionProvider);
 
@@ -103,9 +110,23 @@ class _MapScreenState extends ConsumerState<MapScreen> {
                     initialCameraTarget: initialCameraTarget,
                     cameraTarget: _cameraTarget,
                     onPolygonLongPress: _handlePolygonLongPress,
+                    reshapeWorkingPolygonGeojson: reshapeActive
+                        ? ref
+                            .read(reshapeModeControllerProvider.notifier)
+                            .serializeWorkingPolygon()
+                        : null,
+                    onProjectionReady: (p) {
+                      if (_reshapeProjection != p) {
+                        setState(() => _reshapeProjection = p);
+                      }
+                    },
                   ),
           ),
-          if (_addModeActive)
+          if (reshapeActive && _reshapeProjection != null)
+            Positioned.fill(
+              child: ReshapeOverlay(projection: _reshapeProjection!),
+            ),
+          if (!reshapeActive && _addModeActive)
             Positioned(
               top: 0,
               left: 0,
@@ -150,41 +171,76 @@ class _MapScreenState extends ConsumerState<MapScreen> {
               onTap: _onZoomIn,
             ),
           ),
-          Positioned(
-            left: 12,
-            right: 12,
-            bottom: 18,
-            child: Row(
-              children: [
-                // Scoped Consumer so lock-state stream emissions don't
-                // rebuild the whole map (which would re-mount the Mapbox
-                // renderer and lose its tap handlers — Bug 11, surfaced
-                // during the first manual happy path).
-                Expanded(
-                  child: Consumer(
-                    builder: (context, ref2, _) {
-                      final isLocked =
-                          ref2.watch(isAssignmentLockedProvider);
-                      return _pill(
-                        _addModeActive
-                            ? l.addModePillActiveLabel
-                            : l.newFeaturePlaceholder,
-                        on: _addModeActive,
-                        disabled: isLocked,
-                        key: const Key('map.add-feature-pill'),
-                        onTap: () => setState(
-                          () => _addModeActive = !_addModeActive,
-                        ),
-                      );
-                    },
+          if (!reshapeActive)
+            Positioned(
+              left: 12,
+              right: 12,
+              bottom: 18,
+              child: Row(
+                children: [
+                  // Scoped Consumer so lock-state stream emissions don't
+                  // rebuild the whole map (which would re-mount the Mapbox
+                  // renderer and lose its tap handlers — Bug 11, surfaced
+                  // during the first manual happy path).
+                  Expanded(
+                    child: Consumer(
+                      builder: (context, ref2, _) {
+                        final isLocked =
+                            ref2.watch(isAssignmentLockedProvider);
+                        return _pill(
+                          _addModeActive
+                              ? l.addModePillActiveLabel
+                              : l.newFeaturePlaceholder,
+                          on: _addModeActive,
+                          disabled: isLocked,
+                          key: const Key('map.add-feature-pill'),
+                          onTap: () => setState(
+                            () => _addModeActive = !_addModeActive,
+                          ),
+                        );
+                      },
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
-          ),
+          if (reshapeActive)
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: ReshapeBanner(
+                editCount: reshape.undoStack.length,
+                undoEnabled: reshape.isDirty && !reshape.saving,
+                saveEnabled: reshape.isDirty && !reshape.saving,
+                onCancel: _onReshapeCancel,
+                onUndo: () => ref
+                    .read(reshapeModeControllerProvider.notifier)
+                    .undo(),
+                onSave: _onReshapeSave,
+              ),
+            ),
         ],
       ),
     );
+  }
+
+  void _onReshapeCancel() {
+    final state = ref.read(reshapeModeControllerProvider);
+    final featureId = state.originalFeature?.id ?? '';
+    final ops = state.undoStack.length;
+    ref.read(reshapeModeControllerProvider.notifier).cancel();
+    ref.read(analyticsServiceProvider).track(
+      'map.reshape.cancelled',
+      properties: {
+        'feature_id': featureId,
+        'ops_made': ops,
+      },
+    );
+  }
+
+  Future<void> _onReshapeSave() async {
+    // Implemented in T21.
   }
 
   Future<void> _handleLongPress(double lat, double lng) async {

--- a/lib/features/map/presentation/map_screen.dart
+++ b/lib/features/map/presentation/map_screen.dart
@@ -20,6 +20,7 @@ import 'package:firecheck/features/map/presentation/zoom_button.dart';
 import 'package:firecheck/features/map/presentation/zoom_button_state.dart';
 import 'package:firecheck/features/map/presentation/zoom_direction.dart';
 import 'package:firecheck/features/map/reshape/presentation/reshape_action_sheet.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_providers.dart';
 import 'package:firecheck/features/new_feature/presentation/feature_type_picker.dart';
 import 'package:firecheck/features/survey/building_form/presentation/building_form_providers.dart';
 import 'package:firecheck/features/survey/building_form/presentation/override_reason_dialog.dart';
@@ -236,9 +237,62 @@ class _MapScreenState extends ConsumerState<MapScreen> {
       case ReshapeAction.openForm:
         await _handleFeatureTap(feature);
       case ReshapeAction.reshape:
-        // Distance gate + enterReshape handled in T19.
-        break;
+        await _enterReshape(feature);
     }
+  }
+
+  Future<void> _enterReshape(Feature feature) async {
+    // Distance gate — mirrors _handleFeatureTap; await the resolved position.
+    final pos = await _resolvePosition();
+    if (!mounted) return;
+
+    String? overrideReason;
+    if (pos != null) {
+      final ring = decodePolygonGeojson(feature.geometryGeojson);
+      if (ring == null || ring.isEmpty) return;
+      final centroid = polygonCentroid(ring);
+      final meters = haversineMeters(
+        pos.latitude,
+        pos.longitude,
+        centroid.lat,
+        centroid.lng,
+      );
+      if (meters > 50.0) {
+        if (!mounted) return;
+        overrideReason = await showOverrideReasonDialog(
+          context,
+          distanceMeters: meters,
+        );
+        if (overrideReason == null || overrideReason.trim().isEmpty) {
+          return; // user cancelled or empty
+        }
+      }
+    }
+
+    if (!mounted) return;
+    ref.read(reshapeModeControllerProvider.notifier).enterReshape(
+          feature: feature,
+          overrideReason: overrideReason,
+        );
+
+    ref.read(analyticsServiceProvider).track(
+      'map.reshape.entered',
+      properties: {
+        'feature_id': feature.id,
+        'vertex_count': _vertexCount(feature.geometryGeojson),
+        'override_used': overrideReason != null,
+      },
+    );
+  }
+
+  int _vertexCount(String geojson) {
+    final ring = decodePolygonGeojson(geojson);
+    if (ring == null || ring.isEmpty) return 0;
+    // Strip the duplicated closing vertex if present.
+    if (ring.first[0] == ring.last[0] && ring.first[1] == ring.last[1]) {
+      return ring.length - 1;
+    }
+    return ring.length;
   }
 
   Future<void> _handleFeatureTap(Feature f) async {

--- a/lib/features/map/presentation/map_screen.dart
+++ b/lib/features/map/presentation/map_screen.dart
@@ -60,6 +60,8 @@ class _MapScreenState extends ConsumerState<MapScreen> {
 
   MapProjection? _reshapeProjection;
 
+  bool _lockBlockerShown = false;
+
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context)!;
@@ -70,6 +72,24 @@ class _MapScreenState extends ConsumerState<MapScreen> {
     final reshapeActive = reshape.isActive;
     // Subscribe so the GPS stream is hot from mount, not first tap.
     ref.watch(currentPositionProvider);
+
+    // T22: lock-while-reshape — if the assignment locks while the user is
+    // mid-reshape, dirty edits are blocked behind a non-dismissable dialog
+    // (Exit discards), and a clean session exits silently.
+    final isLocked = ref.watch(isAssignmentLockedProvider);
+    if (reshapeActive && isLocked) {
+      if (reshape.isDirty && !_lockBlockerShown) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          _showLockWhileDirtyBlocker();
+        });
+      } else if (!reshape.isDirty) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          ref.read(reshapeModeControllerProvider.notifier).cancel();
+        });
+      }
+    }
 
     // Bug 13b: don't mount the Mapbox renderer until BOTH the assignment
     // AND the features list have loaded. currentFeaturesProvider returns
@@ -240,6 +260,28 @@ class _MapScreenState extends ConsumerState<MapScreen> {
         'ops_made': ops,
       },
     );
+  }
+
+  Future<void> _showLockWhileDirtyBlocker() async {
+    if (!mounted) return;
+    setState(() => _lockBlockerShown = true);
+    final l = AppLocalizations.of(context)!;
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => AlertDialog(
+        content: Text(l.reshapeLockWhileDirtyBanner),
+        actions: [
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: Text(l.reshapeLockExit),
+          ),
+        ],
+      ),
+    );
+    if (!mounted) return;
+    ref.read(reshapeModeControllerProvider.notifier).cancel();
+    setState(() => _lockBlockerShown = false);
   }
 
   Future<void> _onReshapeSave() async {

--- a/lib/features/map/reshape/data/feature_geometry_revisions_repository.dart
+++ b/lib/features/map/reshape/data/feature_geometry_revisions_repository.dart
@@ -1,0 +1,73 @@
+import 'package:drift/drift.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:uuid/uuid.dart';
+
+class FeatureGeometryRevisionsRepository {
+  FeatureGeometryRevisionsRepository(this._db, {Uuid? uuid})
+      : _uuid = uuid ?? const Uuid();
+
+  final AppDatabase _db;
+  final Uuid _uuid;
+
+  /// Atomically:
+  ///  1. updates `features.geometry_geojson` to [newGeojson]
+  ///  2. inserts a `feature_geometry_revisions` row with status `ready_to_upload`
+  ///  3. inserts a `sync_jobs` row (`entity_type='feature_geometry_update'`, status `pending`)
+  Future<void> saveReshape({
+    required String revisionId,
+    required String featureId,
+    required String prevGeojson,
+    required String newGeojson,
+    required String editedBy,
+    required DateTime editedAt,
+    required String? overrideReason,
+  }) async {
+    await _db.transaction(() async {
+      await (_db.update(_db.features)..where((t) => t.id.equals(featureId)))
+          .write(FeaturesCompanion(geometryGeojson: Value(newGeojson)));
+
+      await _db.into(_db.featureGeometryRevisions).insert(
+            FeatureGeometryRevisionsCompanion.insert(
+              id: revisionId,
+              featureId: featureId,
+              prevGeojson: prevGeojson,
+              newGeojson: newGeojson,
+              editedBy: editedBy,
+              editedAt: editedAt,
+              overrideReason: Value(overrideReason),
+              syncStatus: const Value('ready_to_upload'),
+              createdAt: DateTime.now(),
+            ),
+          );
+
+      await _db.into(_db.syncJobs).insert(
+            SyncJobsCompanion.insert(
+              id: _uuid.v4(),
+              entityType: 'feature_geometry_update',
+              entityId: revisionId,
+              createdAt: DateTime.now(),
+            ),
+          );
+    });
+  }
+
+  Future<FeatureGeometryRevision?> getById(String id) {
+    return (_db.select(_db.featureGeometryRevisions)
+          ..where((t) => t.id.equals(id)))
+        .getSingleOrNull();
+  }
+
+  Future<void> markSynced(String id) async {
+    await (_db.update(_db.featureGeometryRevisions)
+          ..where((t) => t.id.equals(id)))
+        .write(const FeatureGeometryRevisionsCompanion(
+            syncStatus: Value('uploaded')));
+  }
+
+  Future<void> markFailed(String id) async {
+    await (_db.update(_db.featureGeometryRevisions)
+          ..where((t) => t.id.equals(id)))
+        .write(const FeatureGeometryRevisionsCompanion(
+            syncStatus: Value('failed')));
+  }
+}

--- a/lib/features/map/reshape/domain/reshape_mode_state.dart
+++ b/lib/features/map/reshape/domain/reshape_mode_state.dart
@@ -1,0 +1,48 @@
+import 'package:firecheck/core/db/database.dart' show Feature;
+import 'package:firecheck/core/geo/polygon_validator.dart' show LngLat;
+import 'package:firecheck/features/map/reshape/domain/reshape_op.dart';
+
+class ReshapeModeState {
+  const ReshapeModeState({
+    this.originalFeature,
+    this.workingRings = const [],
+    this.undoStack = const [],
+    this.selfIntersects = false,
+    this.saving = false,
+    this.overrideReason,
+  });
+
+  final Feature? originalFeature;
+  final List<List<LngLat>> workingRings;
+  final List<ReshapeOp> undoStack;
+  final bool selfIntersects;
+  final bool saving;
+  final String? overrideReason;
+
+  bool get isActive => originalFeature != null;
+  bool get isDirty => undoStack.isNotEmpty;
+
+  ReshapeModeState copyWith({
+    Object? originalFeature = _sentinel,
+    List<List<LngLat>>? workingRings,
+    List<ReshapeOp>? undoStack,
+    bool? selfIntersects,
+    bool? saving,
+    Object? overrideReason = _sentinel,
+  }) {
+    return ReshapeModeState(
+      originalFeature: identical(originalFeature, _sentinel)
+          ? this.originalFeature
+          : originalFeature as Feature?,
+      workingRings: workingRings ?? this.workingRings,
+      undoStack: undoStack ?? this.undoStack,
+      selfIntersects: selfIntersects ?? this.selfIntersects,
+      saving: saving ?? this.saving,
+      overrideReason: identical(overrideReason, _sentinel)
+          ? this.overrideReason
+          : overrideReason as String?,
+    );
+  }
+
+  static const _sentinel = Object();
+}

--- a/lib/features/map/reshape/domain/reshape_op.dart
+++ b/lib/features/map/reshape/domain/reshape_op.dart
@@ -1,0 +1,36 @@
+import 'package:firecheck/core/geo/polygon_validator.dart' show LngLat;
+
+sealed class ReshapeOp {
+  const ReshapeOp({required this.ringIdx, required this.vertexIdx});
+  final int ringIdx;
+  final int vertexIdx;
+}
+
+class Move extends ReshapeOp {
+  const Move({
+    required super.ringIdx,
+    required super.vertexIdx,
+    required this.prev,
+    required this.next,
+  });
+  final LngLat prev;
+  final LngLat next;
+}
+
+class Add extends ReshapeOp {
+  const Add({
+    required super.ringIdx,
+    required super.vertexIdx,
+    required this.lngLat,
+  });
+  final LngLat lngLat;
+}
+
+class Remove extends ReshapeOp {
+  const Remove({
+    required super.ringIdx,
+    required super.vertexIdx,
+    required this.removed,
+  });
+  final LngLat removed;
+}

--- a/lib/features/map/reshape/presentation/midpoint_handle.dart
+++ b/lib/features/map/reshape/presentation/midpoint_handle.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class MidpointHandle extends StatelessWidget {
+  const MidpointHandle({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 44,
+      height: 44,
+      child: Center(
+        child: Container(
+          width: 10,
+          height: 10,
+          decoration: BoxDecoration(
+            color: const Color(0x993182CE),
+            shape: BoxShape.circle,
+            border: Border.all(color: Colors.white, width: 1.5),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/map/reshape/presentation/reshape_action_sheet.dart
+++ b/lib/features/map/reshape/presentation/reshape_action_sheet.dart
@@ -1,0 +1,50 @@
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+
+enum ReshapeAction { openForm, reshape }
+
+Future<ReshapeAction?> showReshapeActionSheet(
+  BuildContext context, {
+  required bool locked,
+}) {
+  final l = AppLocalizations.of(context)!;
+  return showModalBottomSheet<ReshapeAction>(
+    context: context,
+    builder: (ctx) {
+      return SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              title: Text(
+                l.reshapeActionSheetTitle,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              dense: true,
+            ),
+            ListTile(
+              key: const Key('reshape.actionsheet.openForm'),
+              leading: const Icon(Icons.edit_document),
+              title: Text(l.reshapeActionSheetOpenForm),
+              onTap: () => Navigator.of(ctx).pop(ReshapeAction.openForm),
+            ),
+            ListTile(
+              key: const Key('reshape.actionsheet.reshape'),
+              enabled: !locked,
+              leading: const Icon(Icons.share_location),
+              title: Text(l.reshapeActionSheetReshape),
+              onTap: locked
+                  ? null
+                  : () => Navigator.of(ctx).pop(ReshapeAction.reshape),
+            ),
+            ListTile(
+              leading: const Icon(Icons.close),
+              title: Text(l.cancelLabel),
+              onTap: () => Navigator.of(ctx).pop(),
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}

--- a/lib/features/map/reshape/presentation/reshape_banner.dart
+++ b/lib/features/map/reshape/presentation/reshape_banner.dart
@@ -1,0 +1,86 @@
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+
+class ReshapeBanner extends StatelessWidget {
+  const ReshapeBanner({
+    required this.editCount,
+    required this.undoEnabled,
+    required this.saveEnabled,
+    super.key,
+    this.onCancel,
+    this.onUndo,
+    this.onSave,
+  });
+
+  final int editCount;
+  final bool undoEnabled;
+  final bool saveEnabled;
+  final VoidCallback? onCancel;
+  final VoidCallback? onUndo;
+  final VoidCallback? onSave;
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context)!;
+    return Material(
+      color: const Color(0xFF3182CE),
+      child: SafeArea(
+        bottom: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              child: Row(
+                children: [
+                  TextButton(
+                    key: const Key('reshape.banner.cancel'),
+                    onPressed: onCancel,
+                    style: TextButton.styleFrom(foregroundColor: Colors.white),
+                    child: const Text('Cancel'),
+                  ),
+                  Expanded(
+                    child: Text(
+                      l.reshapeBannerTitle(editCount),
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  FilledButton(
+                    key: const Key('reshape.banner.save'),
+                    onPressed: saveEnabled ? onSave : null,
+                    style: FilledButton.styleFrom(
+                      backgroundColor: Colors.white,
+                      foregroundColor: const Color(0xFF3182CE),
+                      disabledBackgroundColor:
+                          Colors.white.withValues(alpha: 0.4),
+                    ),
+                    child: Text(l.reshapeBannerSave),
+                  ),
+                ],
+              ),
+            ),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(12, 0, 0, 6),
+                child: TextButton.icon(
+                  key: const Key('reshape.banner.undo'),
+                  onPressed: undoEnabled ? onUndo : null,
+                  icon: const Icon(Icons.undo, color: Colors.white, size: 16),
+                  label: const Text(
+                    'Undo',
+                    style: TextStyle(color: Colors.white),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/map/reshape/presentation/reshape_mode_controller.dart
+++ b/lib/features/map/reshape/presentation/reshape_mode_controller.dart
@@ -15,9 +15,6 @@ class ReshapeModeController extends Notifier<ReshapeModeState> {
     state = ReshapeModeState(
       originalFeature: feature,
       workingRings: rings,
-      undoStack: const [],
-      selfIntersects: false,
-      saving: false,
       overrideReason: overrideReason,
     );
   }
@@ -96,7 +93,7 @@ class ReshapeModeController extends Notifier<ReshapeModeState> {
     );
   }
 
-  void markSaving(bool saving) {
+  void markSaving({required bool saving}) {
     state = state.copyWith(saving: saving);
   }
 
@@ -118,6 +115,7 @@ List<List<LngLat>> _parseGeojson(String s) {
       final pair = p as List;
       return (lng: (pair[0] as num).toDouble(), lat: (pair[1] as num).toDouble());
     }).toList();
+    // Strip the duplicated closing vertex if present (open form).
     if (list.length >= 2 && list.first == list.last) {
       list.removeLast();
     }
@@ -126,7 +124,7 @@ List<List<LngLat>> _parseGeojson(String s) {
 }
 
 List<List<LngLat>> _cloneRings(List<List<LngLat>> rings) {
-  return rings.map((r) => List<LngLat>.from(r)).toList();
+  return rings.map(List<LngLat>.from).toList();
 }
 
 bool _hasSelfIntersection(List<LngLat> outer) {

--- a/lib/features/map/reshape/presentation/reshape_mode_controller.dart
+++ b/lib/features/map/reshape/presentation/reshape_mode_controller.dart
@@ -1,0 +1,142 @@
+import 'dart:convert';
+
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/geo/polygon_validator.dart';
+import 'package:firecheck/features/map/reshape/domain/reshape_mode_state.dart';
+import 'package:firecheck/features/map/reshape/domain/reshape_op.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ReshapeModeController extends Notifier<ReshapeModeState> {
+  @override
+  ReshapeModeState build() => const ReshapeModeState();
+
+  void enterReshape({required Feature feature, String? overrideReason}) {
+    final rings = _parseGeojson(feature.geometryGeojson);
+    state = ReshapeModeState(
+      originalFeature: feature,
+      workingRings: rings,
+      undoStack: const [],
+      selfIntersects: false,
+      saving: false,
+      overrideReason: overrideReason,
+    );
+  }
+
+  void cancel() {
+    state = const ReshapeModeState();
+  }
+
+  void moveVertex(int ringIdx, int vertexIdx, LngLat next) {
+    if (!state.isActive) return;
+    final rings = _cloneRings(state.workingRings);
+    final prev = rings[ringIdx][vertexIdx];
+    rings[ringIdx][vertexIdx] = next;
+    final newStack = [
+      ...state.undoStack,
+      Move(ringIdx: ringIdx, vertexIdx: vertexIdx, prev: prev, next: next),
+    ];
+    state = state.copyWith(
+      workingRings: rings,
+      undoStack: newStack,
+      // Latch: once the polygon becomes invalid/degenerate during a drag
+      // sequence, keep the flag set until undo/cancel/enterReshape resets it.
+      selfIntersects: state.selfIntersects || _hasSelfIntersection(rings[0]),
+    );
+  }
+
+  void addVertex(int ringIdx, int vertexIdx, LngLat lngLat) {
+    if (!state.isActive) return;
+    final rings = _cloneRings(state.workingRings);
+    rings[ringIdx].insert(vertexIdx, lngLat);
+    final newStack = [
+      ...state.undoStack,
+      Add(ringIdx: ringIdx, vertexIdx: vertexIdx, lngLat: lngLat),
+    ];
+    state = state.copyWith(
+      workingRings: rings,
+      undoStack: newStack,
+      selfIntersects: state.selfIntersects || _hasSelfIntersection(rings[0]),
+    );
+  }
+
+  void removeVertex(int ringIdx, int vertexIdx) {
+    if (!state.isActive) return;
+    final ring = state.workingRings[ringIdx];
+    if (ring.length <= 3) return;
+    final removed = ring[vertexIdx];
+    final rings = _cloneRings(state.workingRings);
+    rings[ringIdx].removeAt(vertexIdx);
+    final newStack = [
+      ...state.undoStack,
+      Remove(ringIdx: ringIdx, vertexIdx: vertexIdx, removed: removed),
+    ];
+    state = state.copyWith(
+      workingRings: rings,
+      undoStack: newStack,
+      selfIntersects: state.selfIntersects || _hasSelfIntersection(rings[0]),
+    );
+  }
+
+  void undo() {
+    if (state.undoStack.isEmpty) return;
+    final top = state.undoStack.last;
+    final rings = _cloneRings(state.workingRings);
+    switch (top) {
+      case Move():
+        rings[top.ringIdx][top.vertexIdx] = top.prev;
+      case Add():
+        rings[top.ringIdx].removeAt(top.vertexIdx);
+      case Remove():
+        rings[top.ringIdx].insert(top.vertexIdx, top.removed);
+    }
+    state = state.copyWith(
+      workingRings: rings,
+      undoStack: state.undoStack.sublist(0, state.undoStack.length - 1),
+      selfIntersects: _hasSelfIntersection(rings[0]),
+    );
+  }
+
+  void markSaving(bool saving) {
+    state = state.copyWith(saving: saving);
+  }
+
+  /// Serializes the current working copy back to a closed-ring GeoJSON Polygon.
+  String serializeWorkingPolygon() {
+    final rings = state.workingRings.map((r) {
+      final closed = [...r, r.first];
+      return closed.map((v) => [v.lng, v.lat]).toList();
+    }).toList();
+    return jsonEncode({'type': 'Polygon', 'coordinates': rings});
+  }
+}
+
+List<List<LngLat>> _parseGeojson(String s) {
+  final m = jsonDecode(s) as Map<String, dynamic>;
+  final coords = m['coordinates'] as List;
+  return coords.map<List<LngLat>>((ring) {
+    final list = (ring as List).map<LngLat>((p) {
+      final pair = p as List;
+      return (lng: (pair[0] as num).toDouble(), lat: (pair[1] as num).toDouble());
+    }).toList();
+    if (list.length >= 2 && list.first == list.last) {
+      list.removeLast();
+    }
+    return list;
+  }).toList();
+}
+
+List<List<LngLat>> _cloneRings(List<List<LngLat>> rings) {
+  return rings.map((r) => List<LngLat>.from(r)).toList();
+}
+
+bool _hasSelfIntersection(List<LngLat> outer) {
+  // Returns true when the ring is geometrically invalid in any way (transverse
+  // self-intersection, zero area, zero-length edge, etc.).  Used together with
+  // the latch in moveVertex/addVertex/removeVertex: once the polygon becomes
+  // bad during a drag the UI stays red until undo/cancel/enterReshape resets.
+  // World-spanning boundary makes rule 4 a guaranteed pass.
+  const worldBoundary =
+      '{"type":"Polygon","coordinates":[[[-180,-90],[180,-90],[180,90],[-180,90],[-180,-90]]]}';
+  final r = validateBuildingPolygon([outer], boundaryGeojson: worldBoundary);
+  return !r.valid;
+}

--- a/lib/features/map/reshape/presentation/reshape_overlay.dart
+++ b/lib/features/map/reshape/presentation/reshape_overlay.dart
@@ -28,9 +28,17 @@ class ReshapeOverlay extends ConsumerWidget {
         child: GestureDetector(
           key: Key('reshape.vertex.$i'),
           onPanUpdate: (d) {
-            final newScreen = p + d.delta;
-            final newLngLat = projection.lngLatFromScreenPoint(newScreen);
-            notifier.moveVertex(0, i, newLngLat);
+            // Read live vertex position from state, not the build-time `p`.
+            // onPanUpdate fires multiple times per gesture; `d.delta` is the
+            // per-event delta, so adding it to a stale anchor under-tracks
+            // the finger.
+            final cur = ref.read(reshapeModeControllerProvider).workingRings[0];
+            if (i >= cur.length) return;
+            final cv = cur[i];
+            final screen = projection.screenPointFromLngLat(cv.lng, cv.lat);
+            final next = screen + d.delta;
+            final nextLngLat = projection.lngLatFromScreenPoint(next);
+            notifier.moveVertex(0, i, nextLngLat);
           },
           onLongPress: () async {
             final confirm = await showReshapeRemoveConfirm(

--- a/lib/features/map/reshape/presentation/reshape_overlay.dart
+++ b/lib/features/map/reshape/presentation/reshape_overlay.dart
@@ -1,0 +1,79 @@
+import 'package:firecheck/features/map/presentation/map_renderer.dart';
+import 'package:firecheck/features/map/reshape/presentation/midpoint_handle.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_providers.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_remove_confirm_dialog.dart';
+import 'package:firecheck/features/map/reshape/presentation/vertex_handle.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ReshapeOverlay extends ConsumerWidget {
+  const ReshapeOverlay({required this.projection, super.key});
+  final MapProjection projection;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(reshapeModeControllerProvider);
+    if (!state.isActive) return const SizedBox.shrink();
+    final notifier = ref.read(reshapeModeControllerProvider.notifier);
+    final ring = state.workingRings[0];
+
+    final children = <Widget>[];
+
+    for (var i = 0; i < ring.length; i++) {
+      final v = ring[i];
+      final p = projection.screenPointFromLngLat(v.lng, v.lat);
+      children.add(Positioned(
+        left: p.dx - 22,
+        top: p.dy - 22,
+        child: GestureDetector(
+          key: Key('reshape.vertex.$i'),
+          onPanUpdate: (d) {
+            final newScreen = p + d.delta;
+            final newLngLat = projection.lngLatFromScreenPoint(newScreen);
+            notifier.moveVertex(0, i, newLngLat);
+          },
+          onLongPress: () async {
+            final confirm = await showReshapeRemoveConfirm(
+              context,
+              currentRingLength: ring.length,
+            );
+            if (confirm) notifier.removeVertex(0, i);
+          },
+          child: const VertexHandle(),
+        ),
+      ),);
+    }
+
+    for (var i = 0; i < ring.length; i++) {
+      final a = ring[i];
+      final b = ring[(i + 1) % ring.length];
+      final mLng = (a.lng + b.lng) / 2;
+      final mLat = (a.lat + b.lat) / 2;
+      final p = projection.screenPointFromLngLat(mLng, mLat);
+      final insertAt = i + 1;
+      children.add(Positioned(
+        left: p.dx - 22,
+        top: p.dy - 22,
+        child: GestureDetector(
+          key: Key('reshape.midpoint.$i'),
+          onPanStart: (d) {
+            // A2 gesture: insert immediately, then drag with same gesture.
+            notifier.addVertex(0, insertAt, (lng: mLng, lat: mLat));
+          },
+          onPanUpdate: (d) {
+            final cur = ref.read(reshapeModeControllerProvider).workingRings[0];
+            if (insertAt >= cur.length) return;
+            final v = cur[insertAt];
+            final screen = projection.screenPointFromLngLat(v.lng, v.lat);
+            final next = screen + d.delta;
+            final nextLngLat = projection.lngLatFromScreenPoint(next);
+            notifier.moveVertex(0, insertAt, nextLngLat);
+          },
+          child: const MidpointHandle(),
+        ),
+      ),);
+    }
+
+    return Stack(children: children);
+  }
+}

--- a/lib/features/map/reshape/presentation/reshape_providers.dart
+++ b/lib/features/map/reshape/presentation/reshape_providers.dart
@@ -1,0 +1,15 @@
+import 'package:firecheck/features/home/presentation/home_providers.dart';
+import 'package:firecheck/features/map/reshape/data/feature_geometry_revisions_repository.dart';
+import 'package:firecheck/features/map/reshape/domain/reshape_mode_state.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_mode_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final reshapeModeControllerProvider =
+    NotifierProvider<ReshapeModeController, ReshapeModeState>(
+  ReshapeModeController.new,
+);
+
+final reshapeRepositoryProvider =
+    Provider<FeatureGeometryRevisionsRepository>((ref) {
+  return FeatureGeometryRevisionsRepository(ref.watch(appDatabaseProvider));
+});

--- a/lib/features/map/reshape/presentation/reshape_remove_confirm_dialog.dart
+++ b/lib/features/map/reshape/presentation/reshape_remove_confirm_dialog.dart
@@ -1,0 +1,36 @@
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+
+Future<bool> showReshapeRemoveConfirm(
+  BuildContext context, {
+  required int currentRingLength,
+}) async {
+  final l = AppLocalizations.of(context)!;
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (ctx) {
+      final canConfirm = currentRingLength > 3;
+      return AlertDialog(
+        title: Text(l.reshapeRemoveConfirmTitle),
+        content: Text(l.reshapeRemoveConfirmBody),
+        actions: [
+          TextButton(
+            key: const Key('reshape.remove.cancel'),
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(l.cancelLabel),
+          ),
+          FilledButton(
+            key: const Key('reshape.remove.confirm'),
+            onPressed:
+                canConfirm ? () => Navigator.of(ctx).pop(true) : null,
+            style: FilledButton.styleFrom(
+              backgroundColor: const Color(0xFFC53030),
+            ),
+            child: Text(l.reshapeRemoveConfirmRemove),
+          ),
+        ],
+      );
+    },
+  );
+  return result ?? false;
+}

--- a/lib/features/map/reshape/presentation/vertex_handle.dart
+++ b/lib/features/map/reshape/presentation/vertex_handle.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class VertexHandle extends StatelessWidget {
+  const VertexHandle({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 44,
+      height: 44,
+      child: Center(
+        child: Container(
+          width: 14,
+          height: 14,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            shape: BoxShape.circle,
+            border: Border.all(color: const Color(0xFF3182CE), width: 2),
+            boxShadow: const [
+              BoxShadow(blurRadius: 3, color: Color(0x66000000)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/generated/l10n/app_localizations.dart
+++ b/lib/generated/l10n/app_localizations.dart
@@ -1831,6 +1831,102 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Zoom out'**
   String get zoomOutButtonSemanticLabel;
+
+  /// No description provided for @reshapeActionSheetTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Building polygon'**
+  String get reshapeActionSheetTitle;
+
+  /// No description provided for @reshapeActionSheetOpenForm.
+  ///
+  /// In en, this message translates to:
+  /// **'Open form'**
+  String get reshapeActionSheetOpenForm;
+
+  /// No description provided for @reshapeActionSheetReshape.
+  ///
+  /// In en, this message translates to:
+  /// **'Reshape'**
+  String get reshapeActionSheetReshape;
+
+  /// No description provided for @reshapeBannerTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Reshape • {count} edits'**
+  String reshapeBannerTitle(int count);
+
+  /// No description provided for @reshapeBannerSave.
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get reshapeBannerSave;
+
+  /// No description provided for @reshapeRemoveConfirmTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove vertex?'**
+  String get reshapeRemoveConfirmTitle;
+
+  /// No description provided for @reshapeRemoveConfirmBody.
+  ///
+  /// In en, this message translates to:
+  /// **'You can undo this from the banner.'**
+  String get reshapeRemoveConfirmBody;
+
+  /// No description provided for @reshapeRemoveConfirmRemove.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove'**
+  String get reshapeRemoveConfirmRemove;
+
+  /// No description provided for @reshapeErrorTooFewVertices.
+  ///
+  /// In en, this message translates to:
+  /// **'Polygon must have at least 3 vertices'**
+  String get reshapeErrorTooFewVertices;
+
+  /// No description provided for @reshapeErrorZeroArea.
+  ///
+  /// In en, this message translates to:
+  /// **'Polygon area is too small'**
+  String get reshapeErrorZeroArea;
+
+  /// No description provided for @reshapeErrorSelfIntersection.
+  ///
+  /// In en, this message translates to:
+  /// **'Edges cannot cross. Tap Undo or move a corner.'**
+  String get reshapeErrorSelfIntersection;
+
+  /// No description provided for @reshapeErrorOutsideBoundary.
+  ///
+  /// In en, this message translates to:
+  /// **'Some vertices are outside the assignment area'**
+  String get reshapeErrorOutsideBoundary;
+
+  /// No description provided for @reshapeErrorZeroLengthEdge.
+  ///
+  /// In en, this message translates to:
+  /// **'Adjacent corners cannot be on the same spot'**
+  String get reshapeErrorZeroLengthEdge;
+
+  /// No description provided for @reshapeLockedSnackbar.
+  ///
+  /// In en, this message translates to:
+  /// **'Assignment is closed; reshape unavailable'**
+  String get reshapeLockedSnackbar;
+
+  /// No description provided for @reshapeLockWhileDirtyBanner.
+  ///
+  /// In en, this message translates to:
+  /// **'Assignment was closed by supervisor — your edits cannot be saved'**
+  String get reshapeLockWhileDirtyBanner;
+
+  /// No description provided for @reshapeLockExit.
+  ///
+  /// In en, this message translates to:
+  /// **'Exit'**
+  String get reshapeLockExit;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/generated/l10n/app_localizations_en.dart
+++ b/lib/generated/l10n/app_localizations_en.dart
@@ -949,4 +949,60 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get zoomOutButtonSemanticLabel => 'Zoom out';
+
+  @override
+  String get reshapeActionSheetTitle => 'Building polygon';
+
+  @override
+  String get reshapeActionSheetOpenForm => 'Open form';
+
+  @override
+  String get reshapeActionSheetReshape => 'Reshape';
+
+  @override
+  String reshapeBannerTitle(int count) {
+    return 'Reshape • $count edits';
+  }
+
+  @override
+  String get reshapeBannerSave => 'Save';
+
+  @override
+  String get reshapeRemoveConfirmTitle => 'Remove vertex?';
+
+  @override
+  String get reshapeRemoveConfirmBody => 'You can undo this from the banner.';
+
+  @override
+  String get reshapeRemoveConfirmRemove => 'Remove';
+
+  @override
+  String get reshapeErrorTooFewVertices =>
+      'Polygon must have at least 3 vertices';
+
+  @override
+  String get reshapeErrorZeroArea => 'Polygon area is too small';
+
+  @override
+  String get reshapeErrorSelfIntersection =>
+      'Edges cannot cross. Tap Undo or move a corner.';
+
+  @override
+  String get reshapeErrorOutsideBoundary =>
+      'Some vertices are outside the assignment area';
+
+  @override
+  String get reshapeErrorZeroLengthEdge =>
+      'Adjacent corners cannot be on the same spot';
+
+  @override
+  String get reshapeLockedSnackbar =>
+      'Assignment is closed; reshape unavailable';
+
+  @override
+  String get reshapeLockWhileDirtyBanner =>
+      'Assignment was closed by supervisor — your edits cannot be saved';
+
+  @override
+  String get reshapeLockExit => 'Exit';
 }

--- a/lib/generated/l10n/app_localizations_tl.dart
+++ b/lib/generated/l10n/app_localizations_tl.dart
@@ -974,4 +974,60 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get zoomOutButtonSemanticLabel => 'Zoom out';
+
+  @override
+  String get reshapeActionSheetTitle => 'Building polygon';
+
+  @override
+  String get reshapeActionSheetOpenForm => 'Open form';
+
+  @override
+  String get reshapeActionSheetReshape => 'Reshape';
+
+  @override
+  String reshapeBannerTitle(int count) {
+    return 'Reshape • $count edits';
+  }
+
+  @override
+  String get reshapeBannerSave => 'Save';
+
+  @override
+  String get reshapeRemoveConfirmTitle => 'Remove vertex?';
+
+  @override
+  String get reshapeRemoveConfirmBody => 'You can undo this from the banner.';
+
+  @override
+  String get reshapeRemoveConfirmRemove => 'Remove';
+
+  @override
+  String get reshapeErrorTooFewVertices =>
+      'Polygon must have at least 3 vertices';
+
+  @override
+  String get reshapeErrorZeroArea => 'Polygon area is too small';
+
+  @override
+  String get reshapeErrorSelfIntersection =>
+      'Edges cannot cross. Tap Undo or move a corner.';
+
+  @override
+  String get reshapeErrorOutsideBoundary =>
+      'Some vertices are outside the assignment area';
+
+  @override
+  String get reshapeErrorZeroLengthEdge =>
+      'Adjacent corners cannot be on the same spot';
+
+  @override
+  String get reshapeLockedSnackbar =>
+      'Assignment is closed; reshape unavailable';
+
+  @override
+  String get reshapeLockWhileDirtyBanner =>
+      'Assignment was closed by supervisor — your edits cannot be saved';
+
+  @override
+  String get reshapeLockExit => 'Exit';
 }

--- a/supabase/migrations/011_feature_geometry_updates.sql
+++ b/supabase/migrations/011_feature_geometry_updates.sql
@@ -1,0 +1,79 @@
+-- US-9 reshape: feature_geometry_revisions table + update_feature_geometry RPC
+
+create table public.feature_geometry_revisions (
+  id              uuid primary key,
+  feature_id      uuid not null references public.features(id) on delete cascade,
+  edited_by       uuid references public.enumerators(id) on delete set null,
+  prev_geometry   geography(Geometry, 4326) not null,
+  new_geometry    geography(Geometry, 4326) not null,
+  edited_at       timestamptz not null,
+  override_reason text,
+  created_at      timestamptz not null default now()
+);
+
+create index on public.feature_geometry_revisions (feature_id);
+create index on public.feature_geometry_revisions (edited_by);
+
+alter table public.feature_geometry_revisions enable row level security;
+
+create policy fgr_enum_insert on public.feature_geometry_revisions
+  for insert with check (
+    exists (
+      select 1 from public.features f
+      join public.assignments a on a.id = f.assignment_id
+      where f.id = feature_id and a.enumerator_id = auth.uid()
+    )
+  );
+create policy fgr_enum_select on public.feature_geometry_revisions
+  for select using (
+    exists (
+      select 1 from public.features f
+      join public.assignments a on a.id = f.assignment_id
+      where f.id = feature_id and a.enumerator_id = auth.uid()
+    )
+  );
+
+create or replace function public.update_feature_geometry(
+  p_revision_id    uuid,
+  p_feature_id     uuid,
+  p_prev_geojson   text,
+  p_new_geojson    text,
+  p_edited_at      timestamptz,
+  p_override_reason text
+) returns void
+language plpgsql
+security definer
+as $$
+declare
+  v_current geography;
+  v_prev    geography;
+  v_new     geography;
+begin
+  if not exists (
+    select 1 from public.features f
+    join public.assignments a on a.id = f.assignment_id
+    where f.id = p_feature_id and a.enumerator_id = auth.uid()
+  ) then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  v_prev := st_geogfromgeojson(p_prev_geojson);
+  v_new  := st_geogfromgeojson(p_new_geojson);
+
+  select geometry into v_current from public.features
+    where id = p_feature_id for update;
+
+  if not st_equals(v_current::geometry, v_prev::geometry) then
+    raise exception 'geometry_conflict' using errcode = 'P0001';
+  end if;
+
+  insert into public.feature_geometry_revisions
+    (id, feature_id, edited_by, prev_geometry, new_geometry, edited_at, override_reason)
+  values
+    (p_revision_id, p_feature_id, auth.uid(), v_prev, v_new, p_edited_at, p_override_reason);
+
+  update public.features set geometry = v_new where id = p_feature_id;
+end;
+$$;
+
+grant execute on function public.update_feature_geometry to authenticated;

--- a/test/core/db/database_test.dart
+++ b/test/core/db/database_test.dart
@@ -44,9 +44,9 @@ void main() {
       expect(db.schemaVersion, greaterThanOrEqualTo(3));
     });
 
-    test('the DB registers exactly the 11 expected tables', () {
+    test('the DB registers exactly the 12 expected tables', () {
       final names = db.allTables.map((t) => t.actualTableName).toSet();
-      expect(names, hasLength(11));
+      expect(names, hasLength(12));
       expect(
         names,
         equals({
@@ -61,6 +61,7 @@ void main() {
           'ra_9514_types',
           'sync_jobs',
           'offline_tile_packs',
+          'feature_geometry_revisions',
         }),
       );
     });

--- a/test/core/db/feature_geometry_revisions_test.dart
+++ b/test/core/db/feature_geometry_revisions_test.dart
@@ -1,0 +1,99 @@
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/features/map/reshape/data/feature_geometry_revisions_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase db;
+  late FeatureGeometryRevisionsRepository repo;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = FeatureGeometryRevisionsRepository(db);
+
+    // Seed one assignment + one feature so the FK on revisions is satisfied
+    // and the geometry update has something to update.
+    await db.into(db.assignments).insert(
+      AssignmentsCompanion.insert(
+        id: 'a1',
+        enumeratorId: 'e1',
+        campaignId: 'c1',
+        boundaryPolygonGeojson: '{}',
+        createdAt: DateTime.utc(2026, 1, 1),
+      ),
+    );
+    await db.into(db.features).insert(
+      FeaturesCompanion.insert(
+        id: 'f1',
+        assignmentId: 'a1',
+        featureType: 'building',
+        geometryGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[0,1],[0,0]]]}',
+        createdAt: DateTime.utc(2026, 1, 1),
+      ),
+    );
+  });
+
+  tearDown(() => db.close());
+
+  test('saveReshape writes feature update + revision row + sync_job atomically', () async {
+    const newGeojson = '{"type":"Polygon","coordinates":[[[0,0],[2,0],[0,2],[0,0]]]}';
+
+    await repo.saveReshape(
+      revisionId: 'r1',
+      featureId: 'f1',
+      prevGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[0,1],[0,0]]]}',
+      newGeojson: newGeojson,
+      editedBy: 'e1',
+      editedAt: DateTime.utc(2026, 4, 29, 12, 0),
+      overrideReason: null,
+    );
+
+    final feature = await (db.select(db.features)
+          ..where((t) => t.id.equals('f1')))
+        .getSingle();
+    expect(feature.geometryGeojson, newGeojson);
+
+    final revisions = await db.select(db.featureGeometryRevisions).get();
+    expect(revisions, hasLength(1));
+    expect(revisions.first.id, 'r1');
+    expect(revisions.first.syncStatus, 'ready_to_upload');
+    expect(revisions.first.overrideReason, isNull);
+
+    final jobs = await db.select(db.syncJobs).get();
+    expect(jobs, hasLength(1));
+    expect(jobs.first.entityType, 'feature_geometry_update');
+    expect(jobs.first.entityId, 'r1');
+    expect(jobs.first.status, 'pending');
+  });
+
+  test('saveReshape persists overrideReason when provided', () async {
+    await repo.saveReshape(
+      revisionId: 'r2',
+      featureId: 'f1',
+      prevGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[0,1],[0,0]]]}',
+      newGeojson:  '{"type":"Polygon","coordinates":[[[0,0],[2,0],[0,2],[0,0]]]}',
+      editedBy: 'e1',
+      editedAt: DateTime.utc(2026, 4, 29, 12, 0),
+      overrideReason: 'corner visible from sidewalk',
+    );
+
+    final revisions = await db.select(db.featureGeometryRevisions).get();
+    expect(revisions.first.overrideReason, 'corner visible from sidewalk');
+  });
+
+  test('getById returns the revision', () async {
+    await repo.saveReshape(
+      revisionId: 'r3',
+      featureId: 'f1',
+      prevGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[0,1],[0,0]]]}',
+      newGeojson:  '{"type":"Polygon","coordinates":[[[0,0],[2,0],[0,2],[0,0]]]}',
+      editedBy: 'e1',
+      editedAt: DateTime.utc(2026, 4, 29, 12, 0),
+      overrideReason: null,
+    );
+
+    final found = await repo.getById('r3');
+    expect(found, isNotNull);
+    expect(found!.featureId, 'f1');
+  });
+}

--- a/test/core/db/feature_geometry_revisions_test.dart
+++ b/test/core/db/feature_geometry_revisions_test.dart
@@ -96,4 +96,84 @@ void main() {
     expect(found, isNotNull);
     expect(found!.featureId, 'f1');
   });
+
+  test('saveReshape rolls back all writes when revision insert fails', () async {
+    // Pre-insert a row with revisionId='r4' so the second write throws a UNIQUE constraint.
+    await db.into(db.featureGeometryRevisions).insert(
+          FeatureGeometryRevisionsCompanion.insert(
+            id: 'r4',
+            featureId: 'f1',
+            prevGeojson: '{}',
+            newGeojson: '{}',
+            editedBy: 'e1',
+            editedAt: DateTime.utc(2026, 4, 29),
+            createdAt: DateTime.utc(2026, 4, 29),
+          ),
+        );
+
+    final originalGeo = (await (db.select(db.features)
+              ..where((t) => t.id.equals('f1')))
+            .getSingle())
+        .geometryGeojson;
+
+    await expectLater(
+      repo.saveReshape(
+        revisionId: 'r4', // collides on PK
+        featureId: 'f1',
+        prevGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[0,1],[0,0]]]}',
+        newGeojson:  '{"type":"Polygon","coordinates":[[[0,0],[3,0],[0,3],[0,0]]]}',
+        editedBy: 'e1',
+        editedAt: DateTime.utc(2026, 4, 29, 13),
+        overrideReason: null,
+      ),
+      throwsA(anything),
+    );
+
+    // features.geometry_geojson must NOT have been updated.
+    final feature = await (db.select(db.features)
+          ..where((t) => t.id.equals('f1')))
+        .getSingle();
+    expect(feature.geometryGeojson, originalGeo);
+
+    // No sync_job inserted from the failed call.
+    final jobs = await db.select(db.syncJobs).get();
+    expect(jobs, isEmpty);
+
+    // Only the pre-seeded revision row remains.
+    final revs = await db.select(db.featureGeometryRevisions).get();
+    expect(revs, hasLength(1));
+    expect(revs.first.id, 'r4');
+  });
+
+  test('markSynced flips syncStatus to uploaded', () async {
+    await repo.saveReshape(
+      revisionId: 'r5',
+      featureId: 'f1',
+      prevGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[0,1],[0,0]]]}',
+      newGeojson:  '{"type":"Polygon","coordinates":[[[0,0],[2,0],[0,2],[0,0]]]}',
+      editedBy: 'e1',
+      editedAt: DateTime.utc(2026, 4, 29),
+      overrideReason: null,
+    );
+
+    await repo.markSynced('r5');
+    final r = await repo.getById('r5');
+    expect(r!.syncStatus, 'uploaded');
+  });
+
+  test('markFailed flips syncStatus to failed', () async {
+    await repo.saveReshape(
+      revisionId: 'r6',
+      featureId: 'f1',
+      prevGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[0,1],[0,0]]]}',
+      newGeojson:  '{"type":"Polygon","coordinates":[[[0,0],[2,0],[0,2],[0,0]]]}',
+      editedBy: 'e1',
+      editedAt: DateTime.utc(2026, 4, 29),
+      overrideReason: null,
+    );
+
+    await repo.markFailed('r6');
+    final r = await repo.getById('r6');
+    expect(r!.syncStatus, 'failed');
+  });
 }

--- a/test/core/geo/polygon_validator_test.dart
+++ b/test/core/geo/polygon_validator_test.dart
@@ -1,0 +1,59 @@
+import 'package:firecheck/core/geo/polygon_validator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // Brgy. Tisa rectangle (reused throughout the project — see
+  // override_check_test.dart). All vertices well inside this boundary.
+  const boundary = '''
+{"type":"Polygon","coordinates":[[
+  [123.870,10.310],[123.890,10.310],[123.890,10.330],[123.870,10.330],[123.870,10.310]
+]]}''';
+
+  group('rule 1 — tooFewVertices', () {
+    test('passes with 3 unique vertices', () {
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.881, lat: 10.320),
+            (lng: 123.880, lat: 10.321),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isTrue);
+      expect(result.error, isNull);
+    });
+
+    test('fails with 2 unique vertices', () {
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.881, lat: 10.320),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isFalse);
+      expect(result.error, PolygonValidationError.tooFewVertices);
+    });
+  });
+
+  group('rule 2 — zeroOrNegativeArea', () {
+    test('fails for colinear vertices', () {
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.881, lat: 10.320),
+            (lng: 123.882, lat: 10.320),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isFalse);
+      expect(result.error, PolygonValidationError.zeroOrNegativeArea);
+    });
+  });
+}

--- a/test/core/geo/polygon_validator_test.dart
+++ b/test/core/geo/polygon_validator_test.dart
@@ -56,4 +56,62 @@ void main() {
       expect(result.error, PolygonValidationError.zeroOrNegativeArea);
     });
   });
+
+  group('rule 3 — selfIntersection', () {
+    test('passes for a simple convex quad', () {
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.881, lat: 10.320),
+            (lng: 123.881, lat: 10.321),
+            (lng: 123.880, lat: 10.321),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isTrue);
+    });
+
+    test('fails for a bowtie (4 vertices crossing)', () {
+      // Vertices ordered so edges 0-1 and 2-3 cross.
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.881, lat: 10.321),
+            (lng: 123.881, lat: 10.320),
+            (lng: 123.880, lat: 10.321),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isFalse);
+      expect(result.error, PolygonValidationError.selfIntersection);
+      expect(result.intersectingEdges, isNotNull);
+      expect(result.intersectingEdges!.isNotEmpty, isTrue);
+      // Bowtie edge pairs in this 4-vertex layout: (0,2).
+      expect(
+        result.intersectingEdges!.any(
+          (e) => (e.aStart == 0 && e.bStart == 2) || (e.aStart == 2 && e.bStart == 0),
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not report adjacent edges as intersecting', () {
+      // Plain triangle — adjacent edges share endpoints, must not flag.
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.881, lat: 10.320),
+            (lng: 123.880, lat: 10.321),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isTrue);
+    });
+  });
 }

--- a/test/core/geo/polygon_validator_test.dart
+++ b/test/core/geo/polygon_validator_test.dart
@@ -181,7 +181,7 @@ void main() {
   });
 
   group('rule ordering', () {
-    test('returns rule 1 when polygon also fails rule 3', () {
+    test('returns rule 1 when polygon also fails rule 5', () {
       // 2 vertices fails rule 1; can't fail rule 3 simultaneously, so build
       // a case that fails rule 1 + rule 5. Two vertices, both coincident.
       final result = validateBuildingPolygon(

--- a/test/core/geo/polygon_validator_test.dart
+++ b/test/core/geo/polygon_validator_test.dart
@@ -114,4 +114,86 @@ void main() {
       expect(result.valid, isTrue);
     });
   });
+
+  group('rule 4 — vertexOutsideBoundary', () {
+    test('passes when all vertices are inside boundary', () {
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.881, lat: 10.320),
+            (lng: 123.880, lat: 10.321),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isTrue);
+    });
+
+    test('fails when one vertex is outside boundary', () {
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 124.000, lat: 10.320), // way outside
+            (lng: 123.880, lat: 10.321),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isFalse);
+      expect(result.error, PolygonValidationError.vertexOutsideBoundary);
+    });
+  });
+
+  group('rule 5 — zeroLengthEdge', () {
+    test('fails when two adjacent vertices are coincident', () {
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.880, lat: 10.320), // duplicate
+            (lng: 123.881, lat: 10.320),
+            (lng: 123.880, lat: 10.321),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isFalse);
+      expect(result.error, PolygonValidationError.zeroLengthEdge);
+    });
+
+    test('passes when adjacent vertices are 1cm apart (above epsilon)', () {
+      // ~1e-7 degrees is ~1cm at the equator — well above 1e-9 epsilon.
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.8800001, lat: 10.320), // 1cm east
+            (lng: 123.881, lat: 10.320),
+            (lng: 123.880, lat: 10.321),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.valid, isTrue);
+    });
+  });
+
+  group('rule ordering', () {
+    test('returns rule 1 when polygon also fails rule 3', () {
+      // 2 vertices fails rule 1; can't fail rule 3 simultaneously, so build
+      // a case that fails rule 1 + rule 5. Two vertices, both coincident.
+      final result = validateBuildingPolygon(
+        [
+          [
+            (lng: 123.880, lat: 10.320),
+            (lng: 123.880, lat: 10.320),
+          ],
+        ],
+        boundaryGeojson: boundary,
+      );
+      expect(result.error, PolygonValidationError.tooFewVertices);
+    });
+  });
 }

--- a/test/core/sync/worker/feature_geometry_update_sync_test.dart
+++ b/test/core/sync/worker/feature_geometry_update_sync_test.dart
@@ -1,0 +1,112 @@
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/data/fake_sync_api.dart';
+import 'package:firecheck/core/sync/data/submission_payload_builder.dart';
+import 'package:firecheck/core/sync/data/sync_jobs_repository.dart';
+import 'package:firecheck/core/sync/domain/sync_job_status.dart';
+import 'package:firecheck/core/sync/domain/sync_outcome.dart';
+import 'package:firecheck/core/sync/failure/assignment_lock_repository.dart';
+import 'package:firecheck/core/sync/worker/sync_worker.dart';
+import 'package:firecheck/features/map/reshape/data/feature_geometry_revisions_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase db;
+  late SyncJobsRepository jobs;
+  late SubmissionPayloadBuilder payload;
+  late AssignmentLockRepository lock;
+  late FakeSyncApi api;
+  late SyncWorker worker;
+  late FeatureGeometryRevisionsRepository revRepo;
+
+  const revisionId = 'rev-1';
+  const featureId = 'f1';
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    jobs = SyncJobsRepository(db);
+    payload = SubmissionPayloadBuilder(db);
+    lock = AssignmentLockRepository(db);
+    api = FakeSyncApi();
+    worker = SyncWorker(api: api, jobs: jobs, payload: payload, lock: lock, db: db);
+    revRepo = FeatureGeometryRevisionsRepository(db);
+
+    final now = DateTime.now();
+    await db.into(db.assignments).insert(
+          AssignmentsCompanion.insert(
+            id: 'a1',
+            enumeratorId: 'admin',
+            campaignId: 'c1',
+            boundaryPolygonGeojson: '{}',
+            createdAt: now,
+          ),
+        );
+    await db.into(db.features).insert(
+          FeaturesCompanion.insert(
+            id: featureId,
+            assignmentId: 'a1',
+            featureType: 'building',
+            geometryGeojson: '{"old":true}',
+            createdAt: now,
+          ),
+        );
+  });
+
+  tearDown(() async => db.close());
+
+  Future<void> seedRevision() async {
+    await revRepo.saveReshape(
+      revisionId: revisionId,
+      featureId: featureId,
+      prevGeojson: '{"old":true}',
+      newGeojson: '{"new":true}',
+      editedBy: 'admin',
+      editedAt: DateTime.now(),
+      overrideReason: null,
+    );
+  }
+
+  test(
+    'success: revision.syncStatus == uploaded, sync_job.status == success',
+    () async {
+      await seedRevision();
+
+      // No enqueue needed — FakeSyncApi defaults to Success.
+      await worker.drain();
+
+      final rev = await revRepo.getById(revisionId);
+      expect(rev, isNotNull);
+      expect(rev!.syncStatus, 'uploaded');
+
+      final job = await jobs.findByEntity('feature_geometry_update', revisionId);
+      expect(job, isNotNull);
+      expect(job!.status, SyncJobStatus.success);
+
+      expect(api.uploadFeatureGeometryUpdateCalls, hasLength(1));
+      expect(api.uploadFeatureGeometryUpdateCalls.first.id, revisionId);
+    },
+  );
+
+  test(
+    'permanent failure: revision.syncStatus == failed, sync_job.status == dead',
+    () async {
+      await seedRevision();
+
+      api.enqueueFeatureGeometryUpdate(
+          const PermanentFailure('geometry_conflict'),);
+
+      await worker.drain();
+
+      final rev = await revRepo.getById(revisionId);
+      expect(rev, isNotNull);
+      expect(rev!.syncStatus, 'failed');
+
+      final job = await jobs.findByEntity('feature_geometry_update', revisionId);
+      expect(job, isNotNull);
+      expect(job!.status, SyncJobStatus.dead);
+
+      expect(api.uploadFeatureGeometryUpdateCalls, hasLength(1));
+      expect(api.uploadFeatureGeometryUpdateCalls.first.id, revisionId);
+    },
+  );
+}

--- a/test/features/map/map_screen_reshape_test.dart
+++ b/test/features/map/map_screen_reshape_test.dart
@@ -71,6 +71,7 @@ Future<ProviderContainer> pumpMap(
   AnalyticsService? analytics,
   Stream<Position>? positionStream,
   AppDatabase? db,
+  ValueNotifier<bool>? lockNotifier,
 }) async {
   final container = ProviderContainer(
     overrides: [
@@ -84,6 +85,15 @@ Future<ProviderContainer> pumpMap(
       currentFeaturesProvider.overrideWith((_) => Stream.value(features)),
       currentAssignmentProvider.overrideWith((_) => Stream.value(fakeAssignment())),
       assignmentLockStateProvider.overrideWith((_) => Stream.value(const Unlocked())),
+      // For lock-blocker tests, route the synchronous bool through a
+      // mutable ValueNotifier so the test can flip the lock mid-flight.
+      if (lockNotifier != null)
+        isAssignmentLockedProvider.overrideWith((ref) {
+          void listener() => ref.invalidateSelf();
+          lockNotifier.addListener(listener);
+          ref.onDispose(() => lockNotifier.removeListener(listener));
+          return lockNotifier.value;
+        }),
       currentPositionProvider.overrideWith(
         (_) => positionStream ?? const Stream<Position>.empty(),
       ),
@@ -401,6 +411,84 @@ void main() {
             e.event == 'map.reshape.validation_failed' &&
             e.properties?['rule'] == 'selfIntersection',),
         isTrue,
+      );
+    });
+  });
+
+  group('US-9 T22 lock-while-reshape blocker', () {
+    testWidgets('lock-while-dirty shows non-dismissable dialog; Exit discards',
+        (tester) async {
+      final lockNotifier = ValueNotifier<bool>(false);
+      addTearDown(lockNotifier.dispose);
+      final fake = FakeMapRenderer();
+      final container = await pumpMap(
+        tester,
+        renderer: fake,
+        positionStream: Stream.value(fakePos(lat: 10.3180, lng: 123.8830)),
+        features: [fakeFeature()],
+        lockNotifier: lockNotifier,
+      );
+
+      await fake.simulatePolygonLongPress(fakeFeature());
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+      await tester.pumpAndSettle();
+
+      // Make at least one edit so state.isDirty == true.
+      container.read(reshapeModeControllerProvider.notifier).moveVertex(
+            0,
+            0,
+            (lng: 123.8835, lat: 10.3185),
+          );
+      await tester.pumpAndSettle();
+
+      // Trigger lock mid-reshape.
+      lockNotifier.value = true;
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Assignment was closed'), findsOneWidget);
+      // Exit button text comes from l.reshapeLockExit ('Exit').
+      await tester.tap(find.text('Exit'));
+      await tester.pumpAndSettle();
+
+      // Reshape exited; banner gone.
+      expect(find.byKey(const Key('reshape.banner.save')), findsNothing);
+      expect(
+        container.read(reshapeModeControllerProvider).isActive,
+        isFalse,
+      );
+    });
+
+    testWidgets('lock-while-clean exits silently (no dialog)',
+        (tester) async {
+      final lockNotifier = ValueNotifier<bool>(false);
+      addTearDown(lockNotifier.dispose);
+      final fake = FakeMapRenderer();
+      final container = await pumpMap(
+        tester,
+        renderer: fake,
+        positionStream: Stream.value(fakePos(lat: 10.3180, lng: 123.8830)),
+        features: [fakeFeature()],
+        lockNotifier: lockNotifier,
+      );
+
+      await fake.simulatePolygonLongPress(fakeFeature());
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+      await tester.pumpAndSettle();
+
+      // No edits made — state.isDirty == false.
+
+      // Trigger lock.
+      lockNotifier.value = true;
+      await tester.pumpAndSettle();
+
+      // No dialog.
+      expect(find.textContaining('Assignment was closed'), findsNothing);
+      // Reshape exited silently.
+      expect(
+        container.read(reshapeModeControllerProvider).isActive,
+        isFalse,
       );
     });
   });

--- a/test/features/map/map_screen_reshape_test.dart
+++ b/test/features/map/map_screen_reshape_test.dart
@@ -1,11 +1,14 @@
+import 'package:drift/native.dart';
 import 'package:firecheck/core/analytics/analytics_providers.dart';
 import 'package:firecheck/core/analytics/analytics_service.dart';
+import 'package:firecheck/core/auth/current_user_provider.dart';
 import 'package:firecheck/core/db/database.dart';
 import 'package:firecheck/core/location/location_providers.dart';
 import 'package:firecheck/core/location/location_service.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_lock_providers.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_lock_state.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_providers.dart';
+import 'package:firecheck/features/home/presentation/home_providers.dart';
 import 'package:firecheck/features/map/presentation/map_providers.dart';
 import 'package:firecheck/features/map/presentation/map_renderer.dart';
 import 'package:firecheck/features/map/presentation/map_screen.dart';
@@ -67,13 +70,17 @@ Future<ProviderContainer> pumpMap(
   List<Feature> features = const [],
   AnalyticsService? analytics,
   Stream<Position>? positionStream,
+  AppDatabase? db,
 }) async {
   final container = ProviderContainer(
     overrides: [
       mapRendererProvider.overrideWithValue(renderer),
       locationServiceProvider.overrideWithValue(FakeLocationService()),
+      // Avoid the Supabase-dependent auth chain in widget tests.
+      currentUserIdProvider.overrideWithValue('admin'),
       if (analytics != null)
         analyticsServiceProvider.overrideWithValue(analytics),
+      if (db != null) appDatabaseProvider.overrideWithValue(db),
       currentFeaturesProvider.overrideWith((_) => Stream.value(features)),
       currentAssignmentProvider.overrideWith((_) => Stream.value(fakeAssignment())),
       assignmentLockStateProvider.overrideWith((_) => Stream.value(const Unlocked())),
@@ -273,6 +280,128 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('map.add-feature-pill')), findsOneWidget);
+    });
+  });
+
+  group('US-9 T21 Save flow', () {
+    testWidgets('Save with valid edits writes revision + sync_job, exits mode',
+        (tester) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      // Persist the feature so saveReshape's UPDATE finds a row.
+      final feature = fakeFeature();
+      await db.into(db.assignments).insert(
+            AssignmentsCompanion.insert(
+              id: 'a1',
+              enumeratorId: 'admin',
+              campaignId: 'c1',
+              boundaryPolygonGeojson: fakeAssignment().boundaryPolygonGeojson,
+              createdAt: DateTime.now(),
+            ),
+          );
+      await db.into(db.features).insert(
+            FeaturesCompanion.insert(
+              id: feature.id,
+              assignmentId: feature.assignmentId,
+              featureType: feature.featureType,
+              geometryGeojson: feature.geometryGeojson,
+              createdAt: feature.createdAt,
+            ),
+          );
+
+      final fake = FakeMapRenderer();
+      final container = await pumpMap(
+        tester,
+        renderer: fake,
+        positionStream: Stream.value(fakePos(lat: 10.3180, lng: 123.8830)),
+        features: [feature],
+        db: db,
+      );
+
+      await fake.simulatePolygonLongPress(feature);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+      await tester.pumpAndSettle();
+
+      // Drive the controller into a dirty state by performing a small valid
+      // move directly (avoids dependency on overlay layout):
+      container.read(reshapeModeControllerProvider.notifier).moveVertex(
+            0,
+            0,
+            (lng: 123.8826, lat: 10.3176),
+          );
+      await tester.pump();
+
+      await tester.tap(find.byKey(const Key('reshape.banner.save')));
+      // Drift's NativeDatabase does real async I/O; pumpAndSettle in FakeAsync
+      // hangs on the post-save rebuild. Pump a handful of frames instead.
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 20));
+      }
+
+      // Mode is inactive in the controller.
+      expect(container.read(reshapeModeControllerProvider).isActive, isFalse);
+      // Save exited the mode (banner gone).
+      expect(find.byKey(const Key('reshape.banner.save')), findsNothing);
+
+      // Revision + sync_job persisted.
+      final revisions = await db.select(db.featureGeometryRevisions).get();
+      expect(revisions, hasLength(1));
+      expect(revisions.first.featureId, feature.id);
+      expect(revisions.first.syncStatus, 'ready_to_upload');
+      final jobs = await db.select(db.syncJobs).get();
+      expect(jobs, hasLength(1));
+      expect(jobs.first.entityType, 'feature_geometry_update');
+      expect(jobs.first.entityId, revisions.first.id);
+    });
+
+    testWidgets(
+        'Save with self-intersecting polygon shows snackbar; stays in mode',
+        (tester) async {
+      final fake = FakeMapRenderer();
+      final analytics = RecordingAnalyticsService();
+      final container = await pumpMap(
+        tester,
+        renderer: fake,
+        positionStream: Stream.value(fakePos(lat: 10.3180, lng: 123.8830)),
+        features: [fakeFeature()],
+        analytics: analytics,
+      );
+
+      await fake.simulatePolygonLongPress(fakeFeature());
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+      await tester.pumpAndSettle();
+
+      // Drive into a transverse bowtie. Starting from a 4-vertex CCW square,
+      // swap two diagonally-opposite corners.
+      final n = container.read(reshapeModeControllerProvider.notifier);
+      final ring = container.read(reshapeModeControllerProvider).workingRings[0];
+      final c0 = ring[0];
+      final c2 = ring[2];
+      n
+        ..moveVertex(0, 0, c2) // 0 -> 2
+        ..moveVertex(0, 2, c0); // 2 -> 0 — produces a bowtie
+      await tester.pump();
+
+      await tester.tap(find.byKey(const Key('reshape.banner.save')));
+      // Validation snackbar — pump a few frames for it to mount.
+      for (var i = 0; i < 5; i++) {
+        await tester.pump(const Duration(milliseconds: 20));
+      }
+
+      // Snackbar visible — exact text uses i18n. Check by ARB-key text.
+      expect(find.textContaining('cross'), findsWidgets);
+      // Still in reshape mode.
+      expect(container.read(reshapeModeControllerProvider).isActive, isTrue);
+
+      // Validation_failed analytics fired with the rule name.
+      expect(
+        analytics.events.any((e) =>
+            e.event == 'map.reshape.validation_failed' &&
+            e.properties?['rule'] == 'selfIntersection',),
+        isTrue,
+      );
     });
   });
 }

--- a/test/features/map/map_screen_reshape_test.dart
+++ b/test/features/map/map_screen_reshape_test.dart
@@ -9,11 +9,31 @@ import 'package:firecheck/features/assignment/presentation/assignment_providers.
 import 'package:firecheck/features/map/presentation/map_providers.dart';
 import 'package:firecheck/features/map/presentation/map_renderer.dart';
 import 'package:firecheck/features/map/presentation/map_screen.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_providers.dart';
 import 'package:firecheck/generated/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
+
+Position fakePos({
+  required double lat,
+  required double lng,
+  double accuracy = 10,
+}) {
+  return Position(
+    latitude: lat,
+    longitude: lng,
+    timestamp: DateTime.utc(2026),
+    accuracy: accuracy,
+    altitude: 0,
+    altitudeAccuracy: 0,
+    heading: 0,
+    headingAccuracy: 0,
+    speed: 0,
+    speedAccuracy: 0,
+  );
+}
 
 Assignment fakeAssignment() => Assignment(
       id: 'a1',
@@ -41,13 +61,14 @@ Feature fakeFeature() => Feature(
       createdAt: DateTime.utc(2026),
     );
 
-Future<void> pumpMap(
+Future<ProviderContainer> pumpMap(
   WidgetTester tester, {
   required FakeMapRenderer renderer,
   List<Feature> features = const [],
   AnalyticsService? analytics,
+  Stream<Position>? positionStream,
 }) async {
-  await tester.pumpWidget(ProviderScope(
+  final container = ProviderContainer(
     overrides: [
       mapRendererProvider.overrideWithValue(renderer),
       locationServiceProvider.overrideWithValue(FakeLocationService()),
@@ -56,8 +77,14 @@ Future<void> pumpMap(
       currentFeaturesProvider.overrideWith((_) => Stream.value(features)),
       currentAssignmentProvider.overrideWith((_) => Stream.value(fakeAssignment())),
       assignmentLockStateProvider.overrideWith((_) => Stream.value(const Unlocked())),
-      currentPositionProvider.overrideWith((_) => const Stream<Position>.empty()),
+      currentPositionProvider.overrideWith(
+        (_) => positionStream ?? const Stream<Position>.empty(),
+      ),
     ],
+  );
+  addTearDown(container.dispose);
+  await tester.pumpWidget(UncontrolledProviderScope(
+    container: container,
     child: const MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
@@ -66,6 +93,7 @@ Future<void> pumpMap(
   ),);
   await tester.pump();
   await tester.pump();
+  return container;
 }
 
 void main() {
@@ -109,6 +137,95 @@ void main() {
       expect(
         find.byKey(const Key('reshape.actionsheet.reshape')),
         findsNothing,
+      );
+    });
+  });
+
+  group('US-9 T19 distance gate + override-reason → enterReshape', () {
+    testWidgets('Reshape with GPS within 50m enters edit mode (no dialog)',
+        (tester) async {
+      final renderer = FakeMapRenderer();
+      final analytics = RecordingAnalyticsService();
+      final feature = fakeFeature();
+      // GPS fix at (essentially) the feature centroid → distance ≈ 0m.
+      final container = await pumpMap(
+        tester,
+        renderer: renderer,
+        features: [feature],
+        analytics: analytics,
+        positionStream: Stream.value(fakePos(lat: 10.3180, lng: 123.8830)),
+      );
+
+      await renderer.simulatePolygonLongPress(feature);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+      await tester.pumpAndSettle();
+
+      // No override dialog appeared.
+      expect(find.byKey(const Key('override.reason')), findsNothing);
+
+      // Reshape mode is active and the working feature was seeded.
+      final state = container.read(reshapeModeControllerProvider);
+      expect(state.isActive, isTrue);
+      expect(state.originalFeature?.id, feature.id);
+      expect(state.overrideReason, isNull);
+
+      // Analytics recorded entry without override.
+      expect(
+        analytics.events.any((e) =>
+            e.event == 'map.reshape.entered' &&
+            e.properties?['override_used'] == false &&
+            e.properties?['feature_id'] == feature.id,),
+        isTrue,
+      );
+    });
+
+    testWidgets(
+        'Reshape with GPS >50m shows override dialog; confirm enters mode',
+        (tester) async {
+      final renderer = FakeMapRenderer();
+      final analytics = RecordingAnalyticsService();
+      final feature = fakeFeature();
+      // ~155m south of the feature centroid (1° lat ≈ 111km → 0.0014° ≈ 155m).
+      final container = await pumpMap(
+        tester,
+        renderer: renderer,
+        features: [feature],
+        analytics: analytics,
+        positionStream: Stream.value(fakePos(lat: 10.3166, lng: 123.8830)),
+      );
+
+      await renderer.simulatePolygonLongPress(feature);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+      await tester.pumpAndSettle();
+
+      // Override dialog visible.
+      expect(find.byKey(const Key('override.reason')), findsOneWidget);
+      await tester.enterText(
+        find.byKey(const Key('override.reason')),
+        'visible from sidewalk',
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+
+      // Override dialog dismissed.
+      expect(find.byKey(const Key('override.reason')), findsNothing);
+
+      // Reshape mode active with override reason captured.
+      final state = container.read(reshapeModeControllerProvider);
+      expect(state.isActive, isTrue);
+      expect(state.originalFeature?.id, feature.id);
+      expect(state.overrideReason, 'visible from sidewalk');
+
+      // Analytics recorded entry with override.
+      expect(
+        analytics.events.any((e) =>
+            e.event == 'map.reshape.entered' &&
+            e.properties?['override_used'] == true &&
+            e.properties?['feature_id'] == feature.id,),
+        isTrue,
       );
     });
   });

--- a/test/features/map/map_screen_reshape_test.dart
+++ b/test/features/map/map_screen_reshape_test.dart
@@ -229,4 +229,50 @@ void main() {
       );
     });
   });
+
+  group('US-9 T20 mount banner + overlay; hide add-pill', () {
+    testWidgets('add-mode pill hidden while reshape active', (tester) async {
+      final renderer = FakeMapRenderer();
+      final feature = fakeFeature();
+      // GPS at the feature centroid → distance ≈ 0m, no override dialog.
+      await pumpMap(
+        tester,
+        renderer: renderer,
+        features: [feature],
+        positionStream: Stream.value(fakePos(lat: 10.3180, lng: 123.8830)),
+      );
+
+      // Pill visible at start.
+      expect(find.byKey(const Key('map.add-feature-pill')), findsOneWidget);
+
+      await renderer.simulatePolygonLongPress(feature);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+      await tester.pumpAndSettle();
+
+      // Pill hidden once reshape is active.
+      expect(find.byKey(const Key('map.add-feature-pill')), findsNothing);
+    });
+
+    testWidgets('Cancel exits reshape and re-shows add pill', (tester) async {
+      final renderer = FakeMapRenderer();
+      final feature = fakeFeature();
+      await pumpMap(
+        tester,
+        renderer: renderer,
+        features: [feature],
+        positionStream: Stream.value(fakePos(lat: 10.3180, lng: 123.8830)),
+      );
+
+      await renderer.simulatePolygonLongPress(feature);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('reshape.banner.cancel')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('map.add-feature-pill')), findsOneWidget);
+    });
+  });
 }

--- a/test/features/map/map_screen_reshape_test.dart
+++ b/test/features/map/map_screen_reshape_test.dart
@@ -1,0 +1,115 @@
+import 'package:firecheck/core/analytics/analytics_providers.dart';
+import 'package:firecheck/core/analytics/analytics_service.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/location/location_providers.dart';
+import 'package:firecheck/core/location/location_service.dart';
+import 'package:firecheck/features/assignment/presentation/assignment_lock_providers.dart';
+import 'package:firecheck/features/assignment/presentation/assignment_lock_state.dart';
+import 'package:firecheck/features/assignment/presentation/assignment_providers.dart';
+import 'package:firecheck/features/map/presentation/map_providers.dart';
+import 'package:firecheck/features/map/presentation/map_renderer.dart';
+import 'package:firecheck/features/map/presentation/map_screen.dart';
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+
+Assignment fakeAssignment() => Assignment(
+      id: 'a1',
+      enumeratorId: 'e@example.com',
+      campaignId: 'c1',
+      boundaryPolygonGeojson:
+          '{"type":"Polygon","coordinates":[[[123.882,10.317],'
+          '[123.884,10.317],[123.884,10.319],'
+          '[123.882,10.319],[123.882,10.317]]]}',
+      status: 'assigned',
+      closedRemotely: false,
+      createdAt: DateTime(2026),
+    );
+
+Feature fakeFeature() => Feature(
+      id: 'f1',
+      assignmentId: 'a1',
+      featureType: 'building',
+      geometryGeojson:
+          '{"type":"Polygon","coordinates":[[[123.8825,10.3175],'
+          '[123.8835,10.3175],[123.8835,10.3185],'
+          '[123.8825,10.3185],[123.8825,10.3175]]]}',
+      isNew: false,
+      status: 'unfilled',
+      createdAt: DateTime.utc(2026),
+    );
+
+Future<void> pumpMap(
+  WidgetTester tester, {
+  required FakeMapRenderer renderer,
+  List<Feature> features = const [],
+  AnalyticsService? analytics,
+}) async {
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      mapRendererProvider.overrideWithValue(renderer),
+      locationServiceProvider.overrideWithValue(FakeLocationService()),
+      if (analytics != null)
+        analyticsServiceProvider.overrideWithValue(analytics),
+      currentFeaturesProvider.overrideWith((_) => Stream.value(features)),
+      currentAssignmentProvider.overrideWith((_) => Stream.value(fakeAssignment())),
+      assignmentLockStateProvider.overrideWith((_) => Stream.value(const Unlocked())),
+      currentPositionProvider.overrideWith((_) => const Stream<Position>.empty()),
+    ],
+    child: const MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: MapScreen(),
+    ),
+  ),);
+  await tester.pump();
+  await tester.pump();
+}
+
+void main() {
+  group('US-9 T18 polygon long-press → reshape action sheet', () {
+    testWidgets('long-press on a polygon (add-mode off) opens action sheet',
+        (tester) async {
+      final renderer = FakeMapRenderer();
+      final feature = fakeFeature();
+      await pumpMap(tester, renderer: renderer, features: [feature]);
+
+      await renderer.simulatePolygonLongPress(feature);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('reshape.actionsheet.openForm')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('reshape.actionsheet.reshape')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('long-press on a polygon (add-mode on) does NOT open sheet',
+        (tester) async {
+      final renderer = FakeMapRenderer();
+      final feature = fakeFeature();
+      await pumpMap(tester, renderer: renderer, features: [feature]);
+
+      // Toggle add-mode pill on.
+      await tester.tap(find.byKey(const Key('map.add-feature-pill')));
+      await tester.pumpAndSettle();
+
+      await renderer.simulatePolygonLongPress(feature);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('reshape.actionsheet.openForm')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const Key('reshape.actionsheet.reshape')),
+        findsNothing,
+      );
+    });
+  });
+}

--- a/test/features/map/reshape/midpoint_handle_test.dart
+++ b/test/features/map/reshape/midpoint_handle_test.dart
@@ -1,0 +1,16 @@
+import 'package:firecheck/features/map/reshape/presentation/midpoint_handle.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('MidpointHandle has 44x44 hit area', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: Center(child: MidpointHandle()),
+      ),
+    ));
+    final size = tester.getSize(find.byType(MidpointHandle));
+    expect(size.width, greaterThanOrEqualTo(44));
+    expect(size.height, greaterThanOrEqualTo(44));
+  });
+}

--- a/test/features/map/reshape/reshape_action_sheet_test.dart
+++ b/test/features/map/reshape/reshape_action_sheet_test.dart
@@ -1,0 +1,87 @@
+import 'package:firecheck/features/map/reshape/presentation/reshape_action_sheet.dart';
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en')],
+      home: child,
+    );
+
+void main() {
+  testWidgets('returns openForm on Open form tap', (tester) async {
+    ReshapeAction? r;
+    await tester.pumpWidget(
+      _wrap(
+        Builder(
+          builder: (ctx) {
+            return TextButton(
+              onPressed: () async {
+                r = await showReshapeActionSheet(ctx, locked: false);
+              },
+              child: const Text('open'),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('reshape.actionsheet.openForm')));
+    await tester.pumpAndSettle();
+    expect(r, ReshapeAction.openForm);
+  });
+
+  testWidgets('returns reshape on Reshape tap', (tester) async {
+    ReshapeAction? r;
+    await tester.pumpWidget(
+      _wrap(
+        Builder(
+          builder: (ctx) {
+            return TextButton(
+              onPressed: () async {
+                r = await showReshapeActionSheet(ctx, locked: false);
+              },
+              child: const Text('open'),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
+    await tester.pumpAndSettle();
+    expect(r, ReshapeAction.reshape);
+  });
+
+  testWidgets('Reshape item disabled when locked', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        Builder(
+          builder: (ctx) {
+            return TextButton(
+              onPressed: () async {
+                await showReshapeActionSheet(ctx, locked: true);
+              },
+              child: const Text('open'),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    final tile = tester.widget<ListTile>(
+      find.byKey(const Key('reshape.actionsheet.reshape')),
+    );
+    expect(tile.enabled, isFalse);
+  });
+}

--- a/test/features/map/reshape/reshape_banner_test.dart
+++ b/test/features/map/reshape/reshape_banner_test.dart
@@ -1,0 +1,95 @@
+import 'package:firecheck/features/map/reshape/presentation/reshape_banner.dart';
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en')],
+      home: Scaffold(body: child),
+    );
+
+void main() {
+  testWidgets('renders edit count and title', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        const ReshapeBanner(
+          editCount: 3,
+          undoEnabled: true,
+          saveEnabled: true,
+        ),
+      ),
+    );
+    expect(find.textContaining('3'), findsOneWidget);
+  });
+
+  testWidgets('Save tap fires onSave', (tester) async {
+    var saves = 0;
+    await tester.pumpWidget(
+      _wrap(
+        ReshapeBanner(
+          editCount: 1,
+          undoEnabled: true,
+          saveEnabled: true,
+          onSave: () => saves++,
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('reshape.banner.save')));
+    expect(saves, 1);
+  });
+
+  testWidgets('Cancel tap fires onCancel', (tester) async {
+    var cancels = 0;
+    await tester.pumpWidget(
+      _wrap(
+        ReshapeBanner(
+          editCount: 0,
+          undoEnabled: false,
+          saveEnabled: false,
+          onCancel: () => cancels++,
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('reshape.banner.cancel')));
+    expect(cancels, 1);
+  });
+
+  testWidgets('Undo tap fires onUndo when enabled', (tester) async {
+    var undos = 0;
+    await tester.pumpWidget(
+      _wrap(
+        ReshapeBanner(
+          editCount: 1,
+          undoEnabled: true,
+          saveEnabled: true,
+          onUndo: () => undos++,
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('reshape.banner.undo')));
+    expect(undos, 1);
+  });
+
+  testWidgets('Save disabled does not fire onSave', (tester) async {
+    var saves = 0;
+    await tester.pumpWidget(
+      _wrap(
+        ReshapeBanner(
+          editCount: 0,
+          undoEnabled: false,
+          saveEnabled: false,
+          onSave: () => saves++,
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('reshape.banner.save')));
+    expect(saves, 0);
+  });
+}

--- a/test/features/map/reshape/reshape_mode_controller_test.dart
+++ b/test/features/map/reshape/reshape_mode_controller_test.dart
@@ -1,0 +1,126 @@
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/features/map/reshape/domain/reshape_op.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_mode_controller.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+ProviderContainer _container() => ProviderContainer();
+
+Feature _seedBuilding({String id = 'f1'}) => Feature(
+      id: id,
+      assignmentId: 'a1',
+      featureType: 'building',
+      geometryGeojson:
+          '{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}',
+      isNew: false,
+      status: 'unfilled',
+      createdAt: DateTime.utc(2026, 1, 1),
+    );
+
+void main() {
+  test('initial state is inactive', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    final state = c.read(reshapeModeControllerProvider);
+    expect(state.isActive, isFalse);
+  });
+
+  test('enterReshape parses geojson into workingRings', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    c.read(reshapeModeControllerProvider.notifier).enterReshape(
+          feature: _seedBuilding(),
+          overrideReason: null,
+        );
+    final s = c.read(reshapeModeControllerProvider);
+    expect(s.isActive, isTrue);
+    expect(s.workingRings, hasLength(1));
+    expect(s.workingRings[0], hasLength(4));
+    expect(s.isDirty, isFalse);
+  });
+
+  test('moveVertex pushes a Move op and updates the ring', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    final notifier = c.read(reshapeModeControllerProvider.notifier);
+    notifier.enterReshape(feature: _seedBuilding(), overrideReason: null);
+    notifier.moveVertex(0, 0, (lng: 5, lat: 5));
+    final s = c.read(reshapeModeControllerProvider);
+    expect(s.workingRings[0][0], (lng: 5.0, lat: 5.0));
+    expect(s.undoStack, hasLength(1));
+    expect(s.undoStack.last, isA<Move>());
+    expect(s.isDirty, isTrue);
+  });
+
+  test('addVertex inserts at index and pushes Add', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    final n = c.read(reshapeModeControllerProvider.notifier);
+    n.enterReshape(feature: _seedBuilding(), overrideReason: null);
+    n.addVertex(0, 1, (lng: 0.5, lat: 0));
+    final s = c.read(reshapeModeControllerProvider);
+    expect(s.workingRings[0], hasLength(5));
+    expect(s.workingRings[0][1], (lng: 0.5, lat: 0));
+  });
+
+  test('removeVertex removes and pushes Remove', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    final n = c.read(reshapeModeControllerProvider.notifier);
+    n.enterReshape(feature: _seedBuilding(), overrideReason: null);
+    n.removeVertex(0, 0);
+    final s = c.read(reshapeModeControllerProvider);
+    expect(s.workingRings[0], hasLength(3));
+  });
+
+  test('removeVertex is a no-op at 3 vertices', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    final n = c.read(reshapeModeControllerProvider.notifier);
+    n.enterReshape(feature: _seedBuilding(), overrideReason: null);
+    n.removeVertex(0, 0);
+    n.removeVertex(0, 0);
+    final s = c.read(reshapeModeControllerProvider);
+    expect(s.workingRings[0], hasLength(3));
+  });
+
+  test('undo pops and inverts last op', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    final n = c.read(reshapeModeControllerProvider.notifier);
+    n.enterReshape(feature: _seedBuilding(), overrideReason: null);
+    n.moveVertex(0, 0, (lng: 5, lat: 5));
+    n.undo();
+    final s = c.read(reshapeModeControllerProvider);
+    expect(s.workingRings[0][0], (lng: 0.0, lat: 0.0));
+    expect(s.undoStack, isEmpty);
+  });
+
+  test('cancel returns to inactive', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    final n = c.read(reshapeModeControllerProvider.notifier);
+    n.enterReshape(feature: _seedBuilding(), overrideReason: null);
+    n.moveVertex(0, 0, (lng: 5, lat: 5));
+    n.cancel();
+    final s = c.read(reshapeModeControllerProvider);
+    expect(s.isActive, isFalse);
+  });
+
+  test('selfIntersects flag tracks bowtie state during drag', () {
+    final c = _container();
+    addTearDown(c.dispose);
+    final n = c.read(reshapeModeControllerProvider.notifier);
+    n.enterReshape(feature: _seedBuilding(), overrideReason: null);
+
+    n.moveVertex(0, 1, (lng: 1, lat: 1));
+    final s1 = c.read(reshapeModeControllerProvider);
+    expect(s1.workingRings[0][1], (lng: 1.0, lat: 1.0));
+
+    n.moveVertex(0, 1, (lng: 0, lat: 1));
+    n.moveVertex(0, 3, (lng: 1, lat: 0));
+    final s2 = c.read(reshapeModeControllerProvider);
+    expect(s2.selfIntersects, isTrue);
+  });
+}

--- a/test/features/map/reshape/reshape_op_test.dart
+++ b/test/features/map/reshape/reshape_op_test.dart
@@ -1,0 +1,49 @@
+import 'package:firecheck/features/map/reshape/domain/reshape_op.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Move op stores prev and next', () {
+    const op = Move(
+      ringIdx: 0,
+      vertexIdx: 1,
+      prev: (lng: 0, lat: 0),
+      next: (lng: 1, lat: 1),
+    );
+    expect(op.ringIdx, 0);
+    expect(op.vertexIdx, 1);
+    expect(op.prev, (lng: 0.0, lat: 0.0));
+    expect(op.next, (lng: 1.0, lat: 1.0));
+  });
+
+  test('Add op stores inserted lngLat', () {
+    const op = Add(
+      ringIdx: 0,
+      vertexIdx: 2,
+      lngLat: (lng: 5, lat: 5),
+    );
+    expect(op.lngLat, (lng: 5.0, lat: 5.0));
+  });
+
+  test('Remove op stores removed lngLat', () {
+    const op = Remove(
+      ringIdx: 0,
+      vertexIdx: 0,
+      removed: (lng: 9, lat: 9),
+    );
+    expect(op.removed, (lng: 9.0, lat: 9.0));
+  });
+
+  test('switch over ReshapeOp is exhaustive', () {
+    const List<ReshapeOp> ops = [
+      Move(ringIdx: 0, vertexIdx: 0, prev: (lng: 0, lat: 0), next: (lng: 1, lat: 1)),
+      Add(ringIdx: 0, vertexIdx: 0, lngLat: (lng: 0, lat: 0)),
+      Remove(ringIdx: 0, vertexIdx: 0, removed: (lng: 0, lat: 0)),
+    ];
+    final names = ops.map((op) => switch (op) {
+          Move() => 'move',
+          Add() => 'add',
+          Remove() => 'remove',
+        });
+    expect(names, ['move', 'add', 'remove']);
+  });
+}

--- a/test/features/map/reshape/reshape_overlay_test.dart
+++ b/test/features/map/reshape/reshape_overlay_test.dart
@@ -1,0 +1,84 @@
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/features/map/presentation/map_renderer.dart';
+import 'package:firecheck/features/map/reshape/presentation/midpoint_handle.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_overlay.dart';
+import 'package:firecheck/features/map/reshape/presentation/reshape_providers.dart';
+import 'package:firecheck/features/map/reshape/presentation/vertex_handle.dart';
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Feature _seedBuilding() => Feature(
+      id: 'f1',
+      assignmentId: 'a1',
+      featureType: 'building',
+      geometryGeojson:
+          '{"type":"Polygon","coordinates":[[[10,10],[100,10],[100,100],[10,100],[10,10]]]}',
+      isNew: false,
+      status: 'unfilled',
+      createdAt: DateTime.utc(2026),
+    );
+
+Widget _wrap(ProviderContainer container, Widget child) =>
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('en')],
+        home: Scaffold(
+          body: SizedBox(
+            width: 200,
+            height: 200,
+            child: child,
+          ),
+        ),
+      ),
+    );
+
+void main() {
+  testWidgets('renders 4 vertex + 4 midpoint handles for a 4-vertex ring',
+      (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container
+        .read(reshapeModeControllerProvider.notifier)
+        .enterReshape(feature: _seedBuilding());
+
+    await tester.pumpWidget(
+      _wrap(
+        container,
+        ReshapeOverlay(projection: _IdentityProjection()),
+      ),
+    );
+    expect(find.byType(VertexHandle), findsNWidgets(4));
+    expect(find.byType(MidpointHandle), findsNWidgets(4));
+  });
+
+  testWidgets('inactive state renders nothing', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    await tester.pumpWidget(
+      _wrap(
+        container,
+        ReshapeOverlay(projection: _IdentityProjection()),
+      ),
+    );
+    expect(find.byType(VertexHandle), findsNothing);
+    expect(find.byType(MidpointHandle), findsNothing);
+  });
+}
+
+class _IdentityProjection implements MapProjection {
+  @override
+  Offset screenPointFromLngLat(double lng, double lat) => Offset(lng, lat);
+  @override
+  ({double lng, double lat}) lngLatFromScreenPoint(Offset p) =>
+      (lng: p.dx, lat: p.dy);
+}

--- a/test/features/map/reshape/reshape_remove_confirm_dialog_test.dart
+++ b/test/features/map/reshape/reshape_remove_confirm_dialog_test.dart
@@ -1,0 +1,69 @@
+import 'package:firecheck/features/map/reshape/presentation/reshape_remove_confirm_dialog.dart';
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en')],
+      home: child,
+    );
+
+void main() {
+  testWidgets('confirm tap returns true', (tester) async {
+    bool? result;
+    await tester.pumpWidget(_wrap(Builder(builder: (ctx) {
+      return TextButton(
+        onPressed: () async {
+          result = await showReshapeRemoveConfirm(ctx, currentRingLength: 5);
+        },
+        child: const Text('open'),
+      );
+    },),),);
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('reshape.remove.confirm')));
+    await tester.pumpAndSettle();
+    expect(result, isTrue);
+  });
+
+  testWidgets('cancel tap returns false', (tester) async {
+    bool? result;
+    await tester.pumpWidget(_wrap(Builder(builder: (ctx) {
+      return TextButton(
+        onPressed: () async {
+          result = await showReshapeRemoveConfirm(ctx, currentRingLength: 5);
+        },
+        child: const Text('open'),
+      );
+    },),),);
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('reshape.remove.cancel')));
+    await tester.pumpAndSettle();
+    expect(result, isFalse);
+  });
+
+  testWidgets('confirm disabled at 3 vertices', (tester) async {
+    await tester.pumpWidget(_wrap(Builder(builder: (ctx) {
+      return TextButton(
+        onPressed: () async {
+          await showReshapeRemoveConfirm(ctx, currentRingLength: 3);
+        },
+        child: const Text('open'),
+      );
+    },),),);
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    final btn = tester.widget<FilledButton>(
+      find.byKey(const Key('reshape.remove.confirm')),
+    );
+    expect(btn.onPressed, isNull);
+  });
+}

--- a/test/features/map/reshape/vertex_handle_test.dart
+++ b/test/features/map/reshape/vertex_handle_test.dart
@@ -1,0 +1,16 @@
+import 'package:firecheck/features/map/reshape/presentation/vertex_handle.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('VertexHandle has 44x44 hit area', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: Center(child: VertexHandle()),
+      ),
+    ));
+    final size = tester.getSize(find.byType(VertexHandle));
+    expect(size.width, greaterThanOrEqualTo(44));
+    expect(size.height, greaterThanOrEqualTo(44));
+  });
+}


### PR DESCRIPTION
## Summary

Implements **US-9** — As an enumerator, I want to reshape an existing building polygon by moving, adding, or removing vertices, so that I can correct footprints that are inaccurate on the ground.

After this ships, an enumerator can long-press any building polygon → action sheet → **Reshape** → drag corners, drag midpoints to add new corners, long-press to remove corners. Save commits the new geometry locally with an audit revision row and queues a sync job; the new `update_feature_geometry` Supabase RPC applies the change with optimistic prev-geometry concurrency control.

**Spec:** `docs/superpowers/specs/2026-04-29-reshape-building-polygon-design.md`
**Plan:** `docs/superpowers/plans/2026-04-29-reshape-building-polygon.md` (24 TDD tasks)

## AC mapping

| Story scenario | How it's met |
|---|---|
| **1** Move vertex by drag | `ReshapeOverlay` vertex handles dispatch `onPanUpdate` → `ReshapeModeController.moveVertex`; map re-renders via `reshapeWorkingPolygonGeojson` per frame |
| **2** Add vertex via midpoint | Touch-and-drag a midpoint dot — vertex is inserted on `onPanStart` and immediately enters drag in the same gesture (A2 pattern) |
| **3** Remove vertex (long-press + confirm; ≥3 enforced) | `showReshapeRemoveConfirm` AlertDialog; **Remove** button disabled when ring length is 3 |
| **4** Save-time validation with retry | `validateBuildingPolygon` runs 5 rules at Save; failure → snackbar + stay in edit mode; live red-edge feedback for self-intersection |
| **5** Cancel reverts | Cancel discards `ReshapeModeController` state; original Drift row never touched |
| **6** Preserve building metadata | Drift transaction touches only `features.geometry_geojson` and `feature_geometry_revisions`; `submissions`, `building_attributes`, `photos` untouched |

## Architecture

- **`PolygonValidator`** (pure Dart) — 5 rules: ≥3 unique vertices, non-zero area, non-self-intersecting (CCW orientation test), all vertices inside boundary, no zero-length edges. Rule 3 runs before rule 2 so bowties surface as `selfIntersection` (the more actionable error) instead of `zeroOrNegativeArea`.
- **`ReshapeModeController`** (Riverpod `Notifier`) — in-memory working copy + undo stack; `selfIntersects` flag latches during drag and resets on undo/cancel/enter.
- **`MapRenderer` reshape seams** — new optional params: `onPolygonLongPress`, `reshapeWorkingPolygonGeojson`, `reshapeInvalidEdgeGeojson`, `onProjectionReady`. `MapboxMapRenderer` adds polygon hit-test, working-polygon overlay (blue 30% opacity), and `_MapboxProjection` (linear corner-calibration via `coordinateForPixel`, refreshed on every camera change).
- **Sync** — new `entity_type='feature_geometry_update'` flowing through the existing `SyncWorker`. New `update_feature_geometry` Supabase RPC with `ST_Equals` prev-geometry check; `P0001 geometry_conflict` and `42501 forbidden` map to `PermanentFailure` (dead-letter).
- **Drift schema bump** 5 → 6, new `feature_geometry_revisions` table.
- **i18n** — 17 new ARB keys (TL pending translation per project convention).

## Test plan

- ✅ `flutter analyze` exits 0 (info-level lints only, acceptable per plan T24).
- ✅ Unit tests: `PolygonValidator` (11), `FeatureGeometryRevisionsRepository` (6 incl. atomic rollback), `ReshapeModeController` (9), sealed-class round-trip (4).
- ✅ Widget tests: `VertexHandle`, `MidpointHandle`, `ReshapeBanner` (5), `ReshapeRemoveConfirmDialog` (3 incl. confirm-disabled at 3 vertices), `ReshapeActionSheet` (3 incl. locked-disabled), `ReshapeOverlay` (2), `map_screen_reshape_test` (10 covering long-press → action sheet → distance gate → save → lock-while-dirty).
- ✅ Sync test: `feature_geometry_update_sync_test` — success uploads + marks revision uploaded; permanent failure marks revision failed + sync_job dead.
- ✅ Manual happy-path on real Android device:
  - **A1–A11** (action sheet, enter mode, move/add/remove vertices, undo, validation rejects, successful save, cancel, distance override) — all green
  - **B1** sync round-trip — revision + new geometry visible server-side
  - **C** lock interactions (locked from start, locked-while-clean silent exit, locked-while-dirty Exit dialog) — all green
  - **D** regression on existing flows (tap → form, add-mode pill, recenter, zoom, pinch, polygon color stream) — all green
  - **E** three real-world buildings: tested on the field-test assignment polygons

## Server migration

- ✅ **`supabase migration list`** confirms migration `011_feature_geometry_updates.sql` is applied to the linked dev project.
- The migration creates `feature_geometry_revisions` table + RLS policies (insert/select scoped to assignment owner) + the `update_feature_geometry` RPC with optimistic concurrency control via `ST_Equals` on prev_geometry.

## Out of scope (deliberate)

- Reshape on `is_new` point pins (those aren't polygons yet — separate story).
- Reshape on roads (LineStrings) — separate story.
- Splitting / merging polygons.
- Snapping (GPS, vertex, orthogonal) — premature without field feedback.
- Save-draft of an in-progress reshape across app kills — explicit AC choice.
- Real-time multi-enumerator collaboration on the same polygon (master spec §15 confirms v2+).
- Per-vertex `pixelForCoordinate` projection — first pass uses linear corner-calibration; sub-pixel accurate at zoom ≥17 inside the viewport. Captured as a deferred open question in spec §14.

## Notes for review

- **7 parallel commits not part of US-9.** This branch also carries spec edits for the unrelated **flat-file shapefile sync (FF-1..FF-11)** user stories that I drafted in parallel. They are spec-only Markdown changes under `docs/superpowers/specs/`. They do not touch any US-9 code path. If you'd prefer them on a separate PR, happy to split via cherry-pick before merge.
- **Live red-edge feedback during drag** — the renderer accepts `reshapeInvalidEdgeGeojson` but does not yet render it. The validator already populates `intersectingEdges` for downstream consumption. Save-time validation is the hard gate; live feedback is a follow-up polish pass.
- **TL translations pending.** ARB keys ship with English fallback per project convention.

## Test plan checklist (for reviewer)

- [ ] Long-press a polygon (add-mode off) → action sheet appears.
- [ ] Long-press while add-mode on → action sheet does NOT appear.
- [ ] Reshape → drag a vertex → Save → polygon updates; revision row + sync_job exist.
- [ ] Reshape → bowtie → Save → snackbar; mode persists.
- [ ] Reshape → vertex outside boundary → Save → snackbar.
- [ ] Reshape → long-press at 3 vertices → Remove disabled.
- [ ] Reshape on a far building (>50 m) → override-reason dialog.
- [ ] Save offline → online → revision uploads (server row visible).
- [ ] Lock-while-dirty → Exit dialog → discards.
- [ ] Existing flows unaffected: tap-to-form, add-mode, recenter, zoom, pinch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)