### PR TITLE
feat(export): package completed features as attributed shapefiles (US-22)

### DIFF
--- a/docs/superpowers/plans/2026-05-02-export-shapefile.md
+++ b/docs/superpowers/plans/2026-05-02-export-shapefile.md
@@ -1,0 +1,1555 @@
+# Export Completed Work as Attributed Shapefiles — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Package completed enumeration features into attributed Esri shapefiles (buildings + roads), zip them, and share via the device share sheet — accessible from a new "Export Shapefile" tile on HomeScreen.
+
+**Architecture:** Pure Dart binary writers (`ShpWriter`, `DbfWriter`) mirror the existing `ShpParser`/`DbfParser` pattern and run in a `compute` isolate. A `ShapefileExporter` orchestrator queries Drift, splits by feature type, calls the writers, and zips with the existing `archive` package. A `ShapefileExportNotifier` (`StateNotifier`) drives a simple `Idle → Exporting → Done/Failed` state machine, and a new action tile on `HomeScreen` is disabled until at least one feature is complete.
+
+**Tech Stack:** Dart (`ByteData`/`Uint8List`), Drift (DB queries), `archive ^3.4.0` (ZIP), `share_plus ^12.0.2` (share sheet), `flutter/foundation.dart` (`compute`), Riverpod `StateNotifier`, Flutter l10n (ARB).
+
+---
+
+## File Map
+
+| Status | Path | Responsibility |
+|---|---|---|
+| Create | `lib/core/sync/shapefile/export/export_failure.dart` | Sealed `ExportFailure` types |
+| Create | `lib/features/home/domain/export_state.dart` | Sealed `ExportState` machine |
+| Create | `lib/core/sync/shapefile/export/shp_writer.dart` | Writes `.shp` + `.shx` bytes |
+| Create | `lib/core/sync/shapefile/export/dbf_writer.dart` | Writes `.dbf` bytes |
+| Create | `lib/core/sync/shapefile/export/shapefile_exporter.dart` | Orchestrator: DB → bytes → ZIP → share |
+| Create | `lib/features/home/data/shapefile_export_notifier.dart` | Riverpod notifier + provider |
+| Modify | `lib/features/home/presentation/home_screen.dart` | Add 4th action tile |
+| Modify | `lib/core/i18n/app_en.arb` | Add l10n keys |
+| Create | `test/core/sync/shapefile/export/shp_writer_test.dart` | ShpWriter round-trip tests |
+| Create | `test/core/sync/shapefile/export/dbf_writer_test.dart` | DbfWriter round-trip tests |
+| Create | `test/core/sync/shapefile/export/shapefile_exporter_test.dart` | Exporter unit tests |
+| Create | `test/features/home/shapefile_export_notifier_test.dart` | Notifier state-machine tests |
+
+---
+
+## Task 1: Core sealed types — `ExportFailure` and `ExportState`
+
+**Files:**
+- Create: `lib/core/sync/shapefile/export/export_failure.dart`
+- Create: `lib/features/home/domain/export_state.dart`
+
+These are value types only — no business logic — so no tests are needed.
+
+- [ ] **Step 1: Create `ExportFailure`**
+
+```dart
+// lib/core/sync/shapefile/export/export_failure.dart
+sealed class ExportFailure {
+  const ExportFailure();
+}
+
+class NoCompletedFeatures extends ExportFailure {
+  const NoCompletedFeatures();
+}
+
+class WriteError extends ExportFailure {
+  const WriteError(this.message);
+  final String message;
+}
+
+class ShareError extends ExportFailure {
+  const ShareError(this.message);
+  final String message;
+}
+```
+
+- [ ] **Step 2: Create `ExportState`**
+
+```dart
+// lib/features/home/domain/export_state.dart
+import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
+
+sealed class ExportState {
+  const ExportState();
+}
+
+class ExportIdle extends ExportState {
+  const ExportIdle();
+}
+
+class ExportExporting extends ExportState {
+  const ExportExporting();
+}
+
+class ExportDone extends ExportState {
+  const ExportDone();
+}
+
+class ExportFailed extends ExportState {
+  const ExportFailed(this.failure);
+  final ExportFailure failure;
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/core/sync/shapefile/export/export_failure.dart \
+        lib/features/home/domain/export_state.dart
+git commit -m "feat(export): add ExportFailure and ExportState sealed types"
+```
+
+---
+
+## Task 2: `ShpWriter` — binary `.shp` + `.shx` writer
+
+**Files:**
+- Create: `lib/core/sync/shapefile/export/shp_writer.dart`
+- Create: `test/core/sync/shapefile/export/shp_writer_test.dart`
+
+`ShpWriter` is a pure function (no Flutter deps, no I/O). It produces `ShpWriteResult(shp, shx)` from a list of part arrays. The existing `ShpParser` is used for round-trip verification in tests.
+
+- [ ] **Step 1: Create the test file and run it to confirm it fails**
+
+```dart
+// test/core/sync/shapefile/export/shp_writer_test.dart
+import 'package:firecheck/core/sync/shapefile/export/shp_writer.dart';
+import 'package:firecheck/core/sync/shapefile/shp_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const writer = ShpWriter();
+  const parser = ShpParser();
+
+  group('ShpWriter — polygons', () {
+    // A simple square polygon ring (WGS84 coords)
+    final ring = [
+      [120.0, 14.0],
+      [121.0, 14.0],
+      [121.0, 15.0],
+      [120.0, 15.0],
+      [120.0, 14.0], // closed
+    ];
+
+    test('round-trip: written polygon parses back with matching coordinates', () {
+      final result = writer.writePolygons([[ring]]);
+      final geometries = parser.parse(result.shp);
+
+      expect(geometries, hasLength(1));
+      final poly = geometries.first as ShpPolygon;
+      expect(poly.rings, hasLength(1));
+      expect(poly.rings.first, hasLength(ring.length));
+      for (var i = 0; i < ring.length; i++) {
+        expect(poly.rings.first[i][0], closeTo(ring[i][0], 0.0001));
+        expect(poly.rings.first[i][1], closeTo(ring[i][1], 0.0001));
+      }
+    });
+
+    test('bounding box in file header matches feature extents', () {
+      final result = writer.writePolygons([[ring]]);
+      final data = result.shp.buffer.asByteData();
+
+      final minX = data.getFloat64(36, Endian.little);
+      final minY = data.getFloat64(44, Endian.little);
+      final maxX = data.getFloat64(52, Endian.little);
+      final maxY = data.getFloat64(60, Endian.little);
+
+      expect(minX, closeTo(120.0, 0.0001));
+      expect(minY, closeTo(14.0, 0.0001));
+      expect(maxX, closeTo(121.0, 0.0001));
+      expect(maxY, closeTo(15.0, 0.0001));
+    });
+
+    test('shx offsets correctly index each record', () {
+      final ring2 = [
+        [122.0, 16.0],
+        [123.0, 16.0],
+        [123.0, 17.0],
+        [122.0, 16.0], // triangle
+      ];
+      final result = writer.writePolygons([[ring], [ring2]]);
+      final shpData = result.shp.buffer.asByteData();
+      final shxData = result.shx.buffer.asByteData();
+
+      // SHX record 0 (at byte 100 in SHX): offset in SHP (in 16-bit words)
+      final offset0 = shxData.getInt32(100, Endian.big) * 2;
+      // SHP record 0 starts at byte 100 (after 100-byte file header)
+      expect(offset0, equals(100));
+
+      // SHX record 1 (at byte 108 in SHX)
+      final offset1 = shxData.getInt32(108, Endian.big) * 2;
+      // Verify that reading the SHP at that offset gives a valid record
+      final contentWords = shpData.getInt32(offset1 + 4, Endian.big);
+      expect(contentWords, greaterThan(0));
+    });
+  });
+
+  group('ShpWriter — polylines', () {
+    final part = [
+      [120.0, 14.0],
+      [121.0, 14.5],
+      [122.0, 14.0],
+    ];
+
+    test('round-trip: written polyline parses back with matching coordinates', () {
+      final result = writer.writePolylines([[part]]);
+      final geometries = parser.parse(result.shp);
+
+      expect(geometries, hasLength(1));
+      final line = geometries.first as ShpPolyline;
+      expect(line.parts.first, hasLength(part.length));
+      for (var i = 0; i < part.length; i++) {
+        expect(line.parts.first[i][0], closeTo(part[i][0], 0.0001));
+        expect(line.parts.first[i][1], closeTo(part[i][1], 0.0001));
+      }
+    });
+  });
+}
+```
+
+Run: `flutter test test/core/sync/shapefile/export/shp_writer_test.dart`
+Expected: compilation error — `ShpWriter` does not exist yet.
+
+- [ ] **Step 2: Implement `ShpWriter`**
+
+```dart
+// lib/core/sync/shapefile/export/shp_writer.dart
+import 'dart:typed_data';
+
+class ShpWriteResult {
+  const ShpWriteResult({required this.shp, required this.shx});
+  final Uint8List shp;
+  final Uint8List shx;
+}
+
+class ShpWriter {
+  const ShpWriter();
+
+  /// Writes polygon shapefile (shape type 5).
+  /// [geometries]: one entry per feature; each entry is a list of rings;
+  /// each ring is a list of [longitude, latitude] pairs.
+  ShpWriteResult writePolygons(List<List<List<List<double>>>> geometries) =>
+      _write(5, geometries);
+
+  /// Writes polyline shapefile (shape type 3).
+  /// [geometries]: one entry per feature; each entry is a list of parts;
+  /// each part is a list of [longitude, latitude] pairs.
+  ShpWriteResult writePolylines(List<List<List<List<double>>>> geometries) =>
+      _write(3, geometries);
+
+  ShpWriteResult _write(
+    int shapeType,
+    List<List<List<List<double>>>> geometries,
+  ) {
+    final contents =
+        geometries.map((parts) => _buildContent(shapeType, parts)).toList();
+
+    var minX = double.infinity;
+    var minY = double.infinity;
+    var maxX = double.negativeInfinity;
+    var maxY = double.negativeInfinity;
+    for (final parts in geometries) {
+      for (final part in parts) {
+        for (final pt in part) {
+          if (pt[0] < minX) minX = pt[0];
+          if (pt[0] > maxX) maxX = pt[0];
+          if (pt[1] < minY) minY = pt[1];
+          if (pt[1] > maxY) maxY = pt[1];
+        }
+      }
+    }
+    if (geometries.isEmpty) minX = minY = maxX = maxY = 0.0;
+
+    final shpSize =
+        100 + contents.fold<int>(0, (acc, c) => acc + 8 + c.length);
+    final shxSize = 100 + geometries.length * 8;
+
+    final shpData = ByteData(shpSize);
+    final shxData = ByteData(shxSize);
+
+    _writeFileHeader(shpData, shapeType, shpSize, minX, minY, maxX, maxY);
+    _writeFileHeader(shxData, shapeType, shxSize, minX, minY, maxX, maxY);
+
+    var shpByteOffset = 100;
+    var shxByteOffset = 100;
+    var shpWordOffset = 50; // 100 bytes ÷ 2
+
+    for (var i = 0; i < contents.length; i++) {
+      final content = contents[i];
+      final contentWords = content.length ~/ 2;
+
+      // SHP: 8-byte record header
+      shpData.setInt32(shpByteOffset, i + 1, Endian.big);
+      shpData.setInt32(shpByteOffset + 4, contentWords, Endian.big);
+      shpByteOffset += 8;
+
+      // SHP: content bytes
+      for (var b = 0; b < content.length; b++) {
+        shpData.setUint8(shpByteOffset + b, content.getUint8(b));
+      }
+      shpByteOffset += content.length;
+
+      // SHX: 8-byte entry (offset + content length, both in 16-bit words)
+      shxData.setInt32(shxByteOffset, shpWordOffset, Endian.big);
+      shxData.setInt32(shxByteOffset + 4, contentWords, Endian.big);
+      shxByteOffset += 8;
+
+      shpWordOffset += 4 + contentWords; // 8-byte record header = 4 words
+    }
+
+    return ShpWriteResult(
+      shp: shpData.buffer.asUint8List(),
+      shx: shxData.buffer.asUint8List(),
+    );
+  }
+
+  void _writeFileHeader(
+    ByteData data,
+    int shapeType,
+    int fileSizeBytes,
+    double minX,
+    double minY,
+    double maxX,
+    double maxY,
+  ) {
+    data.setInt32(0, 9994, Endian.big);
+    // bytes 4–23: unused (zero-filled by default)
+    data.setInt32(24, fileSizeBytes ~/ 2, Endian.big); // file length in words
+    data.setInt32(28, 1000, Endian.little); // version
+    data.setInt32(32, shapeType, Endian.little);
+    data.setFloat64(36, minX, Endian.little);
+    data.setFloat64(44, minY, Endian.little);
+    data.setFloat64(52, maxX, Endian.little);
+    data.setFloat64(60, maxY, Endian.little);
+    // bytes 68–99: Zmin, Zmax, Mmin, Mmax (zero)
+  }
+
+  ByteData _buildContent(int shapeType, List<List<List<double>>> parts) {
+    final numParts = parts.length;
+    final numPoints =
+        parts.fold<int>(0, (acc, p) => acc + p.length);
+
+    var minX = double.infinity;
+    var minY = double.infinity;
+    var maxX = double.negativeInfinity;
+    var maxY = double.negativeInfinity;
+    for (final part in parts) {
+      for (final pt in part) {
+        if (pt[0] < minX) minX = pt[0];
+        if (pt[0] > maxX) maxX = pt[0];
+        if (pt[1] < minY) minY = pt[1];
+        if (pt[1] > maxY) maxY = pt[1];
+      }
+    }
+
+    // 4 (shapeType) + 32 (bbox) + 4 (numParts) + 4 (numPoints)
+    // + numParts*4 (parts array) + numPoints*16 (XY pairs)
+    final size = 4 + 32 + 4 + 4 + numParts * 4 + numPoints * 16;
+    final d = ByteData(size);
+    var o = 0;
+
+    d.setInt32(o, shapeType, Endian.little); o += 4;
+    d.setFloat64(o, minX, Endian.little); o += 8;
+    d.setFloat64(o, minY, Endian.little); o += 8;
+    d.setFloat64(o, maxX, Endian.little); o += 8;
+    d.setFloat64(o, maxY, Endian.little); o += 8;
+    d.setInt32(o, numParts, Endian.little); o += 4;
+    d.setInt32(o, numPoints, Endian.little); o += 4;
+
+    var pointIndex = 0;
+    for (var i = 0; i < parts.length; i++) {
+      d.setInt32(o, pointIndex, Endian.little);
+      o += 4;
+      pointIndex += parts[i].length;
+    }
+
+    for (final part in parts) {
+      for (final pt in part) {
+        d.setFloat64(o, pt[0], Endian.little); o += 8;
+        d.setFloat64(o, pt[1], Endian.little); o += 8;
+      }
+    }
+
+    return d;
+  }
+}
+```
+
+- [ ] **Step 3: Run tests — expect all to pass**
+
+Run: `flutter test test/core/sync/shapefile/export/shp_writer_test.dart`
+Expected: All tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/core/sync/shapefile/export/shp_writer.dart \
+        test/core/sync/shapefile/export/shp_writer_test.dart
+git commit -m "feat(export): add ShpWriter with round-trip tests"
+```
+
+---
+
+## Task 3: `DbfWriter` — binary `.dbf` writer
+
+**Files:**
+- Create: `lib/core/sync/shapefile/export/dbf_writer.dart`
+- Create: `test/core/sync/shapefile/export/dbf_writer_test.dart`
+
+`DbfWriter` is a pure function. The existing `DbfParser` is used for round-trip verification.
+
+- [ ] **Step 1: Create the test file and run it to confirm it fails**
+
+```dart
+// test/core/sync/shapefile/export/dbf_writer_test.dart
+import 'package:firecheck/core/sync/shapefile/dbf_parser.dart';
+import 'package:firecheck/core/sync/shapefile/export/dbf_writer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const writer = DbfWriter();
+  const parser = DbfParser();
+
+  final fields = [
+    const DbfFieldDef(name: 'FEAT_ID', type: 'C', width: 36),
+    const DbfFieldDef(name: 'STOREYS', type: 'N', width: 3),
+    const DbfFieldDef(name: 'NOT_EXIST', type: 'L', width: 1),
+    const DbfFieldDef(name: 'REMARKS', type: 'C', width: 254),
+  ];
+
+  test('round-trip: written DBF parses back with correct field names and types', () {
+    final bytes = writer.write(fields, []);
+    final result = parser.parse(bytes);
+
+    expect(result.fields, hasLength(4));
+    expect(result.fields[0].name, equals('FEAT_ID'));
+    expect(result.fields[0].type, equals('C'));
+    expect(result.fields[1].name, equals('STOREYS'));
+    expect(result.fields[1].type, equals('N'));
+    expect(result.fields[2].name, equals('NOT_EXIST'));
+    expect(result.fields[2].type, equals('L'));
+    expect(result.fields[3].name, equals('REMARKS'));
+  });
+
+  test('round-trip: C field value survives write and parse', () {
+    final bytes = writer.write(fields, [
+      {'FEAT_ID': 'abc-123', 'STOREYS': null, 'NOT_EXIST': null, 'REMARKS': null},
+    ]);
+    final result = parser.parse(bytes);
+
+    expect(result.records, hasLength(1));
+    expect(result.records.first['FEAT_ID'], equals('abc-123'));
+  });
+
+  test('round-trip: N field value is right-aligned and parses back trimmed', () {
+    final bytes = writer.write(fields, [
+      {'FEAT_ID': null, 'STOREYS': '42', 'NOT_EXIST': null, 'REMARKS': null},
+    ]);
+    final result = parser.parse(bytes);
+    expect(result.records.first['STOREYS'], equals('42'));
+  });
+
+  test('round-trip: L field T writes as T', () {
+    final bytes = writer.write(fields, [
+      {'FEAT_ID': null, 'STOREYS': null, 'NOT_EXIST': 'T', 'REMARKS': null},
+    ]);
+    final result = parser.parse(bytes);
+    expect(result.records.first['NOT_EXIST'], equals('T'));
+  });
+
+  test('round-trip: L field F writes as F', () {
+    final bytes = writer.write(fields, [
+      {'FEAT_ID': null, 'STOREYS': null, 'NOT_EXIST': 'F', 'REMARKS': null},
+    ]);
+    final result = parser.parse(bytes);
+    expect(result.records.first['NOT_EXIST'], equals('F'));
+  });
+
+  test('null C value writes as blank (empty string after trim)', () {
+    final bytes = writer.write(fields, [
+      {'FEAT_ID': null, 'STOREYS': null, 'NOT_EXIST': null, 'REMARKS': null},
+    ]);
+    final result = parser.parse(bytes);
+    expect(result.records.first['REMARKS'], isEmpty);
+  });
+
+  test('pipe-delimited value survives round-trip intact', () {
+    const pipeValue = 'sprinkler|extinguisher|hose';
+    final bytes = writer.write(fields, [
+      {'FEAT_ID': null, 'STOREYS': null, 'NOT_EXIST': null, 'REMARKS': pipeValue},
+    ]);
+    final result = parser.parse(bytes);
+    expect(result.records.first['REMARKS'], equals(pipeValue));
+  });
+
+  test('multiple records all present in output', () {
+    final bytes = writer.write(fields, [
+      {'FEAT_ID': 'id-1', 'STOREYS': '1', 'NOT_EXIST': 'F', 'REMARKS': null},
+      {'FEAT_ID': 'id-2', 'STOREYS': '2', 'NOT_EXIST': 'T', 'REMARKS': 'note'},
+    ]);
+    final result = parser.parse(bytes);
+
+    expect(result.records, hasLength(2));
+    expect(result.records[0]['FEAT_ID'], equals('id-1'));
+    expect(result.records[1]['FEAT_ID'], equals('id-2'));
+    expect(result.records[1]['NOT_EXIST'], equals('T'));
+  });
+}
+```
+
+Run: `flutter test test/core/sync/shapefile/export/dbf_writer_test.dart`
+Expected: compilation error — `DbfWriter` does not exist yet.
+
+- [ ] **Step 2: Implement `DbfWriter`**
+
+```dart
+// lib/core/sync/shapefile/export/dbf_writer.dart
+import 'dart:typed_data';
+
+class DbfFieldDef {
+  const DbfFieldDef({
+    required this.name,
+    required this.type,
+    required this.width,
+    this.decimals = 0,
+  });
+  final String name;    // max 10 chars, ASCII
+  final String type;    // 'C', 'N', or 'L'
+  final int width;
+  final int decimals;
+}
+
+class DbfWriter {
+  const DbfWriter();
+
+  /// Writes a dBASE III+ .dbf file.
+  ///
+  /// [fields]: column definitions.
+  /// [records]: one map per row; keys are field names; null values write as blank.
+  /// For 'L' fields pass 'T' or 'F'; for 'N' fields pass the numeric string.
+  Uint8List write(
+    List<DbfFieldDef> fields,
+    List<Map<String, String?>> records,
+  ) {
+    final recordCount = records.length;
+    final fieldCount = fields.length;
+    final headerSize = 32 + 32 * fieldCount + 1; // +1 for 0x0D terminator
+    final recordSize =
+        1 + fields.fold<int>(0, (acc, f) => acc + f.width); // 1 for deletion flag
+    final totalSize = headerSize + recordCount * recordSize + 1; // +1 for 0x1A EOF
+
+    final d = ByteData(totalSize);
+    var o = 0;
+
+    // File header (32 bytes)
+    final now = DateTime.now();
+    d.setUint8(o, 0x03); o++;          // version
+    d.setUint8(o, now.year - 1900); o++; // YY
+    d.setUint8(o, now.month); o++;     // MM
+    d.setUint8(o, now.day); o++;       // DD
+    d.setInt32(o, recordCount, Endian.little); o += 4;
+    d.setUint16(o, headerSize, Endian.little); o += 2;
+    d.setUint16(o, recordSize, Endian.little); o += 2;
+    o += 20; // reserved (zero)
+
+    // Field descriptors (32 bytes each)
+    for (final field in fields) {
+      final nameBytes = field.name.codeUnits;
+      for (var i = 0; i < 11; i++) {
+        d.setUint8(o + i, i < nameBytes.length ? nameBytes[i] : 0);
+      }
+      o += 11;
+      d.setUint8(o, field.type.codeUnitAt(0)); o++;
+      o += 4; // reserved
+      d.setUint8(o, field.width); o++;
+      d.setUint8(o, field.decimals); o++;
+      o += 14; // reserved
+    }
+
+    // Header terminator
+    d.setUint8(o, 0x0D); o++;
+
+    // Records
+    for (final record in records) {
+      d.setUint8(o, 0x20); o++; // deletion flag: space = active
+      for (final field in fields) {
+        final value = record[field.name];
+        final encoded = _encodeField(field, value);
+        for (var i = 0; i < field.width; i++) {
+          d.setUint8(o + i, encoded[i]);
+        }
+        o += field.width;
+      }
+    }
+
+    // EOF marker
+    d.setUint8(o, 0x1A);
+
+    return d.buffer.asUint8List();
+  }
+
+  List<int> _encodeField(DbfFieldDef field, String? value) {
+    final out = List<int>.filled(field.width, 0x20); // space-filled
+    if (value == null || value.isEmpty) return out;
+
+    switch (field.type) {
+      case 'C':
+        // Left-align, right-pad with spaces
+        final bytes = value.codeUnits;
+        for (var i = 0; i < bytes.length && i < field.width; i++) {
+          out[i] = bytes[i];
+        }
+      case 'N':
+        // Right-align, left-pad with spaces
+        final bytes = value.codeUnits;
+        final start = field.width - bytes.length;
+        for (var i = 0; i < bytes.length; i++) {
+          final idx = start + i;
+          if (idx >= 0 && idx < field.width) out[idx] = bytes[i];
+        }
+      case 'L':
+        // Single char: T or F
+        out[0] = value.codeUnitAt(0);
+    }
+    return out;
+  }
+}
+```
+
+- [ ] **Step 3: Run tests — expect all to pass**
+
+Run: `flutter test test/core/sync/shapefile/export/dbf_writer_test.dart`
+Expected: All tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/core/sync/shapefile/export/dbf_writer.dart \
+        test/core/sync/shapefile/export/dbf_writer_test.dart
+git commit -m "feat(export): add DbfWriter with round-trip tests"
+```
+
+---
+
+## Task 4: `ShapefileExporter` — orchestrator
+
+**Files:**
+- Create: `lib/core/sync/shapefile/export/shapefile_exporter.dart`
+- Create: `test/core/sync/shapefile/export/shapefile_exporter_test.dart`
+
+The exporter queries Drift, builds layer data, runs writers in a `compute` isolate, zips with `archive`, writes to temp dir, and calls `SharePlus`. Tests use a real in-memory Drift DB seeded with fixture data. `SharePlus` is abstracted behind a thin callback so tests can verify the zip path without invoking platform channels.
+
+- [ ] **Step 1: Write the failing tests**
+
+```dart
+// test/core/sync/shapefile/export/shapefile_exporter_test.dart
+import 'dart:convert';
+
+import 'package:archive/archive.dart';
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Helper: insert a completed building feature with its submission and attrs.
+Future<void> _seedBuilding(
+  AppDatabase db, {
+  required String assignmentId,
+  required String featureId,
+  required String submissionId,
+  bool doesNotExist = false,
+  List<String> geometryRing = const [
+    [120.0, 14.0], [121.0, 14.0], [121.0, 15.0], [120.0, 15.0], [120.0, 14.0],
+  ],
+}) async {
+  final geoJson = jsonEncode({
+    'type': 'Polygon',
+    'coordinates': [geometryRing],
+  });
+
+  await db.into(db.features).insert(FeaturesCompanion.insert(
+    id: featureId,
+    assignmentId: assignmentId,
+    featureType: 'building',
+    geometryGeojson: geoJson,
+    isNew: const Value(false),
+    status: const Value('complete'),
+    createdAt: DateTime.now(),
+  ));
+
+  await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+    id: submissionId,
+    featureId: featureId,
+    doesNotExist: Value(doesNotExist),
+    syncStatus: const Value('ready_to_upload'),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  ));
+
+  await db.into(db.buildingAttributes).insert(BuildingAttributesCompanion.insert(
+    submissionId: submissionId,
+    cbmsId: const Value('C001'),
+    buildingName: const Value('Test Hall'),
+    ra9514Type: const Value('Group E'),
+    storeys: const Value(3),
+    material: const Value('Concrete'),
+    costAmount: const Value(500000.0),
+    fireFightingFacilitiesJson: const Value('["sprinkler","extinguisher"]'),
+    fireLoadJson: const Value('["paper","chemicals"]'),
+  ));
+}
+
+// Helper: insert a completed road feature with its submission and attrs.
+Future<void> _seedRoad(
+  AppDatabase db, {
+  required String assignmentId,
+  required String featureId,
+  required String submissionId,
+}) async {
+  final geoJson = jsonEncode({
+    'type': 'LineString',
+    'coordinates': [[120.0, 14.0], [121.0, 14.5]],
+  });
+
+  await db.into(db.features).insert(FeaturesCompanion.insert(
+    id: featureId,
+    assignmentId: assignmentId,
+    featureType: 'road',
+    geometryGeojson: geoJson,
+    isNew: const Value(false),
+    status: const Value('complete'),
+    createdAt: DateTime.now(),
+  ));
+
+  await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+    id: submissionId,
+    featureId: featureId,
+    syncStatus: const Value('ready_to_upload'),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  ));
+
+  await db.into(db.roadAttributes).insert(RoadAttributesCompanion.insert(
+    submissionId: submissionId,
+    roadName: const Value('Main St'),
+    widthMeters: const Value(8.0),
+    roadFeaturesJson: const Value('["Pedestrian"]'),
+  ));
+}
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() => db.close());
+
+  ShapefileExporter _makeExporter({List<String>? capturedPaths}) {
+    return ShapefileExporter(
+      db: db,
+      shareFile: (path) async {
+        capturedPaths?.add(path);
+      },
+      tempDirOverride: Directory.systemTemp.createTempSync('shp_test_'),
+    );
+  }
+
+  test('two buildings + one road → ZIP contains exactly 10 files', () async {
+    const assignmentId = 'assignment-001';
+    await _seedBuilding(db, assignmentId: assignmentId, featureId: 'f1', submissionId: 's1');
+    await _seedBuilding(db, assignmentId: assignmentId, featureId: 'f2', submissionId: 's2');
+    await _seedRoad(db, assignmentId: assignmentId, featureId: 'f3', submissionId: 's3');
+
+    final result = await _makeExporter().export(assignmentId: assignmentId);
+
+    expect(result, isNull); // null = success (no ExportFailure)
+  });
+
+  test('two buildings + one road → ZIP file is created and has 10 entries', () async {
+    const assignmentId = 'assignment-001';
+    await _seedBuilding(db, assignmentId: assignmentId, featureId: 'f1', submissionId: 's1');
+    await _seedBuilding(db, assignmentId: assignmentId, featureId: 'f2', submissionId: 's2');
+    await _seedRoad(db, assignmentId: assignmentId, featureId: 'f3', submissionId: 's3');
+
+    final capturedPaths = <String>[];
+    await _makeExporter(capturedPaths: capturedPaths).export(assignmentId: assignmentId);
+
+    expect(capturedPaths, hasLength(1));
+    final zipBytes = await File(capturedPaths.first).readAsBytes();
+    final archive = ZipDecoder().decodeBytes(zipBytes);
+    expect(archive.files, hasLength(10)); // 5 buildings + 5 roads
+  });
+
+  test('only buildings → ZIP contains 5 building files only', () async {
+    const assignmentId = 'assignment-002';
+    await _seedBuilding(db, assignmentId: assignmentId, featureId: 'f1', submissionId: 's1');
+
+    final capturedPaths = <String>[];
+    await _makeExporter(capturedPaths: capturedPaths).export(assignmentId: assignmentId);
+
+    final zipBytes = await File(capturedPaths.first).readAsBytes();
+    final archive = ZipDecoder().decodeBytes(zipBytes);
+    expect(archive.files, hasLength(5));
+    expect(archive.files.map((f) => f.name), everyElement(startsWith('buildings')));
+  });
+
+  test('no completed features → returns NoCompletedFeatures failure', () async {
+    const assignmentId = 'assignment-003';
+    final failure = await _makeExporter().export(assignmentId: assignmentId);
+    expect(failure, isA<NoCompletedFeatures>());
+  });
+
+  test('doesNotExist building is included in output', () async {
+    const assignmentId = 'assignment-004';
+    await _seedBuilding(
+      db,
+      assignmentId: assignmentId,
+      featureId: 'f1',
+      submissionId: 's1',
+      doesNotExist: true,
+    );
+
+    final capturedPaths = <String>[];
+    await _makeExporter(capturedPaths: capturedPaths).export(assignmentId: assignmentId);
+
+    final zipBytes = await File(capturedPaths.first).readAsBytes();
+    final archive = ZipDecoder().decodeBytes(zipBytes);
+    final dbfEntry = archive.files.firstWhere((f) => f.name == 'buildings.dbf');
+    // The DBF will have 1 record with NOT_EXIST=T
+    expect(dbfEntry.content, isNotEmpty);
+  });
+}
+```
+
+Run: `flutter test test/core/sync/shapefile/export/shapefile_exporter_test.dart`
+Expected: compilation error — `ShapefileExporter` does not exist yet.
+
+- [ ] **Step 2: Implement `ShapefileExporter`**
+
+```dart
+// lib/core/sync/shapefile/export/shapefile_exporter.dart
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/shapefile/export/dbf_writer.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
+import 'package:firecheck/core/sync/shapefile/export/shp_writer.dart';
+import 'package:flutter/foundation.dart';
+import 'package:intl/intl.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+// ── Field definitions ────────────────────────────────────────────────────────
+
+const _buildingFields = [
+  DbfFieldDef(name: 'FEAT_ID',    type: 'C', width: 36),
+  DbfFieldDef(name: 'CBMS_ID',    type: 'C', width: 20),
+  DbfFieldDef(name: 'BLDG_NAME',  type: 'C', width: 60),
+  DbfFieldDef(name: 'RA9514_TYPE',type: 'C', width: 20),
+  DbfFieldDef(name: 'STOREYS',    type: 'N', width: 3),
+  DbfFieldDef(name: 'MATERIAL',   type: 'C', width: 30),
+  DbfFieldDef(name: 'COST_EXACT', type: 'L', width: 1),
+  DbfFieldDef(name: 'COST_AMT',   type: 'N', width: 12, decimals: 2),
+  DbfFieldDef(name: 'COST_RANGE', type: 'C', width: 20),
+  DbfFieldDef(name: 'FIRE_FACIL', type: 'C', width: 254),
+  DbfFieldDef(name: 'FIRE_LOAD',  type: 'C', width: 254),
+  DbfFieldDef(name: 'NOT_EXIST',  type: 'L', width: 1),
+  DbfFieldDef(name: 'REMARKS',    type: 'C', width: 254),
+];
+
+const _roadFields = [
+  DbfFieldDef(name: 'FEAT_ID',    type: 'C', width: 36),
+  DbfFieldDef(name: 'IS_BRIDGE',  type: 'L', width: 1),
+  DbfFieldDef(name: 'ROAD_NAME',  type: 'C', width: 60),
+  DbfFieldDef(name: 'WIDTH_M',    type: 'N', width: 8, decimals: 2),
+  DbfFieldDef(name: 'ROAD_FEAT',  type: 'C', width: 254),
+  DbfFieldDef(name: 'OTHER_DESC', type: 'C', width: 254),
+  DbfFieldDef(name: 'NOT_EXIST',  type: 'L', width: 1),
+  DbfFieldDef(name: 'REMARKS',    type: 'C', width: 254),
+];
+
+const _prjContent =
+    'GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",'
+    'SPHEROID["WGS_1984",6378137.0,298.257223563]],'
+    'PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]]';
+
+// ── Compute payload ──────────────────────────────────────────────────────────
+
+class _LayerInput {
+  const _LayerInput({
+    required this.layerName,
+    required this.isPolygon,
+    required this.geometries,
+    required this.records,
+    required this.fields,
+  });
+  final String layerName;
+  final bool isPolygon;
+  final List<List<List<List<double>>>> geometries;
+  final List<Map<String, String?>> records;
+  final List<DbfFieldDef> fields;
+}
+
+class _LayerOutput {
+  const _LayerOutput({
+    required this.layerName,
+    required this.shp,
+    required this.shx,
+    required this.dbf,
+  });
+  final String layerName;
+  final Uint8List shp;
+  final Uint8List shx;
+  final Uint8List dbf;
+}
+
+// Top-level function required by compute().
+_LayerOutput _writeLayer(_LayerInput input) {
+  final writer = const ShpWriter();
+  final shpResult = input.isPolygon
+      ? writer.writePolygons(input.geometries)
+      : writer.writePolylines(input.geometries);
+  final dbf = const DbfWriter().write(input.fields, input.records);
+  return _LayerOutput(
+    layerName: input.layerName,
+    shp: shpResult.shp,
+    shx: shpResult.shx,
+    dbf: dbf,
+  );
+}
+
+// ── Exporter ─────────────────────────────────────────────────────────────────
+
+class ShapefileExporter {
+  ShapefileExporter({
+    required AppDatabase db,
+    Future<void> Function(String path)? shareFile,
+    Directory? tempDirOverride,
+  })  : _db = db,
+        _shareFile = shareFile,
+        _tempDirOverride = tempDirOverride;
+
+  final AppDatabase _db;
+  final Future<void> Function(String path)? _shareFile;
+  final Directory? _tempDirOverride;
+
+  /// Returns null on success; returns an [ExportFailure] subtype on failure.
+  Future<ExportFailure?> export({required String assignmentId}) async {
+    // ── 1. Query DB on main isolate ──────────────────────────────────────────
+    final features = await (_db.select(_db.features)
+          ..where(
+            (t) =>
+                t.assignmentId.equals(assignmentId) &
+                t.status.equals('complete'),
+          ))
+        .get();
+
+    if (features.isEmpty) return const NoCompletedFeatures();
+
+    final featureIds = features.map((f) => f.id).toList();
+    final submissions = await (_db.select(_db.submissions)
+          ..where((t) => t.featureId.isIn(featureIds)))
+        .get();
+    final submissionIds = submissions.map((s) => s.id).toList();
+
+    final buildingAttrs = await (_db.select(_db.buildingAttributes)
+          ..where((t) => t.submissionId.isIn(submissionIds)))
+        .get();
+    final roadAttrs = await (_db.select(_db.roadAttributes)
+          ..where((t) => t.submissionId.isIn(submissionIds)))
+        .get();
+
+    // Index submissions and attrs by featureId / submissionId for O(1) lookup
+    final subByFeatureId = {for (final s in submissions) s.featureId: s};
+    final buildingBySubId = {for (final a in buildingAttrs) a.submissionId: a};
+    final roadBySubId = {for (final a in roadAttrs) a.submissionId: a};
+
+    // ── 2. Split features by type and build layer inputs ─────────────────────
+    final buildingFeatures = features.where((f) => f.featureType == 'building').toList();
+    final roadFeatures = features.where((f) => f.featureType == 'road').toList();
+
+    final layers = <_LayerInput>[];
+
+    if (buildingFeatures.isNotEmpty) {
+      final geometries = <List<List<List<double>>>>[];
+      final records = <Map<String, String?>>[];
+      for (final f in buildingFeatures) {
+        geometries.add(_parsePolygonParts(f.geometryGeojson));
+        final sub = subByFeatureId[f.id];
+        final attr = sub != null ? buildingBySubId[sub.id] : null;
+        records.add(_buildingRecord(f.id, sub, attr));
+      }
+      layers.add(_LayerInput(
+        layerName: 'buildings',
+        isPolygon: true,
+        geometries: geometries,
+        records: records,
+        fields: _buildingFields,
+      ));
+    }
+
+    if (roadFeatures.isNotEmpty) {
+      final geometries = <List<List<List<double>>>>[];
+      final records = <Map<String, String?>>[];
+      for (final f in roadFeatures) {
+        geometries.add(_parsePolylineParts(f.geometryGeojson));
+        final sub = subByFeatureId[f.id];
+        final attr = sub != null ? roadBySubId[sub.id] : null;
+        records.add(_roadRecord(f.id, sub, attr));
+      }
+      layers.add(_LayerInput(
+        layerName: 'roads',
+        isPolygon: false,
+        geometries: geometries,
+        records: records,
+        fields: _roadFields,
+      ));
+    }
+
+    // ── 3. Write bytes in compute isolate ─────────────────────────────────────
+    final outputs = <_LayerOutput>[];
+    try {
+      for (final layer in layers) {
+        final out = await compute(_writeLayer, layer);
+        outputs.add(out);
+      }
+    } catch (e) {
+      return WriteError(e.toString());
+    }
+
+    // ── 4. ZIP all files ──────────────────────────────────────────────────────
+    final archive = Archive();
+    const prjBytes = _prjContent;
+    const cpgBytes = 'UTF-8';
+
+    for (final out in outputs) {
+      final name = out.layerName;
+      archive.addFile(ArchiveFile('$name.shp', out.shp.length, out.shp));
+      archive.addFile(ArchiveFile('$name.shx', out.shx.length, out.shx));
+      archive.addFile(ArchiveFile('$name.dbf', out.dbf.length, out.dbf));
+      final prj = prjBytes.codeUnits;
+      archive.addFile(ArchiveFile('$name.prj', prj.length, prj));
+      final cpg = cpgBytes.codeUnits;
+      archive.addFile(ArchiveFile('$name.cpg', cpg.length, cpg));
+    }
+
+    final zipBytes = ZipEncoder().encode(archive)!;
+
+    // ── 5. Write ZIP to temp dir ──────────────────────────────────────────────
+    try {
+      final dir = _tempDirOverride ?? await getTemporaryDirectory();
+      final ts = DateFormat('yyyyMMdd_HHmmss').format(DateTime.now());
+      final zipPath = p.join(dir.path, 'firecheck_${assignmentId}_$ts.zip');
+      await File(zipPath).writeAsBytes(zipBytes);
+
+      // ── 6. Share ─────────────────────────────────────────────────────────────
+      final shareFn = _shareFile ?? _defaultShare;
+      await shareFn(zipPath);
+    } catch (e) {
+      return WriteError(e.toString());
+    }
+
+    return null;
+  }
+
+  static Future<void> _defaultShare(String path) async {
+    // Imported inline to avoid top-level share_plus import in tests.
+    // ignore: avoid_dynamic_calls
+    await _invokeShare(path);
+  }
+
+  // ── GeoJSON parsing helpers ───────────────────────────────────────────────
+
+  List<List<List<double>>> _parsePolygonParts(String geojson) {
+    final json = jsonDecode(geojson) as Map<String, dynamic>;
+    final type = json['type'] as String;
+    final coords = json['coordinates'] as List<dynamic>;
+    if (type == 'MultiPolygon') {
+      final rings = <List<List<double>>>[];
+      for (final polygon in coords) {
+        for (final ring in polygon as List<dynamic>) {
+          rings.add(_toPoints(ring as List<dynamic>));
+        }
+      }
+      return rings;
+    }
+    // Polygon
+    return (coords).map((ring) => _toPoints(ring as List<dynamic>)).toList();
+  }
+
+  List<List<List<double>>> _parsePolylineParts(String geojson) {
+    final json = jsonDecode(geojson) as Map<String, dynamic>;
+    final type = json['type'] as String;
+    final coords = json['coordinates'] as List<dynamic>;
+    if (type == 'MultiLineString') {
+      return coords.map((part) => _toPoints(part as List<dynamic>)).toList();
+    }
+    // LineString
+    return [_toPoints(coords)];
+  }
+
+  List<List<double>> _toPoints(List<dynamic> coords) {
+    return coords
+        .map((pt) => (pt as List<dynamic>)
+            .map((v) => (v as num).toDouble())
+            .toList())
+        .toList();
+  }
+
+  // ── Record builders ───────────────────────────────────────────────────────
+
+  Map<String, String?> _buildingRecord(
+    String featureId,
+    Submission? sub,
+    BuildingAttribute? attr,
+  ) {
+    return {
+      'FEAT_ID':    featureId,
+      'CBMS_ID':    attr?.cbmsId,
+      'BLDG_NAME':  attr?.buildingName,
+      'RA9514_TYPE': attr?.ra9514Type,
+      'STOREYS':    attr?.storeys?.toString(),
+      'MATERIAL':   attr?.material,
+      'COST_EXACT': attr != null ? (attr.costIsExact ? 'T' : 'F') : null,
+      'COST_AMT':   attr?.costAmount?.toStringAsFixed(2),
+      'COST_RANGE': attr?.costEstimateRange,
+      'FIRE_FACIL': _toPipe(attr?.fireFightingFacilitiesJson),
+      'FIRE_LOAD':  _toPipe(attr?.fireLoadJson),
+      'NOT_EXIST':  sub != null ? (sub.doesNotExist ? 'T' : 'F') : null,
+      'REMARKS':    sub?.remarks,
+    };
+  }
+
+  Map<String, String?> _roadRecord(
+    String featureId,
+    Submission? sub,
+    RoadAttribute? attr,
+  ) {
+    return {
+      'FEAT_ID':    featureId,
+      'IS_BRIDGE':  attr != null ? (attr.isBridge ? 'T' : 'F') : null,
+      'ROAD_NAME':  attr?.roadName,
+      'WIDTH_M':    attr?.widthMeters?.toStringAsFixed(2),
+      'ROAD_FEAT':  _toPipe(attr?.roadFeaturesJson),
+      'OTHER_DESC': attr?.othersDescription,
+      'NOT_EXIST':  sub != null ? (sub.doesNotExist ? 'T' : 'F') : null,
+      'REMARKS':    sub?.remarks,
+    };
+  }
+
+  /// Converts a JSON-encoded list of strings to a pipe-delimited string.
+  String? _toPipe(String? json) {
+    if (json == null || json.isEmpty || json == '[]') return null;
+    try {
+      final list = (jsonDecode(json) as List<dynamic>).whereType<String>();
+      final joined = list.join('|');
+      return joined.isEmpty ? null : joined;
+    } on Object {
+      return null;
+    }
+  }
+}
+
+// Isolated import to keep tests free of platform channels.
+Future<void> _invokeShare(String path) async {
+  // ignore: depend_on_referenced_packages
+  final share = await _loadSharePlus();
+  await share(path);
+}
+
+// Lazy-loaded to avoid importing share_plus at the class level.
+Future<Future<void> Function(String)> _loadSharePlus() async {
+  // ignore: invalid_use_of_visible_for_testing_member
+  return (String path) async {
+    // import is deferred to avoid pulling platform channels into tests
+    // ignore: avoid_dynamic_calls
+    final SharePlus = await _getSharePlusClass();
+    await (SharePlus as dynamic).instance.share(
+      _makeShareParams(path),
+    );
+  };
+}
+```
+
+**Note:** The `_defaultShare` / `_invokeShare` approach is awkward for tests. Use a cleaner pattern instead:
+
+Replace the `_defaultShare` static method with a simpler direct import. For production use, construct with the default `shareFile` callback:
+
+```dart
+// In main.dart when constructing the notifier's exporter:
+ShapefileExporter(
+  db: ref.watch(appDatabaseProvider),
+  shareFile: (path) async {
+    await SharePlus.instance.share(ShareParams(files: [XFile(path)]));
+  },
+)
+```
+
+The `shareFile` parameter is `null` by default in the class definition above. Replace the `_defaultShare` and `_invokeShare` helpers with this simpler version in the actual implementation:
+
+```dart
+// lib/core/sync/shapefile/export/shapefile_exporter.dart
+// Replace the bottom section after "── 6. Share ──" with:
+
+      final shareFn = _shareFile;
+      if (shareFn != null) {
+        try {
+          await shareFn(zipPath);
+        } catch (e) {
+          return ShareError(e.toString());
+        }
+      }
+    } catch (e) {
+      return WriteError(e.toString());
+    }
+
+    return null;
+  }
+```
+
+And remove `_defaultShare`, `_invokeShare`, and `_loadSharePlus` entirely. The `shareFile` callback is provided by the notifier (which imports `share_plus` directly). This keeps `shapefile_exporter.dart` free of `share_plus` — cleaner testability.
+
+**Final clean implementation of the export method's bottom half:**
+
+```dart
+    // ── 5. Write ZIP to temp dir ──────────────────────────────────────────────
+    try {
+      final dir = _tempDirOverride ?? await getTemporaryDirectory();
+      final ts = DateFormat('yyyyMMdd_HHmmss').format(DateTime.now());
+      final zipPath = p.join(dir.path, 'firecheck_${assignmentId}_$ts.zip');
+      await File(zipPath).writeAsBytes(zipBytes);
+
+      // ── 6. Invoke share callback (injected by caller) ─────────────────────
+      if (_shareFile != null) {
+        await _shareFile!(zipPath);
+      }
+    } catch (e) {
+      return WriteError(e.toString());
+    }
+
+    return null;
+  }
+```
+
+- [ ] **Step 3: Run tests — expect all to pass**
+
+Run: `flutter test test/core/sync/shapefile/export/shapefile_exporter_test.dart`
+Expected: All tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/core/sync/shapefile/export/shapefile_exporter.dart \
+        test/core/sync/shapefile/export/shapefile_exporter_test.dart
+git commit -m "feat(export): add ShapefileExporter orchestrator with tests"
+```
+
+---
+
+## Task 5: `ShapefileExportNotifier` — Riverpod state machine
+
+**Files:**
+- Create: `lib/features/home/data/shapefile_export_notifier.dart`
+- Create: `test/features/home/shapefile_export_notifier_test.dart`
+
+Follows the same `StateNotifier` pattern as `GetMapsNotifier`. The notifier owns a `ShapefileExporter` instance (injected). State transitions drive the home screen tile.
+
+- [ ] **Step 1: Write the failing tests**
+
+```dart
+// test/features/home/shapefile_export_notifier_test.dart
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
+import 'package:firecheck/features/home/data/shapefile_export_notifier.dart';
+import 'package:firecheck/features/home/domain/export_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+ShapefileExportNotifier _makeNotifier({
+  required String assignmentId,
+  required AppDatabase db,
+  ExportFailure? forceFailure,
+  List<String>? capturedPaths,
+}) {
+  final exporter = ShapefileExporter(
+    db: db,
+    shareFile: (path) async {
+      capturedPaths?.add(path);
+    },
+    tempDirOverride: Directory.systemTemp.createTempSync('notifier_test_'),
+  );
+  return ShapefileExportNotifier(
+    assignmentId: assignmentId,
+    exporter: exporter,
+  );
+}
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() => db.close());
+
+  test('initial state is ExportIdle', () {
+    final notifier = _makeNotifier(assignmentId: 'a1', db: db);
+    expect(notifier.state, isA<ExportIdle>());
+  });
+
+  test('export with no features → stays Idle then transitions to Failed', () async {
+    final notifier = _makeNotifier(assignmentId: 'a1', db: db);
+    final states = <ExportState>[];
+    notifier.addListener(states.add);
+
+    await notifier.export();
+
+    expect(states, [isA<ExportExporting>(), isA<ExportFailed>()]);
+    expect((states.last as ExportFailed).failure, isA<NoCompletedFeatures>());
+  });
+
+  test('tapping export while Exporting is a no-op', () async {
+    final notifier = _makeNotifier(assignmentId: 'a1', db: db);
+    final states = <ExportState>[];
+    notifier.addListener(states.add);
+
+    // Start first export (no features → will complete quickly)
+    final first = notifier.export();
+    // Immediately attempt second export — should be ignored since state is Exporting
+    final second = notifier.export();
+
+    await Future.wait([first, second]);
+
+    // ExportExporting appears exactly once
+    expect(states.whereType<ExportExporting>(), hasLength(1));
+  });
+
+  test('after Failed state, notifier resets to Idle', () async {
+    final notifier = _makeNotifier(assignmentId: 'a1', db: db);
+    await notifier.export(); // fails — no features
+    expect(notifier.state, isA<ExportIdle>());
+  });
+}
+```
+
+Run: `flutter test test/features/home/shapefile_export_notifier_test.dart`
+Expected: compilation error — `ShapefileExportNotifier` does not exist yet.
+
+- [ ] **Step 2: Implement `ShapefileExportNotifier`**
+
+```dart
+// lib/features/home/data/shapefile_export_notifier.dart
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
+import 'package:firecheck/features/assignment/presentation/assignment_providers.dart';
+import 'package:firecheck/features/home/domain/export_state.dart';
+import 'package:firecheck/features/home/presentation/home_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:share_plus/share_plus.dart';
+
+class ShapefileExportNotifier extends StateNotifier<ExportState> {
+  ShapefileExportNotifier({
+    required String assignmentId,
+    required ShapefileExporter exporter,
+  })  : _assignmentId = assignmentId,
+        _exporter = exporter,
+        super(const ExportIdle());
+
+  final String _assignmentId;
+  final ShapefileExporter _exporter;
+
+  Future<void> export() async {
+    if (state is ExportExporting) return;
+    state = const ExportExporting();
+
+    final failure = await _exporter.export(assignmentId: _assignmentId);
+
+    if (!mounted) return;
+    if (failure != null) {
+      state = ExportFailed(failure);
+      // Auto-reset after failure so the tile becomes tappable again.
+      state = const ExportIdle();
+      return;
+    }
+
+    state = const ExportDone();
+    state = const ExportIdle();
+  }
+}
+
+// ── Provider ─────────────────────────────────────────────────────────────────
+
+final shapefileExportNotifierProvider =
+    StateNotifierProvider<ShapefileExportNotifier, ExportState>((ref) {
+  final db = ref.watch(appDatabaseProvider);
+  final assignmentAsync = ref.watch(currentAssignmentProvider);
+  final assignmentId = assignmentAsync.value?.id ?? '';
+
+  return ShapefileExportNotifier(
+    assignmentId: assignmentId,
+    exporter: ShapefileExporter(
+      db: db,
+      shareFile: (path) async {
+        await SharePlus.instance.share(ShareParams(files: [XFile(path)]));
+      },
+    ),
+  );
+});
+```
+
+- [ ] **Step 3: Run tests — expect all to pass**
+
+Run: `flutter test test/features/home/shapefile_export_notifier_test.dart`
+Expected: All tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/features/home/data/shapefile_export_notifier.dart \
+        test/features/home/shapefile_export_notifier_test.dart
+git commit -m "feat(export): add ShapefileExportNotifier with state machine tests"
+```
+
+---
+
+## Task 6: HomeScreen tile + l10n keys
+
+**Files:**
+- Modify: `lib/core/i18n/app_en.arb`
+- Modify: `lib/features/home/presentation/home_screen.dart`
+
+Add the "Export Shapefile" action tile as the 4th tile. It is disabled (greyed out with `onTap: null`) when `completedFeatures == 0`. While `ExportExporting`, the tile shows a `CircularProgressIndicator` trailing widget.
+
+- [ ] **Step 1: Add l10n keys to `app_en.arb`**
+
+Open `lib/core/i18n/app_en.arb` and add these keys before the closing `}`:
+
+```json
+  "exportShapefile": "Export Shapefile",
+  "exportShapefileSubtitle": "Package completed features as .shp",
+  "exportShapefileExporting": "Packaging…",
+  "exportErrorNoFeatures": "No completed features to export.",
+  "exportErrorWriteFailed": "Export failed: could not write files. Please try again.",
+  "exportErrorShareFailed": "Export ready but could not open share sheet. Please try again."
+```
+
+Then run `flutter gen-l10n` (or `flutter pub run build_runner build`) to regenerate `AppLocalizations`.
+
+Run: `flutter gen-l10n`
+Expected: No errors. `lib/generated/l10n/app_localizations.dart` updated.
+
+- [ ] **Step 2: Update `HomeScreen` to add the 4th tile**
+
+In `lib/features/home/presentation/home_screen.dart`:
+
+1. Add imports:
+
+```dart
+import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
+import 'package:firecheck/features/home/data/shapefile_export_notifier.dart';
+import 'package:firecheck/features/home/domain/export_state.dart';
+```
+
+2. Inside `build`, watch the two new providers:
+
+```dart
+    final exportState = ref.watch(shapefileExportNotifierProvider);
+    final isExporting = exportState is ExportExporting;
+```
+
+3. Handle `ExportFailed` to show a SnackBar. Add this block after the existing `final isLocked = ...` line:
+
+```dart
+    ref.listen<ExportState>(shapefileExportNotifierProvider, (prev, next) {
+      if (next is ExportFailed) {
+        final msg = switch (next.failure) {
+          NoCompletedFeatures() => l.exportErrorNoFeatures,
+          WriteError()          => l.exportErrorWriteFailed,
+          ShareError()          => l.exportErrorShareFailed,
+        };
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+      }
+    });
+```
+
+4. Add the 4th tile in the `Column` children list, after the existing `_ActionTile` for `uploadData` (inside the `if (!isLocked)` block, or as its own unconditional tile — export is always available once there are completed features):
+
+```dart
+              _ActionTile(
+                title: isExporting ? l.exportShapefileExporting : l.exportShapefile,
+                subtitle: l.exportShapefileSubtitle,
+                trailing: isExporting
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.chevron_right),
+                onTap: (snap.completedFeatures == 0 || isExporting)
+                    ? null
+                    : () => ref
+                        .read(shapefileExportNotifierProvider.notifier)
+                        .export(),
+              ),
+```
+
+5. Update `_ActionTile` to accept an optional `trailing` widget:
+
+```dart
+class _ActionTile extends StatelessWidget {
+  const _ActionTile({
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+    this.trailing,
+  });
+  final String title;
+  final String subtitle;
+  final VoidCallback? onTap;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        title: Text(title),
+        subtitle: Text(subtitle),
+        trailing: trailing ?? const Icon(Icons.chevron_right),
+        onTap: onTap,
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 3: Run all tests to confirm no regressions**
+
+Run: `flutter test`
+Expected: All tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/core/i18n/app_en.arb \
+        lib/features/home/presentation/home_screen.dart \
+        lib/generated/l10n/
+git commit -m "feat(export): add Export Shapefile tile to HomeScreen"
+```
+
+---
+
+## Self-Review Checklist
+
+After all tasks are complete:
+
+- [ ] `flutter test` — all tests pass
+- [ ] `flutter analyze` — no warnings or errors
+- [ ] Run the app on a simulator: tap "Export Shapefile" with completed features → share sheet appears with a `.zip` file
+- [ ] Unzip the archive in Finder and verify it contains `buildings.shp`, `buildings.shx`, `buildings.dbf`, `buildings.prj`, `buildings.cpg` (and `roads.*` if road features exist)
+- [ ] Open `buildings.shp` in QGIS: verify geometries render, all attribute columns are present, `NOT_EXIST` field shows `T`/`F`

--- a/docs/superpowers/specs/2026-05-02-export-shapefile-design.md
+++ b/docs/superpowers/specs/2026-05-02-export-shapefile-design.md
@@ -1,0 +1,221 @@
+# Export Completed Work as Attributed Shapefiles
+
+**Date:** 2026-05-02
+**Status:** Draft, awaiting review
+**Author:** John Lester Escarlan (with brainstorming assistance)
+**Branch:** 22-as-an-enumerator-i-want-the-app-to-package-my-completed-work-as-attributed-shapefiles-so-that-i-can-hand-it-back-in-the-format-the-course-expects
+
+---
+
+## User Story
+
+> As an Enumerator, I want the app to package my completed work as attributed shapefiles, so that I can hand it back in the format the course expects.
+
+---
+
+## Acceptance Criteria
+
+1. The app provides an export action accessible once an enumeration session has at least one completed feature.
+2. Exporting produces a valid Esri shapefile bundle containing `.shp`, `.shx`, `.dbf`, `.prj`, and `.cpg`.
+3. Each exported feature retains its geometry (point, line, or polygon) and is correctly georeferenced in WGS84 / EPSG:4326.
+4. All field attributes captured during enumeration are written to the `.dbf` table, with column names and data types consistent across records.
+5. Field names conform to shapefile constraints (max 10 characters, no spaces or special characters).
+6. The exported files are bundled into a single `.zip` archive named with the session identifier and timestamp.
+7. The user can save or share the exported archive through the device's standard file/share interface.
+8. If export fails, the user sees a clear error message explaining the cause.
+9. The exported shapefile opens correctly in QGIS or ArcGIS with all attributes intact.
+
+---
+
+## Decisions
+
+| Topic | Choice | Rationale |
+|---|---|---|
+| Shapefile structure | Two shapefiles inside one ZIP (`buildings_*`, `roads_*`) | Shapefile format is homogeneous — polygon and polyline must be separate. One ZIP keeps the handoff simple. |
+| `doesNotExist` features | Included with `NOT_EXIST = T` DBF field | A negative finding is still a finding; omitting silently makes coverage look incomplete. |
+| Export action location | 4th action tile on HomeScreen | Consistent with the existing tile pattern; no new navigation layer needed. |
+| JSON array fields | Pipe-delimited strings (e.g., `"sprinkler\|extinguisher"`) | Human-readable in QGIS attribute table; avoids embedding raw JSON in fixed-width DBF cells. |
+| Writer approach | Pure Dart binary writer, no new dependencies | Mirrors existing `ShpParser`/`DbfParser` pattern. `archive` and `share_plus` already in pubspec. |
+| CRS | WGS84 / EPSG:4326, no reprojection needed | Geometry is stored as GeoJSON (WGS84) in the DB; direct write. |
+| Compute isolation | `compute` isolate for write step | Keeps the UI thread free; consistent with the pattern used elsewhere in the project. |
+| Temp file cleanup | OS-managed via `getTemporaryDirectory()` | No proactive cleanup; consistent with the share-sheet pattern used by Upload Data. |
+| Empty layers | Skip files for a geometry type with zero features | No point writing an empty shapefile; ZIP only contains layers that have data. |
+
+---
+
+## Architecture
+
+### New files
+
+```
+lib/core/sync/shapefile/export/
+  shp_writer.dart          ← writes .shp + .shx bytes (pure function, no Flutter deps)
+  dbf_writer.dart          ← writes .dbf bytes (pure function, no Flutter deps)
+  shapefile_exporter.dart  ← orchestrator: query DB → write → zip → share
+  export_failure.dart      ← sealed failure types
+
+lib/features/home/
+  domain/export_state.dart                     ← Idle | Exporting | Done | Failed
+  data/shapefile_export_notifier.dart          ← Riverpod notifier
+  presentation/home_screen.dart                ← 4th action tile wired to notifier
+```
+
+### Data flow
+
+1. User taps "Export Shapefile" tile on `HomeScreen`.
+2. `ShapefileExportNotifier` transitions to `Exporting`; tile shows loading indicator.
+3. Queries DB: all features with `status = 'complete'` for the current assignment, joined to `submissions` + `building_attributes` / `road_attributes`.
+4. Splits by `featureType`: buildings → `buildings_*` files, roads → `roads_*` files. Layers with zero features are omitted.
+5. In a `compute` isolate: writes `.shp`, `.shx`, `.dbf`, `.prj`, `.cpg` bytes for each non-empty type. The DB query runs on the main isolate first; only plain serializable structs (lists of coordinate arrays and field value maps) are passed into `compute`.
+6. ZIPs all files into `firecheck_<assignmentId>_<yyyyMMddHHmmss>.zip` in `getTemporaryDirectory()`. The session identifier is the `assignments.id` UUID.
+7. Calls `SharePlus.shareXFiles([XFile(zipPath)])` to open the system share sheet.
+8. Notifier transitions to `Done` (resets to `Idle` after share sheet opens) or `Failed`.
+
+---
+
+## Binary Writer Internals
+
+### `ShpWriter`
+
+Produces paired `.shp` and `.shx` `Uint8List` values from a list of GeoJSON geometry objects.
+
+**File header** (100 bytes, identical structure for both files):
+- File code `9994` (big-endian int32)
+- File length in 16-bit words (big-endian int32)
+- Version `1000` (little-endian int32)
+- Shape type: `5` = Polygon, `3` = Polyline (little-endian int32)
+- Bounding box: minX, minY, maxX, maxY as float64 (little-endian)
+- Remaining bbox fields (Zmin/Zmax/Mmin/Mmax) zero-filled
+
+**Per record (`.shp`)**:
+- Record header: record number (1-based, big-endian int32) + content length in 16-bit words (big-endian int32)
+- Content: shape type (little-endian int32) + geometry bytes
+  - Polygon: bbox (4× float64) + numParts (int32) + numPoints (int32) + parts array + points array
+  - Polyline: same layout as Polygon
+
+**Per record (`.shx`)**:
+- 8 bytes: byte offset of record in `.shp` as 16-bit words (big-endian int32) + content length in 16-bit words (big-endian int32)
+
+### `DbfWriter`
+
+Produces `.dbf` `Uint8List` from a field schema and a list of record maps.
+
+**File header** (32 bytes):
+- Version `0x03`
+- Date: YY, MM, DD (3 bytes)
+- Record count (little-endian int32)
+- Header size = `32 + (32 × fieldCount) + 1` (little-endian int16)
+- Record size = `1 + Σ(field widths)` (little-endian int16)
+- Remaining bytes zero-filled
+
+**Field descriptors** (32 bytes each):
+- Name: 11 bytes, null-padded
+- Type char: `C` (character), `N` (numeric), `L` (logical)
+- 4 bytes reserved
+- Field length (uint8)
+- Decimal count (uint8)
+- Remaining bytes zero-filled
+
+**Header terminator**: `0x0D`
+
+**Records**:
+- Deletion flag `0x20` (space = active record)
+- Fixed-width ASCII fields, right-padded with spaces for `C`, left-padded with spaces for `N`
+- `L` fields: `T` or `F`; null values write as space
+
+**EOF marker**: `0x1A`
+
+### Static files
+
+| File | Content |
+|---|---|
+| `.prj` | `GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]]` |
+| `.cpg` | `UTF-8` |
+
+---
+
+## Field Mapping
+
+### Buildings (`buildings.dbf`)
+
+| DB column | DBF name | Type | Width | Notes |
+|---|---|---|---|---|
+| `features.id` | `FEAT_ID` | C | 36 | UUID |
+| `building_attributes.cbmsId` | `CBMS_ID` | C | 20 | |
+| `building_attributes.buildingName` | `BLDG_NAME` | C | 60 | |
+| `building_attributes.ra9514Type` | `RA9514_TYPE` | C | 20 | |
+| `building_attributes.storeys` | `STOREYS` | N | 3 | 0 decimals |
+| `building_attributes.material` | `MATERIAL` | C | 30 | |
+| `building_attributes.costIsExact` | `COST_EXACT` | L | 1 | |
+| `building_attributes.costAmount` | `COST_AMT` | N | 12 | 2 decimals |
+| `building_attributes.costEstimateRange` | `COST_RANGE` | C | 20 | |
+| `building_attributes.fireFightingFacilitiesJson` | `FIRE_FACIL` | C | 254 | pipe-delimited |
+| `building_attributes.fireLoadJson` | `FIRE_LOAD` | C | 254 | pipe-delimited |
+| `submissions.doesNotExist` | `NOT_EXIST` | L | 1 | |
+| `submissions.remarks` | `REMARKS` | C | 254 | |
+
+### Roads (`roads.dbf`)
+
+| DB column | DBF name | Type | Width | Notes |
+|---|---|---|---|---|
+| `features.id` | `FEAT_ID` | C | 36 | UUID |
+| `road_attributes.isBridge` | `IS_BRIDGE` | L | 1 | |
+| `road_attributes.roadName` | `ROAD_NAME` | C | 60 | |
+| `road_attributes.widthMeters` | `WIDTH_M` | N | 8 | 2 decimals |
+| `road_attributes.roadFeaturesJson` | `ROAD_FEAT` | C | 254 | pipe-delimited |
+| `road_attributes.othersDescription` | `OTHER_DESC` | C | 254 | |
+| `submissions.doesNotExist` | `NOT_EXIST` | L | 1 | |
+| `submissions.remarks` | `REMARKS` | C | 254 | |
+
+---
+
+## Error Handling
+
+### `ExportFailure` (sealed class)
+
+| Subtype | Cause | User message |
+|---|---|---|
+| `NoCompletedFeatures` | Export triggered with no completed features | "No completed features to export." |
+| `WriteError(message)` | I/O failure writing to temp directory | "Export failed: could not write files. Please try again." |
+| `ShareError(message)` | `SharePlus` invocation failed | "Export ready but could not open share sheet. Please try again." |
+
+### `ExportState` state machine
+
+```
+Idle ──tap──▶ Exporting ──success──▶ Done ──(auto)──▶ Idle
+                        ──failure──▶ Failed(ExportFailure) ──(snackbar)──▶ Idle
+```
+
+- **`Idle`**: tile enabled if `completedFeatures > 0`, disabled otherwise.
+- **`Exporting`**: tile shows loading indicator; repeat taps are no-ops.
+- **`Done`**: share sheet opens; notifier auto-resets to `Idle`.
+- **`Failed`**: `SnackBar` shows human-readable message; notifier auto-resets to `Idle`.
+
+---
+
+## Testing
+
+### `shp_writer_test.dart`
+- Write a polygon feature → parse bytes with existing `ShpParser` → assert coordinates match
+- Write a polyline feature → same round-trip assertion
+- Assert bounding box in file header matches feature extents
+- Assert `.shx` offsets correctly index each record
+
+### `dbf_writer_test.dart`
+- Write building fields → parse bytes with existing `DbfParser` → assert field names, types, and values match
+- Write road fields → same round-trip assertion
+- Null DB values → blank strings / blank numerics in output
+- `doesNotExist = true` → `NOT_EXIST` field writes `T`
+- JSON array → pipe-delimited string in `FIRE_FACIL` / `ROAD_FEAT`
+
+### `shapefile_exporter_test.dart`
+- 2 completed buildings + 1 completed road → ZIP contains exactly 10 files
+- 0 completed features → `NoCompletedFeatures` failure
+- Only buildings, no roads → ZIP contains 5 building files only (roads layer skipped)
+- Building with `doesNotExist = true` → feature present in output with `NOT_EXIST = T`
+
+### `shapefile_export_notifier_test.dart`
+- Happy path: `Idle → Exporting → Done`
+- Export failure: `Idle → Exporting → Failed(WriteError)`
+- Tap while `Exporting` → state stays `Exporting` (no-op)
+- After `Done` → notifier resets to `Idle`

--- a/lib/core/i18n/app_en.arb
+++ b/lib/core/i18n/app_en.arb
@@ -400,5 +400,11 @@
     }
   },
   "getMapsWarningContinue": "Continue anyway",
-  "getMapsClose": "Close"
+  "getMapsClose": "Close",
+  "exportShapefile": "Export Shapefile",
+  "exportShapefileSubtitle": "Package completed features as .shp",
+  "exportShapefileExporting": "Packaging…",
+  "exportErrorNoFeatures": "No completed features to export.",
+  "exportErrorWriteFailed": "Export failed: could not write files. Please try again.",
+  "exportErrorShareFailed": "Export ready but could not open share sheet. Please try again."
 }

--- a/lib/core/sync/shapefile/export/dbf_writer.dart
+++ b/lib/core/sync/shapefile/export/dbf_writer.dart
@@ -1,4 +1,5 @@
 // lib/core/sync/shapefile/export/dbf_writer.dart
+import 'dart:convert';
 import 'dart:typed_data';
 
 class DbfFieldDef {
@@ -78,12 +79,12 @@ class DbfWriter {
 
     switch (field.type) {
       case 'C':
-        final bytes = value.codeUnits;
+        final bytes = utf8.encode(value);
         for (var i = 0; i < bytes.length && i < field.width; i++) {
           out[i] = bytes[i];
         }
       case 'N':
-        final bytes = value.codeUnits;
+        final bytes = utf8.encode(value);
         final start = field.width - bytes.length;
         for (var i = 0; i < bytes.length; i++) {
           final idx = start + i;

--- a/lib/core/sync/shapefile/export/dbf_writer.dart
+++ b/lib/core/sync/shapefile/export/dbf_writer.dart
@@ -1,0 +1,97 @@
+// lib/core/sync/shapefile/export/dbf_writer.dart
+import 'dart:typed_data';
+
+class DbfFieldDef {
+  const DbfFieldDef({
+    required this.name,
+    required this.type,
+    required this.width,
+    this.decimals = 0,
+  });
+  final String name;    // max 10 chars, ASCII
+  final String type;    // 'C', 'N', or 'L'
+  final int width;
+  final int decimals;
+}
+
+class DbfWriter {
+  const DbfWriter();
+
+  Uint8List write(
+    List<DbfFieldDef> fields,
+    List<Map<String, String?>> records,
+  ) {
+    final recordCount = records.length;
+    final fieldCount = fields.length;
+    final headerSize = 32 + 32 * fieldCount + 1;
+    final recordSize = 1 + fields.fold<int>(0, (acc, f) => acc + f.width);
+    final totalSize = headerSize + recordCount * recordSize + 1;
+
+    final d = ByteData(totalSize);
+    var o = 0;
+
+    final now = DateTime.now();
+    d.setUint8(o, 0x03); o++;
+    d.setUint8(o, now.year - 1900); o++;
+    d.setUint8(o, now.month); o++;
+    d.setUint8(o, now.day); o++;
+    d.setInt32(o, recordCount, Endian.little); o += 4;
+    d.setUint16(o, headerSize, Endian.little); o += 2;
+    d.setUint16(o, recordSize, Endian.little); o += 2;
+    o += 20;
+
+    for (final field in fields) {
+      final nameBytes = field.name.codeUnits;
+      for (var i = 0; i < 11; i++) {
+        d.setUint8(o + i, i < nameBytes.length ? nameBytes[i] : 0);
+      }
+      o += 11;
+      d.setUint8(o, field.type.codeUnitAt(0)); o++;
+      o += 4;
+      d.setUint8(o, field.width); o++;
+      d.setUint8(o, field.decimals); o++;
+      o += 14;
+    }
+
+    d.setUint8(o, 0x0D); o++;
+
+    for (final record in records) {
+      d.setUint8(o, 0x20); o++;
+      for (final field in fields) {
+        final value = record[field.name];
+        final encoded = _encodeField(field, value);
+        for (var i = 0; i < field.width; i++) {
+          d.setUint8(o + i, encoded[i]);
+        }
+        o += field.width;
+      }
+    }
+
+    d.setUint8(o, 0x1A);
+
+    return d.buffer.asUint8List();
+  }
+
+  List<int> _encodeField(DbfFieldDef field, String? value) {
+    final out = List<int>.filled(field.width, 0x20);
+    if (value == null || value.isEmpty) return out;
+
+    switch (field.type) {
+      case 'C':
+        final bytes = value.codeUnits;
+        for (var i = 0; i < bytes.length && i < field.width; i++) {
+          out[i] = bytes[i];
+        }
+      case 'N':
+        final bytes = value.codeUnits;
+        final start = field.width - bytes.length;
+        for (var i = 0; i < bytes.length; i++) {
+          final idx = start + i;
+          if (idx >= 0 && idx < field.width) out[idx] = bytes[i];
+        }
+      case 'L':
+        out[0] = value.codeUnitAt(0);
+    }
+    return out;
+  }
+}

--- a/lib/core/sync/shapefile/export/export_failure.dart
+++ b/lib/core/sync/shapefile/export/export_failure.dart
@@ -1,0 +1,18 @@
+// lib/core/sync/shapefile/export/export_failure.dart
+sealed class ExportFailure {
+  const ExportFailure();
+}
+
+class NoCompletedFeatures extends ExportFailure {
+  const NoCompletedFeatures();
+}
+
+class WriteError extends ExportFailure {
+  const WriteError(this.message);
+  final String message;
+}
+
+class ShareError extends ExportFailure {
+  const ShareError(this.message);
+  final String message;
+}

--- a/lib/core/sync/shapefile/export/shapefile_exporter.dart
+++ b/lib/core/sync/shapefile/export/shapefile_exporter.dart
@@ -122,6 +122,11 @@ _LayerOutput _writeLayer(_LayerInput input) {
   const writer = ShpWriter();
   const dbfWriter = DbfWriter();
 
+  // Geometry and record lists are built in lock-step: index i in geometries
+  // corresponds to index i in records. Do not reorder either list independently.
+  // Both lists are populated from the same ordered source in export() — features
+  // is mapped from buildingRows/roadRows in iteration order, preserving alignment.
+
   // Parse geometries
   final geometries = <List<List<List<double>>>>[];
   for (final f in input.features) {
@@ -415,7 +420,8 @@ class ShapefileExporter {
     }
 
     // Write ZIP to temp directory
-    final zipBytes = ZipEncoder().encode(archive)!;
+    final zipBytes = ZipEncoder().encode(archive);
+    if (zipBytes == null) return const WriteError('ZIP encoding produced no output');
     final tempDir = tempDirOverride ?? await getTemporaryDirectory();
     final timestamp = DateFormat('yyyyMMdd_HHmmss').format(DateTime.now());
     final zipName = 'firecheck_${assignmentId}_$timestamp.zip';

--- a/lib/core/sync/shapefile/export/shapefile_exporter.dart
+++ b/lib/core/sync/shapefile/export/shapefile_exporter.dart
@@ -142,8 +142,8 @@ _LayerOutput _writeLayer(_LayerInput input) {
             (r) => (r as List<dynamic>)
                 .map(
                   (pt) => [
-                    (pt as List<dynamic>)[0] as double,
-                    pt[1] as double,
+                    ((pt as List<dynamic>)[0] as num).toDouble(),
+                    (pt[1] as num).toDouble(),
                   ],
                 )
                 .toList(),
@@ -157,8 +157,8 @@ _LayerOutput _writeLayer(_LayerInput input) {
             (ring as List<dynamic>)
                 .map(
                   (pt) => [
-                    (pt as List<dynamic>)[0] as double,
-                    pt[1] as double,
+                    ((pt as List<dynamic>)[0] as num).toDouble(),
+                    (pt[1] as num).toDouble(),
                   ],
                 )
                 .toList(),

--- a/lib/core/sync/shapefile/export/shapefile_exporter.dart
+++ b/lib/core/sync/shapefile/export/shapefile_exporter.dart
@@ -1,0 +1,556 @@
+// lib/core/sync/shapefile/export/shapefile_exporter.dart
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:drift/drift.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/shapefile/export/dbf_writer.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
+import 'package:firecheck/core/sync/shapefile/export/shp_writer.dart';
+import 'package:flutter/foundation.dart';
+import 'package:intl/intl.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+// ---------------------------------------------------------------------------
+// Serializable structs passed to compute()
+// ---------------------------------------------------------------------------
+
+class _FeatureRow {
+  const _FeatureRow({
+    required this.featureId,
+    required this.geometryGeojson,
+  });
+  final String featureId;
+  final String geometryGeojson;
+}
+
+class _BuildingRow {
+  const _BuildingRow({
+    required this.featureId,
+    required this.doesNotExist,
+    required this.remarks,
+    required this.cbmsId,
+    required this.buildingName,
+    required this.ra9514Type,
+    required this.storeys,
+    required this.material,
+    required this.costIsExact,
+    required this.costAmount,
+    required this.costEstimateRange,
+    required this.fireFightingFacilitiesJson,
+    required this.fireLoadJson,
+  });
+  final String featureId;
+  final bool doesNotExist;
+  final String? remarks;
+  final String? cbmsId;
+  final String? buildingName;
+  final String? ra9514Type;
+  final int? storeys;
+  final String? material;
+  final bool costIsExact;
+  final double? costAmount;
+  final String? costEstimateRange;
+  final String fireFightingFacilitiesJson;
+  final String fireLoadJson;
+}
+
+class _RoadRow {
+  const _RoadRow({
+    required this.featureId,
+    required this.doesNotExist,
+    required this.remarks,
+    required this.isBridge,
+    required this.roadName,
+    required this.widthMeters,
+    required this.roadFeaturesJson,
+    required this.othersDescription,
+  });
+  final String featureId;
+  final bool doesNotExist;
+  final String? remarks;
+  final bool isBridge;
+  final String? roadName;
+  final double? widthMeters;
+  final String roadFeaturesJson;
+  final String? othersDescription;
+}
+
+class _LayerInput {
+  const _LayerInput({
+    required this.layerName,
+    required this.isPolygon,
+    required this.features,
+    required this.buildingRows,
+    required this.roadRows,
+  });
+  final String layerName;
+  final bool isPolygon;
+  final List<_FeatureRow> features;
+  final List<_BuildingRow> buildingRows;
+  final List<_RoadRow> roadRows;
+}
+
+class _LayerOutput {
+  const _LayerOutput({
+    required this.layerName,
+    required this.shp,
+    required this.shx,
+    required this.dbf,
+  });
+  final String layerName;
+  final List<int> shp;
+  final List<int> shx;
+  final List<int> dbf;
+}
+
+// ---------------------------------------------------------------------------
+// PRJ / CPG constants
+// ---------------------------------------------------------------------------
+
+const _prjContent =
+    'GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]]';
+const _cpgContent = 'UTF-8';
+
+// ---------------------------------------------------------------------------
+// Top-level function required by compute()
+// ---------------------------------------------------------------------------
+
+_LayerOutput _writeLayer(_LayerInput input) {
+  const writer = ShpWriter();
+  const dbfWriter = DbfWriter();
+
+  // Parse geometries
+  final geometries = <List<List<List<double>>>>[];
+  for (final f in input.features) {
+    final geo = jsonDecode(f.geometryGeojson) as Map<String, dynamic>;
+    final type = geo['type'] as String;
+    final coords = geo['coordinates'];
+    final List<List<List<double>>> parts;
+
+    if (type == 'Polygon') {
+      final rings = coords as List<dynamic>;
+      parts = rings
+          .map(
+            (r) => (r as List<dynamic>)
+                .map(
+                  (pt) => [
+                    (pt as List<dynamic>)[0] as double,
+                    pt[1] as double,
+                  ],
+                )
+                .toList(),
+          )
+          .toList();
+    } else if (type == 'MultiPolygon') {
+      final multiParts = <List<List<double>>>[];
+      for (final polygon in coords as List<dynamic>) {
+        for (final ring in polygon as List<dynamic>) {
+          multiParts.add(
+            (ring as List<dynamic>)
+                .map(
+                  (pt) => [
+                    (pt as List<dynamic>)[0] as double,
+                    pt[1] as double,
+                  ],
+                )
+                .toList(),
+          );
+        }
+      }
+      parts = multiParts;
+    } else if (type == 'LineString') {
+      final line = coords as List<dynamic>;
+      parts = [
+        line
+            .map(
+              (pt) => [
+                (pt as List<dynamic>)[0] as double,
+                pt[1] as double,
+              ],
+            )
+            .toList(),
+      ];
+    } else if (type == 'MultiLineString') {
+      final multiParts = <List<List<double>>>[];
+      for (final part in coords as List<dynamic>) {
+        multiParts.add(
+          (part as List<dynamic>)
+              .map(
+                (pt) => [
+                  (pt as List<dynamic>)[0] as double,
+                  pt[1] as double,
+                ],
+              )
+              .toList(),
+        );
+      }
+      parts = multiParts;
+    } else {
+      parts = [];
+    }
+
+    geometries.add(parts);
+  }
+
+  // Write SHP/SHX
+  final shpResult = input.isPolygon
+      ? writer.writePolygons(geometries)
+      : writer.writePolylines(geometries);
+
+  // Build DBF records
+  final List<DbfFieldDef> fields;
+  final List<Map<String, String?>> records;
+
+  if (input.isPolygon) {
+    fields = _buildingFields();
+    records = input.buildingRows
+        .map(
+          (r) => _buildingRecord(
+            r,
+            input.features
+                .firstWhere((f) => f.featureId == r.featureId)
+                .featureId,
+          ),
+        )
+        .toList();
+  } else {
+    fields = _roadFields();
+    records = input.roadRows
+        .map(
+          (r) => _roadRecord(
+            r,
+            input.features
+                .firstWhere((f) => f.featureId == r.featureId)
+                .featureId,
+          ),
+        )
+        .toList();
+  }
+
+  final dbf = dbfWriter.write(fields, records);
+
+  return _LayerOutput(
+    layerName: input.layerName,
+    shp: shpResult.shp,
+    shx: shpResult.shx,
+    dbf: dbf,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Field definitions
+// ---------------------------------------------------------------------------
+
+List<DbfFieldDef> _buildingFields() => const [
+      DbfFieldDef(name: 'FEAT_ID', type: 'C', width: 36),
+      DbfFieldDef(name: 'CBMS_ID', type: 'C', width: 20),
+      DbfFieldDef(name: 'BLDG_NAME', type: 'C', width: 60),
+      DbfFieldDef(name: 'RA9514_TYPE', type: 'C', width: 20),
+      DbfFieldDef(name: 'STOREYS', type: 'N', width: 3),
+      DbfFieldDef(name: 'MATERIAL', type: 'C', width: 30),
+      DbfFieldDef(name: 'COST_EXACT', type: 'L', width: 1),
+      DbfFieldDef(name: 'COST_AMT', type: 'N', width: 12, decimals: 2),
+      DbfFieldDef(name: 'COST_RANGE', type: 'C', width: 20),
+      DbfFieldDef(name: 'FIRE_FACIL', type: 'C', width: 254),
+      DbfFieldDef(name: 'FIRE_LOAD', type: 'C', width: 254),
+      DbfFieldDef(name: 'NOT_EXIST', type: 'L', width: 1),
+      DbfFieldDef(name: 'REMARKS', type: 'C', width: 254),
+    ];
+
+List<DbfFieldDef> _roadFields() => const [
+      DbfFieldDef(name: 'FEAT_ID', type: 'C', width: 36),
+      DbfFieldDef(name: 'IS_BRIDGE', type: 'L', width: 1),
+      DbfFieldDef(name: 'ROAD_NAME', type: 'C', width: 60),
+      DbfFieldDef(name: 'WIDTH_M', type: 'N', width: 8, decimals: 2),
+      DbfFieldDef(name: 'ROAD_FEAT', type: 'C', width: 254),
+      DbfFieldDef(name: 'OTHER_DESC', type: 'C', width: 254),
+      DbfFieldDef(name: 'NOT_EXIST', type: 'L', width: 1),
+      DbfFieldDef(name: 'REMARKS', type: 'C', width: 254),
+    ];
+
+// ---------------------------------------------------------------------------
+// Record builders
+// ---------------------------------------------------------------------------
+
+String? _jsonArrayToPipe(String? json) {
+  if (json == null || json.isEmpty) return null;
+  try {
+    final list = jsonDecode(json) as List<dynamic>;
+    if (list.isEmpty) return null;
+    return list.map((e) => e.toString()).join('|');
+  } catch (_) {
+    return null;
+  }
+}
+
+Map<String, String?> _buildingRecord(_BuildingRow r, String featureId) => {
+      'FEAT_ID': featureId,
+      'CBMS_ID': r.cbmsId,
+      'BLDG_NAME': r.buildingName,
+      'RA9514_TYPE': r.ra9514Type,
+      'STOREYS': r.storeys?.toString(),
+      'MATERIAL': r.material,
+      'COST_EXACT': r.costIsExact ? 'T' : 'F',
+      'COST_AMT': r.costAmount?.toStringAsFixed(2),
+      'COST_RANGE': r.costEstimateRange,
+      'FIRE_FACIL': _jsonArrayToPipe(r.fireFightingFacilitiesJson),
+      'FIRE_LOAD': _jsonArrayToPipe(r.fireLoadJson),
+      'NOT_EXIST': r.doesNotExist ? 'T' : 'F',
+      'REMARKS': r.remarks,
+    };
+
+Map<String, String?> _roadRecord(_RoadRow r, String featureId) => {
+      'FEAT_ID': featureId,
+      'IS_BRIDGE': r.isBridge ? 'T' : 'F',
+      'ROAD_NAME': r.roadName,
+      'WIDTH_M': r.widthMeters?.toStringAsFixed(2),
+      'ROAD_FEAT': _jsonArrayToPipe(r.roadFeaturesJson),
+      'OTHER_DESC': r.othersDescription,
+      'NOT_EXIST': r.doesNotExist ? 'T' : 'F',
+      'REMARKS': r.remarks,
+    };
+
+// ---------------------------------------------------------------------------
+// ShapefileExporter
+// ---------------------------------------------------------------------------
+
+class ShapefileExporter {
+  ShapefileExporter({
+    required this.db,
+    this.shareFile,
+    this.tempDirOverride,
+  });
+
+  final AppDatabase db;
+  final Future<void> Function(String path)? shareFile;
+  final Directory? tempDirOverride;
+
+  Future<ExportFailure?> export({required String assignmentId}) async {
+    // Query all completed features with their submissions and attributes.
+    final buildingRows = await _queryBuildings(assignmentId);
+    final roadRows = await _queryRoads(assignmentId);
+
+    if (buildingRows.isEmpty && roadRows.isEmpty) {
+      return const NoCompletedFeatures();
+    }
+
+    // Build layer inputs
+    final inputs = <_LayerInput>[];
+
+    if (buildingRows.isNotEmpty) {
+      final featureRows = buildingRows
+          .map(
+            (r) => _FeatureRow(
+              featureId: r.featureId,
+              geometryGeojson: r.geometryGeojson,
+            ),
+          )
+          .toList();
+      inputs.add(
+        _LayerInput(
+          layerName: 'buildings',
+          isPolygon: true,
+          features: featureRows,
+          buildingRows: buildingRows.map((r) => r.buildingRow).toList(),
+          roadRows: const [],
+        ),
+      );
+    }
+
+    if (roadRows.isNotEmpty) {
+      final featureRows = roadRows
+          .map(
+            (r) => _FeatureRow(
+              featureId: r.featureId,
+              geometryGeojson: r.geometryGeojson,
+            ),
+          )
+          .toList();
+      inputs.add(
+        _LayerInput(
+          layerName: 'roads',
+          isPolygon: false,
+          features: featureRows,
+          buildingRows: const [],
+          roadRows: roadRows.map((r) => r.roadRow).toList(),
+        ),
+      );
+    }
+
+    // Write each layer via compute
+    List<_LayerOutput> outputs;
+    try {
+      outputs = await Future.wait(
+        inputs.map((input) => compute(_writeLayer, input)),
+      );
+    } catch (e) {
+      return WriteError(e.toString());
+    }
+
+    // Build ZIP archive
+    final archive = Archive();
+    for (final out in outputs) {
+      final name = out.layerName;
+      archive
+        ..addFile(ArchiveFile('$name.shp', out.shp.length, out.shp))
+        ..addFile(ArchiveFile('$name.shx', out.shx.length, out.shx))
+        ..addFile(ArchiveFile('$name.dbf', out.dbf.length, out.dbf))
+        ..addFile(
+          ArchiveFile(
+            '$name.prj',
+            _prjContent.length,
+            _prjContent.codeUnits,
+          ),
+        )
+        ..addFile(
+          ArchiveFile(
+            '$name.cpg',
+            _cpgContent.length,
+            _cpgContent.codeUnits,
+          ),
+        );
+    }
+
+    // Write ZIP to temp directory
+    final zipBytes = ZipEncoder().encode(archive)!;
+    final tempDir = tempDirOverride ?? await getTemporaryDirectory();
+    final timestamp = DateFormat('yyyyMMdd_HHmmss').format(DateTime.now());
+    final zipName = 'firecheck_${assignmentId}_$timestamp.zip';
+    final zipPath = p.join(tempDir.path, zipName);
+
+    try {
+      await File(zipPath).writeAsBytes(zipBytes);
+    } catch (e) {
+      return WriteError(e.toString());
+    }
+
+    // Share / hand off
+    if (shareFile != null) {
+      try {
+        await shareFile!(zipPath);
+      } catch (e) {
+        return ShareError(e.toString());
+      }
+    }
+
+    return null;
+  }
+
+  // -------------------------------------------------------------------------
+  // DB queries — run on the main isolate
+  // -------------------------------------------------------------------------
+
+  Future<List<_BuildingQueryRow>> _queryBuildings(
+    String assignmentId,
+  ) async {
+    final query = db.select(db.features).join([
+      innerJoin(
+        db.submissions,
+        db.submissions.featureId.equalsExp(db.features.id),
+      ),
+      innerJoin(
+        db.buildingAttributes,
+        db.buildingAttributes.submissionId.equalsExp(db.submissions.id),
+      ),
+    ])
+      ..where(
+        db.features.assignmentId.equals(assignmentId) &
+            db.features.featureType.equals('building') &
+            db.features.status.equals('complete'),
+      );
+
+    final rows = await query.get();
+    return rows.map((row) {
+      final feature = row.readTable(db.features);
+      final submission = row.readTable(db.submissions);
+      final attr = row.readTable(db.buildingAttributes);
+      return _BuildingQueryRow(
+        featureId: feature.id,
+        geometryGeojson: feature.geometryGeojson,
+        buildingRow: _BuildingRow(
+          featureId: feature.id,
+          doesNotExist: submission.doesNotExist,
+          remarks: submission.remarks,
+          cbmsId: attr.cbmsId,
+          buildingName: attr.buildingName,
+          ra9514Type: attr.ra9514Type,
+          storeys: attr.storeys,
+          material: attr.material,
+          costIsExact: attr.costIsExact,
+          costAmount: attr.costAmount,
+          costEstimateRange: attr.costEstimateRange,
+          fireFightingFacilitiesJson: attr.fireFightingFacilitiesJson,
+          fireLoadJson: attr.fireLoadJson,
+        ),
+      );
+    }).toList();
+  }
+
+  Future<List<_RoadQueryRow>> _queryRoads(String assignmentId) async {
+    final query = db.select(db.features).join([
+      innerJoin(
+        db.submissions,
+        db.submissions.featureId.equalsExp(db.features.id),
+      ),
+      innerJoin(
+        db.roadAttributes,
+        db.roadAttributes.submissionId.equalsExp(db.submissions.id),
+      ),
+    ])
+      ..where(
+        db.features.assignmentId.equals(assignmentId) &
+            db.features.featureType.equals('road') &
+            db.features.status.equals('complete'),
+      );
+
+    final rows = await query.get();
+    return rows.map((row) {
+      final feature = row.readTable(db.features);
+      final submission = row.readTable(db.submissions);
+      final attr = row.readTable(db.roadAttributes);
+      return _RoadQueryRow(
+        featureId: feature.id,
+        geometryGeojson: feature.geometryGeojson,
+        roadRow: _RoadRow(
+          featureId: feature.id,
+          doesNotExist: submission.doesNotExist,
+          remarks: submission.remarks,
+          isBridge: attr.isBridge,
+          roadName: attr.roadName,
+          widthMeters: attr.widthMeters,
+          roadFeaturesJson: attr.roadFeaturesJson,
+          othersDescription: attr.othersDescription,
+        ),
+      );
+    }).toList();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal query result holders (not passed to compute)
+// ---------------------------------------------------------------------------
+
+class _BuildingQueryRow {
+  const _BuildingQueryRow({
+    required this.featureId,
+    required this.geometryGeojson,
+    required this.buildingRow,
+  });
+  final String featureId;
+  final String geometryGeojson;
+  final _BuildingRow buildingRow;
+}
+
+class _RoadQueryRow {
+  const _RoadQueryRow({
+    required this.featureId,
+    required this.geometryGeojson,
+    required this.roadRow,
+  });
+  final String featureId;
+  final String geometryGeojson;
+  final _RoadRow roadRow;
+}

--- a/lib/core/sync/shapefile/export/shp_writer.dart
+++ b/lib/core/sync/shapefile/export/shp_writer.dart
@@ -1,0 +1,169 @@
+// lib/core/sync/shapefile/export/shp_writer.dart
+import 'dart:typed_data';
+
+class ShpWriteResult {
+  const ShpWriteResult({required this.shp, required this.shx});
+  final Uint8List shp;
+  final Uint8List shx;
+}
+
+class ShpWriter {
+  const ShpWriter();
+
+  /// Writes polygon shapefile (shape type 5).
+  /// [geometries]: one entry per feature; each entry is a list of rings;
+  /// each ring is a list of [longitude, latitude] pairs.
+  ShpWriteResult writePolygons(List<List<List<List<double>>>> geometries) =>
+      _write(5, geometries);
+
+  /// Writes polyline shapefile (shape type 3).
+  /// [geometries]: one entry per feature; each entry is a list of parts;
+  /// each part is a list of [longitude, latitude] pairs.
+  ShpWriteResult writePolylines(List<List<List<List<double>>>> geometries) =>
+      _write(3, geometries);
+
+  ShpWriteResult _write(
+    int shapeType,
+    List<List<List<List<double>>>> geometries,
+  ) {
+    final contents =
+        geometries.map((parts) => _buildContent(shapeType, parts)).toList();
+
+    var minX = double.infinity;
+    var minY = double.infinity;
+    var maxX = double.negativeInfinity;
+    var maxY = double.negativeInfinity;
+    for (final parts in geometries) {
+      for (final part in parts) {
+        for (final pt in part) {
+          if (pt[0] < minX) minX = pt[0];
+          if (pt[0] > maxX) maxX = pt[0];
+          if (pt[1] < minY) minY = pt[1];
+          if (pt[1] > maxY) maxY = pt[1];
+        }
+      }
+    }
+    if (geometries.isEmpty) minX = minY = maxX = maxY = 0.0;
+
+    final shpSize =
+        100 + contents.fold<int>(0, (acc, c) => acc + 8 + c.lengthInBytes);
+    final shxSize = 100 + geometries.length * 8;
+
+    final shpData = ByteData(shpSize);
+    final shxData = ByteData(shxSize);
+
+    _writeFileHeader(shpData, shapeType, shpSize, minX, minY, maxX, maxY);
+    _writeFileHeader(shxData, shapeType, shxSize, minX, minY, maxX, maxY);
+
+    var shpByteOffset = 100;
+    var shxByteOffset = 100;
+    var shpWordOffset = 50; // 100 bytes ÷ 2
+
+    for (var i = 0; i < contents.length; i++) {
+      final content = contents[i];
+      final contentBytes = content.lengthInBytes;
+      final contentWords = contentBytes ~/ 2;
+
+      // Write shp record header (big-endian, which is the default)
+      shpData
+        ..setInt32(shpByteOffset, i + 1)
+        ..setInt32(shpByteOffset + 4, contentWords);
+      shpByteOffset += 8;
+
+      for (var b = 0; b < contentBytes; b++) {
+        shpData.setUint8(shpByteOffset + b, content.getUint8(b));
+      }
+      shpByteOffset += contentBytes;
+
+      // Write shx record (big-endian, which is the default)
+      shxData
+        ..setInt32(shxByteOffset, shpWordOffset)
+        ..setInt32(shxByteOffset + 4, contentWords);
+      shxByteOffset += 8;
+
+      shpWordOffset += 4 + contentWords; // 8-byte record header = 4 words
+    }
+
+    return ShpWriteResult(
+      shp: shpData.buffer.asUint8List(),
+      shx: shxData.buffer.asUint8List(),
+    );
+  }
+
+  void _writeFileHeader(
+    ByteData data,
+    int shapeType,
+    int fileSizeBytes,
+    double minX,
+    double minY,
+    double maxX,
+    double maxY,
+  ) {
+    // File code and file length are big-endian (default); version and shape
+    // type and bounding box values are little-endian per Esri spec.
+    data
+      ..setInt32(0, 9994)
+      ..setInt32(24, fileSizeBytes ~/ 2)
+      ..setInt32(28, 1000, Endian.little)
+      ..setInt32(32, shapeType, Endian.little)
+      ..setFloat64(36, minX, Endian.little)
+      ..setFloat64(44, minY, Endian.little)
+      ..setFloat64(52, maxX, Endian.little)
+      ..setFloat64(60, maxY, Endian.little);
+  }
+
+  ByteData _buildContent(int shapeType, List<List<List<double>>> parts) {
+    final numParts = parts.length;
+    final numPoints = parts.fold<int>(0, (acc, p) => acc + p.length);
+
+    var minX = double.infinity;
+    var minY = double.infinity;
+    var maxX = double.negativeInfinity;
+    var maxY = double.negativeInfinity;
+    for (final part in parts) {
+      for (final pt in part) {
+        if (pt[0] < minX) minX = pt[0];
+        if (pt[0] > maxX) maxX = pt[0];
+        if (pt[1] < minY) minY = pt[1];
+        if (pt[1] > maxY) maxY = pt[1];
+      }
+    }
+
+    final size = 4 + 32 + 4 + 4 + numParts * 4 + numPoints * 16;
+    final d = ByteData(size);
+    var o = 0;
+
+    d.setInt32(o, shapeType, Endian.little);
+    o += 4;
+    d.setFloat64(o, minX, Endian.little);
+    o += 8;
+    d.setFloat64(o, minY, Endian.little);
+    o += 8;
+    d.setFloat64(o, maxX, Endian.little);
+    o += 8;
+    d.setFloat64(o, maxY, Endian.little);
+    o += 8;
+    d.setInt32(o, numParts, Endian.little);
+    o += 4;
+    d.setInt32(o, numPoints, Endian.little);
+    o += 4;
+
+    var pointIndex = 0;
+    for (var i = 0; i < parts.length; i++) {
+      d.setInt32(o, pointIndex, Endian.little);
+      o += 4;
+      pointIndex += parts[i].length;
+    }
+
+    for (final part in parts) {
+      for (final pt in part) {
+        d.setFloat64(o, pt[0], Endian.little);
+        o += 8;
+        d.setFloat64(o, pt[1], Endian.little);
+        o += 8;
+      }
+    }
+
+    return d;
+  }
+}

--- a/lib/features/home/data/shapefile_export_notifier.dart
+++ b/lib/features/home/data/shapefile_export_notifier.dart
@@ -1,0 +1,53 @@
+// lib/features/home/data/shapefile_export_notifier.dart
+import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
+import 'package:firecheck/features/assignment/presentation/assignment_providers.dart';
+import 'package:firecheck/features/home/domain/export_state.dart';
+import 'package:firecheck/features/home/presentation/home_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:share_plus/share_plus.dart';
+
+class ShapefileExportNotifier extends StateNotifier<ExportState> {
+  ShapefileExportNotifier({
+    required String assignmentId,
+    required ShapefileExporter exporter,
+  })  : _assignmentId = assignmentId,
+        _exporter = exporter,
+        super(const ExportIdle());
+
+  final String _assignmentId;
+  final ShapefileExporter _exporter;
+
+  Future<void> export() async {
+    if (state is ExportExporting) return;
+    state = const ExportExporting();
+
+    final failure = await _exporter.export(assignmentId: _assignmentId);
+
+    if (!mounted) return;
+    if (failure != null) {
+      state = ExportFailed(failure);
+      state = const ExportIdle();
+      return;
+    }
+
+    state = const ExportDone();
+    state = const ExportIdle();
+  }
+}
+
+final shapefileExportNotifierProvider =
+    StateNotifierProvider<ShapefileExportNotifier, ExportState>((ref) {
+  final db = ref.watch(appDatabaseProvider);
+  final assignmentAsync = ref.watch(currentAssignmentProvider);
+  final assignmentId = assignmentAsync.value?.id ?? '';
+
+  return ShapefileExportNotifier(
+    assignmentId: assignmentId,
+    exporter: ShapefileExporter(
+      db: db,
+      shareFile: (path) async {
+        await SharePlus.instance.share(ShareParams(files: [XFile(path)]));
+      },
+    ),
+  );
+});

--- a/lib/features/home/domain/export_state.dart
+++ b/lib/features/home/domain/export_state.dart
@@ -1,0 +1,23 @@
+// lib/features/home/domain/export_state.dart
+import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
+
+sealed class ExportState {
+  const ExportState();
+}
+
+class ExportIdle extends ExportState {
+  const ExportIdle();
+}
+
+class ExportExporting extends ExportState {
+  const ExportExporting();
+}
+
+class ExportDone extends ExportState {
+  const ExportDone();
+}
+
+class ExportFailed extends ExportState {
+  const ExportFailed(this.failure);
+  final ExportFailure failure;
+}

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -176,6 +176,7 @@ class _ActionTile extends StatelessWidget {
         subtitle: Text(subtitle),
         trailing: trailing ?? const Icon(Icons.chevron_right),
         onTap: onTap,
+        enabled: onTap != null,
       ),
     );
   }

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -1,7 +1,10 @@
 import 'package:firecheck/core/security/biometric_gate_provider.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_lock_providers.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_lock_state.dart';
 import 'package:firecheck/features/assignment/presentation/submitted_banner.dart';
+import 'package:firecheck/features/home/data/shapefile_export_notifier.dart';
+import 'package:firecheck/features/home/domain/export_state.dart';
 import 'package:firecheck/features/home/presentation/home_providers.dart';
 import 'package:firecheck/generated/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
@@ -17,6 +20,21 @@ class HomeScreen extends ConsumerWidget {
     final asyncSnap = ref.watch(progressProvider);
     final lock = ref.watch(assignmentLockStateProvider).value;
     final isLocked = lock is Submitted || lock is ClosedRemotely;
+    final exportState = ref.watch(shapefileExportNotifierProvider);
+    final isExporting = exportState is ExportExporting;
+
+    ref.listen<ExportState>(shapefileExportNotifierProvider, (prev, next) {
+      if (next is ExportFailed) {
+        final msg = switch (next.failure) {
+          NoCompletedFeatures() => l.exportErrorNoFeatures,
+          WriteError()          => l.exportErrorWriteFailed,
+          ShareError()          => l.exportErrorShareFailed,
+        };
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(msg)),
+        );
+      }
+    });
 
     return Scaffold(
       appBar: AppBar(title: const Text('FireCheck')),
@@ -89,6 +107,24 @@ class HomeScreen extends ConsumerWidget {
                   subtitle: l.uploadDataSubtitle,
                   onTap: () => _onUploadDataTap(context, ref, l),
                 ),
+              _ActionTile(
+                title: isExporting
+                    ? l.exportShapefileExporting
+                    : l.exportShapefile,
+                subtitle: l.exportShapefileSubtitle,
+                trailing: isExporting
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.chevron_right),
+                onTap: (snap.completedFeatures == 0 || isExporting)
+                    ? null
+                    : () => ref
+                        .read(shapefileExportNotifierProvider.notifier)
+                        .export(),
+              ),
             ],
           ),
         ),
@@ -125,10 +161,12 @@ class _ActionTile extends StatelessWidget {
     required this.title,
     required this.subtitle,
     required this.onTap,
+    this.trailing,
   });
   final String title;
   final String subtitle;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
+  final Widget? trailing;
 
   @override
   Widget build(BuildContext context) {
@@ -136,7 +174,7 @@ class _ActionTile extends StatelessWidget {
       child: ListTile(
         title: Text(title),
         subtitle: Text(subtitle),
-        trailing: const Icon(Icons.chevron_right),
+        trailing: trailing ?? const Icon(Icons.chevron_right),
         onTap: onTap,
       ),
     );

--- a/lib/generated/l10n/app_localizations.dart
+++ b/lib/generated/l10n/app_localizations.dart
@@ -2083,6 +2083,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Close'**
   String get getMapsClose;
+
+  /// No description provided for @exportShapefile.
+  ///
+  /// In en, this message translates to:
+  /// **'Export Shapefile'**
+  String get exportShapefile;
+
+  /// No description provided for @exportShapefileSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Package completed features as .shp'**
+  String get exportShapefileSubtitle;
+
+  /// No description provided for @exportShapefileExporting.
+  ///
+  /// In en, this message translates to:
+  /// **'Packaging…'**
+  String get exportShapefileExporting;
+
+  /// No description provided for @exportErrorNoFeatures.
+  ///
+  /// In en, this message translates to:
+  /// **'No completed features to export.'**
+  String get exportErrorNoFeatures;
+
+  /// No description provided for @exportErrorWriteFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Export failed: could not write files. Please try again.'**
+  String get exportErrorWriteFailed;
+
+  /// No description provided for @exportErrorShareFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Export ready but could not open share sheet. Please try again.'**
+  String get exportErrorShareFailed;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/generated/l10n/app_localizations_en.dart
+++ b/lib/generated/l10n/app_localizations_en.dart
@@ -1092,4 +1092,24 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get getMapsClose => 'Close';
+
+  @override
+  String get exportShapefile => 'Export Shapefile';
+
+  @override
+  String get exportShapefileSubtitle => 'Package completed features as .shp';
+
+  @override
+  String get exportShapefileExporting => 'Packaging…';
+
+  @override
+  String get exportErrorNoFeatures => 'No completed features to export.';
+
+  @override
+  String get exportErrorWriteFailed =>
+      'Export failed: could not write files. Please try again.';
+
+  @override
+  String get exportErrorShareFailed =>
+      'Export ready but could not open share sheet. Please try again.';
 }

--- a/lib/generated/l10n/app_localizations_tl.dart
+++ b/lib/generated/l10n/app_localizations_tl.dart
@@ -1118,4 +1118,24 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get getMapsClose => 'Close';
+
+  @override
+  String get exportShapefile => 'Export Shapefile';
+
+  @override
+  String get exportShapefileSubtitle => 'Package completed features as .shp';
+
+  @override
+  String get exportShapefileExporting => 'Packaging…';
+
+  @override
+  String get exportErrorNoFeatures => 'No completed features to export.';
+
+  @override
+  String get exportErrorWriteFailed =>
+      'Export failed: could not write files. Please try again.';
+
+  @override
+  String get exportErrorShareFailed =>
+      'Export ready but could not open share sheet. Please try again.';
 }

--- a/test/core/sync/shapefile/export/dbf_writer_test.dart
+++ b/test/core/sync/shapefile/export/dbf_writer_test.dart
@@ -1,0 +1,94 @@
+// test/core/sync/shapefile/export/dbf_writer_test.dart
+import 'package:firecheck/core/sync/shapefile/dbf_parser.dart';
+import 'package:firecheck/core/sync/shapefile/export/dbf_writer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const writer = DbfWriter();
+  const parser = DbfParser();
+
+  final fields = [
+    const DbfFieldDef(name: 'FEAT_ID', type: 'C', width: 36),
+    const DbfFieldDef(name: 'STOREYS', type: 'N', width: 3),
+    const DbfFieldDef(name: 'NOT_EXIST', type: 'L', width: 1),
+    const DbfFieldDef(name: 'REMARKS', type: 'C', width: 254),
+  ];
+
+  test('round-trip: written DBF parses back with correct field names and types', () {
+    final bytes = writer.write(fields, []);
+    final result = parser.parse(bytes);
+
+    expect(result.fields, hasLength(4));
+    expect(result.fields[0].name, equals('FEAT_ID'));
+    expect(result.fields[0].type, equals('C'));
+    expect(result.fields[1].name, equals('STOREYS'));
+    expect(result.fields[1].type, equals('N'));
+    expect(result.fields[2].name, equals('NOT_EXIST'));
+    expect(result.fields[2].type, equals('L'));
+    expect(result.fields[3].name, equals('REMARKS'));
+  });
+
+  test('round-trip: C field value survives write and parse', () {
+    final bytes = writer.write(fields, [
+      {'FEAT_ID': 'abc-123', 'STOREYS': null, 'NOT_EXIST': null, 'REMARKS': null},
+    ]);
+    final result = parser.parse(bytes);
+
+    expect(result.records, hasLength(1));
+    expect(result.records.first['FEAT_ID'], equals('abc-123'));
+  });
+
+  test('round-trip: N field value is right-aligned and parses back trimmed', () {
+    final bytes = writer.write(fields, [
+      {'FEAT_ID': null, 'STOREYS': '42', 'NOT_EXIST': null, 'REMARKS': null},
+    ]);
+    final result = parser.parse(bytes);
+    expect(result.records.first['STOREYS'], equals('42'));
+  });
+
+  test('round-trip: L field T writes as T', () {
+    final bytes = writer.write(fields, [
+      {'FEAT_ID': null, 'STOREYS': null, 'NOT_EXIST': 'T', 'REMARKS': null},
+    ]);
+    final result = parser.parse(bytes);
+    expect(result.records.first['NOT_EXIST'], equals('T'));
+  });
+
+  test('round-trip: L field F writes as F', () {
+    final bytes = writer.write(fields, [
+      {'FEAT_ID': null, 'STOREYS': null, 'NOT_EXIST': 'F', 'REMARKS': null},
+    ]);
+    final result = parser.parse(bytes);
+    expect(result.records.first['NOT_EXIST'], equals('F'));
+  });
+
+  test('null C value writes as blank (empty string after trim)', () {
+    final bytes = writer.write(fields, [
+      {'FEAT_ID': null, 'STOREYS': null, 'NOT_EXIST': null, 'REMARKS': null},
+    ]);
+    final result = parser.parse(bytes);
+    expect(result.records.first['REMARKS'], isEmpty);
+  });
+
+  test('pipe-delimited value survives round-trip intact', () {
+    const pipeValue = 'sprinkler|extinguisher|hose';
+    final bytes = writer.write(fields, [
+      {'FEAT_ID': null, 'STOREYS': null, 'NOT_EXIST': null, 'REMARKS': pipeValue},
+    ]);
+    final result = parser.parse(bytes);
+    expect(result.records.first['REMARKS'], equals(pipeValue));
+  });
+
+  test('multiple records all present in output', () {
+    final bytes = writer.write(fields, [
+      {'FEAT_ID': 'id-1', 'STOREYS': '1', 'NOT_EXIST': 'F', 'REMARKS': null},
+      {'FEAT_ID': 'id-2', 'STOREYS': '2', 'NOT_EXIST': 'T', 'REMARKS': 'note'},
+    ]);
+    final result = parser.parse(bytes);
+
+    expect(result.records, hasLength(2));
+    expect(result.records[0]['FEAT_ID'], equals('id-1'));
+    expect(result.records[1]['FEAT_ID'], equals('id-2'));
+    expect(result.records[1]['NOT_EXIST'], equals('T'));
+  });
+}

--- a/test/core/sync/shapefile/export/shapefile_exporter_test.dart
+++ b/test/core/sync/shapefile/export/shapefile_exporter_test.dart
@@ -1,0 +1,180 @@
+// test/core/sync/shapefile/export/shapefile_exporter_test.dart
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> _seedBuilding(
+  AppDatabase db, {
+  required String assignmentId,
+  required String featureId,
+  required String submissionId,
+  bool doesNotExist = false,
+}) async {
+  final geoJson = jsonEncode({
+    'type': 'Polygon',
+    'coordinates': [
+      [
+        [120.0, 14.0], [121.0, 14.0], [121.0, 15.0], [120.0, 15.0], [120.0, 14.0],
+      ]
+    ],
+  });
+
+  await db.into(db.features).insert(FeaturesCompanion.insert(
+    id: featureId,
+    assignmentId: assignmentId,
+    featureType: 'building',
+    geometryGeojson: geoJson,
+    isNew: const Value(false),
+    status: const Value('complete'),
+    createdAt: DateTime.now(),
+  ));
+
+  await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+    id: submissionId,
+    featureId: featureId,
+    doesNotExist: Value(doesNotExist),
+    syncStatus: const Value('ready_to_upload'),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  ));
+
+  await db.into(db.buildingAttributes).insert(BuildingAttributesCompanion.insert(
+    submissionId: submissionId,
+    cbmsId: const Value('C001'),
+    buildingName: const Value('Test Hall'),
+    ra9514Type: const Value('Group E'),
+    storeys: const Value(3),
+    material: const Value('Concrete'),
+    costAmount: const Value(500000.0),
+    fireFightingFacilitiesJson: const Value('["sprinkler","extinguisher"]'),
+    fireLoadJson: const Value('["paper","chemicals"]'),
+  ));
+}
+
+Future<void> _seedRoad(
+  AppDatabase db, {
+  required String assignmentId,
+  required String featureId,
+  required String submissionId,
+}) async {
+  final geoJson = jsonEncode({
+    'type': 'LineString',
+    'coordinates': [[120.0, 14.0], [121.0, 14.5]],
+  });
+
+  await db.into(db.features).insert(FeaturesCompanion.insert(
+    id: featureId,
+    assignmentId: assignmentId,
+    featureType: 'road',
+    geometryGeojson: geoJson,
+    isNew: const Value(false),
+    status: const Value('complete'),
+    createdAt: DateTime.now(),
+  ));
+
+  await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+    id: submissionId,
+    featureId: featureId,
+    syncStatus: const Value('ready_to_upload'),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  ));
+
+  await db.into(db.roadAttributes).insert(RoadAttributesCompanion.insert(
+    submissionId: submissionId,
+    roadName: const Value('Main St'),
+    widthMeters: const Value(8.0),
+    roadFeaturesJson: const Value('["Pedestrian"]'),
+  ));
+}
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() => db.close());
+
+  ShapefileExporter makeExporter({List<String>? capturedPaths}) {
+    return ShapefileExporter(
+      db: db,
+      shareFile: (path) async {
+        capturedPaths?.add(path);
+      },
+      tempDirOverride: Directory.systemTemp.createTempSync('shp_test_'),
+    );
+  }
+
+  test('two buildings + one road → export returns null (success)', () async {
+    const assignmentId = 'assignment-001';
+    await _seedBuilding(db, assignmentId: assignmentId, featureId: 'f1', submissionId: 's1');
+    await _seedBuilding(db, assignmentId: assignmentId, featureId: 'f2', submissionId: 's2');
+    await _seedRoad(db, assignmentId: assignmentId, featureId: 'f3', submissionId: 's3');
+
+    final result = await makeExporter().export(assignmentId: assignmentId);
+
+    expect(result, isNull);
+  });
+
+  test('two buildings + one road → ZIP file has 10 entries', () async {
+    const assignmentId = 'assignment-001';
+    await _seedBuilding(db, assignmentId: assignmentId, featureId: 'f1', submissionId: 's1');
+    await _seedBuilding(db, assignmentId: assignmentId, featureId: 'f2', submissionId: 's2');
+    await _seedRoad(db, assignmentId: assignmentId, featureId: 'f3', submissionId: 's3');
+
+    final capturedPaths = <String>[];
+    await makeExporter(capturedPaths: capturedPaths).export(assignmentId: assignmentId);
+
+    expect(capturedPaths, hasLength(1));
+    final zipBytes = await File(capturedPaths.first).readAsBytes();
+    final archive = ZipDecoder().decodeBytes(zipBytes);
+    expect(archive.files, hasLength(10));
+  });
+
+  test('only buildings → ZIP contains 5 building files only', () async {
+    const assignmentId = 'assignment-002';
+    await _seedBuilding(db, assignmentId: assignmentId, featureId: 'f1', submissionId: 's1');
+
+    final capturedPaths = <String>[];
+    await makeExporter(capturedPaths: capturedPaths).export(assignmentId: assignmentId);
+
+    final zipBytes = await File(capturedPaths.first).readAsBytes();
+    final archive = ZipDecoder().decodeBytes(zipBytes);
+    expect(archive.files, hasLength(5));
+    expect(archive.files.map((f) => f.name), everyElement(startsWith('buildings')));
+  });
+
+  test('no completed features → returns NoCompletedFeatures', () async {
+    const assignmentId = 'assignment-003';
+    final failure = await makeExporter().export(assignmentId: assignmentId);
+    expect(failure, isA<NoCompletedFeatures>());
+  });
+
+  test('doesNotExist building is included in ZIP output', () async {
+    const assignmentId = 'assignment-004';
+    await _seedBuilding(
+      db,
+      assignmentId: assignmentId,
+      featureId: 'f1',
+      submissionId: 's1',
+      doesNotExist: true,
+    );
+
+    final capturedPaths = <String>[];
+    await makeExporter(capturedPaths: capturedPaths).export(assignmentId: assignmentId);
+
+    final zipBytes = await File(capturedPaths.first).readAsBytes();
+    final archive = ZipDecoder().decodeBytes(zipBytes);
+    final dbfEntry = archive.files.firstWhere((f) => f.name == 'buildings.dbf');
+    expect(dbfEntry.content, isNotEmpty);
+  });
+}

--- a/test/core/sync/shapefile/export/shapefile_exporter_test.dart
+++ b/test/core/sync/shapefile/export/shapefile_exporter_test.dart
@@ -34,7 +34,7 @@ Future<void> _seedBuilding(
     isNew: const Value(false),
     status: const Value('complete'),
     createdAt: DateTime.now(),
-  ));
+  ),);
 
   await db.into(db.submissions).insert(SubmissionsCompanion.insert(
     id: submissionId,
@@ -43,7 +43,7 @@ Future<void> _seedBuilding(
     syncStatus: const Value('ready_to_upload'),
     createdAt: DateTime.now(),
     updatedAt: DateTime.now(),
-  ));
+  ),);
 
   await db.into(db.buildingAttributes).insert(BuildingAttributesCompanion.insert(
     submissionId: submissionId,
@@ -52,10 +52,10 @@ Future<void> _seedBuilding(
     ra9514Type: const Value('Group E'),
     storeys: const Value(3),
     material: const Value('Concrete'),
-    costAmount: const Value(500000.0),
+    costAmount: const Value(500000),
     fireFightingFacilitiesJson: const Value('["sprinkler","extinguisher"]'),
     fireLoadJson: const Value('["paper","chemicals"]'),
-  ));
+  ),);
 }
 
 Future<void> _seedRoad(
@@ -77,7 +77,7 @@ Future<void> _seedRoad(
     isNew: const Value(false),
     status: const Value('complete'),
     createdAt: DateTime.now(),
-  ));
+  ),);
 
   await db.into(db.submissions).insert(SubmissionsCompanion.insert(
     id: submissionId,
@@ -85,14 +85,14 @@ Future<void> _seedRoad(
     syncStatus: const Value('ready_to_upload'),
     createdAt: DateTime.now(),
     updatedAt: DateTime.now(),
-  ));
+  ),);
 
   await db.into(db.roadAttributes).insert(RoadAttributesCompanion.insert(
     submissionId: submissionId,
     roadName: const Value('Main St'),
-    widthMeters: const Value(8.0),
+    widthMeters: const Value(8),
     roadFeaturesJson: const Value('["Pedestrian"]'),
-  ));
+  ),);
 }
 
 void main() {

--- a/test/core/sync/shapefile/export/shp_writer_test.dart
+++ b/test/core/sync/shapefile/export/shp_writer_test.dart
@@ -1,0 +1,102 @@
+// test/core/sync/shapefile/export/shp_writer_test.dart
+import 'dart:typed_data';
+
+import 'package:firecheck/core/sync/shapefile/export/shp_writer.dart';
+import 'package:firecheck/core/sync/shapefile/shp_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const writer = ShpWriter();
+  const parser = ShpParser();
+
+  group('ShpWriter — polygons', () {
+    final ring = [
+      [120.0, 14.0],
+      [121.0, 14.0],
+      [121.0, 15.0],
+      [120.0, 15.0],
+      [120.0, 14.0],
+    ];
+
+    test('round-trip: written polygon parses back with matching coordinates', () {
+      final result = writer.writePolygons([[ring]]);
+      final geometries = parser.parse(result.shp);
+
+      expect(geometries, hasLength(1));
+      final poly = geometries.first as ShpPolygon;
+      expect(poly.rings, hasLength(1));
+      expect(poly.rings.first, hasLength(ring.length));
+      for (var i = 0; i < ring.length; i++) {
+        expect(poly.rings.first[i][0], closeTo(ring[i][0], 0.0001));
+        expect(poly.rings.first[i][1], closeTo(ring[i][1], 0.0001));
+      }
+    });
+
+    test('bounding box in file header matches feature extents', () {
+      final result = writer.writePolygons([[ring]]);
+      final data = result.shp.buffer.asByteData();
+
+      final minX = data.getFloat64(36, Endian.little);
+      final minY = data.getFloat64(44, Endian.little);
+      final maxX = data.getFloat64(52, Endian.little);
+      final maxY = data.getFloat64(60, Endian.little);
+
+      expect(minX, closeTo(120.0, 0.0001));
+      expect(minY, closeTo(14.0, 0.0001));
+      expect(maxX, closeTo(121.0, 0.0001));
+      expect(maxY, closeTo(15.0, 0.0001));
+    });
+
+    test('shx offsets correctly index each record', () {
+      final ring2 = [
+        [122.0, 16.0],
+        [123.0, 16.0],
+        [123.0, 17.0],
+        [122.0, 16.0],
+      ];
+      final result = writer.writePolygons([[ring], [ring2]]);
+      final shpData = result.shp.buffer.asByteData();
+      final shxData = result.shx.buffer.asByteData();
+
+      final offset0 = shxData.getInt32(100, Endian.big) * 2;
+      expect(offset0, equals(100));
+
+      final offset1 = shxData.getInt32(108, Endian.big) * 2;
+      final contentWords = shpData.getInt32(offset1 + 4, Endian.big);
+      expect(contentWords, greaterThan(0));
+    });
+
+    test('empty geometry list produces header-only SHP with zeroed bbox', () {
+      final result = writer.writePolygons([]);
+      expect(result.shp.length, equals(100));
+      expect(result.shx.length, equals(100));
+
+      final data = result.shp.buffer.asByteData();
+      expect(data.getFloat64(36, Endian.little), equals(0.0)); // minX
+      expect(data.getFloat64(44, Endian.little), equals(0.0)); // minY
+      expect(data.getFloat64(52, Endian.little), equals(0.0)); // maxX
+      expect(data.getFloat64(60, Endian.little), equals(0.0)); // maxY
+    });
+  });
+
+  group('ShpWriter — polylines', () {
+    final part = [
+      [120.0, 14.0],
+      [121.0, 14.5],
+      [122.0, 14.0],
+    ];
+
+    test('round-trip: written polyline parses back with matching coordinates', () {
+      final result = writer.writePolylines([[part]]);
+      final geometries = parser.parse(result.shp);
+
+      expect(geometries, hasLength(1));
+      final line = geometries.first as ShpPolyline;
+      expect(line.parts.first, hasLength(part.length));
+      for (var i = 0; i < part.length; i++) {
+        expect(line.parts.first[i][0], closeTo(part[i][0], 0.0001));
+        expect(line.parts.first[i][1], closeTo(part[i][1], 0.0001));
+      }
+    });
+  });
+}

--- a/test/features/home/shapefile_export_notifier_test.dart
+++ b/test/features/home/shapefile_export_notifier_test.dart
@@ -1,0 +1,77 @@
+// test/features/home/shapefile_export_notifier_test.dart
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
+import 'package:firecheck/features/home/data/shapefile_export_notifier.dart';
+import 'package:firecheck/features/home/domain/export_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+ShapefileExportNotifier makeNotifier({
+  required String assignmentId,
+  required AppDatabase db,
+  List<String>? capturedPaths,
+}) {
+  final exporter = ShapefileExporter(
+    db: db,
+    shareFile: (path) async {
+      capturedPaths?.add(path);
+    },
+    tempDirOverride: Directory.systemTemp.createTempSync('notifier_test_'),
+  );
+  return ShapefileExportNotifier(
+    assignmentId: assignmentId,
+    exporter: exporter,
+  );
+}
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() => db.close());
+
+  test('initial state is ExportIdle', () {
+    final notifier = makeNotifier(assignmentId: 'a1', db: db);
+    expect(notifier.state, isA<ExportIdle>());
+  });
+
+  test('export with no features transitions Exporting then Failed', () async {
+    final notifier = makeNotifier(assignmentId: 'a1', db: db);
+    final states = <ExportState>[];
+    notifier.addListener(states.add, fireImmediately: false);
+
+    await notifier.export();
+
+    expect(states, [
+      isA<ExportExporting>(),
+      isA<ExportFailed>(),
+      isA<ExportIdle>(),
+    ]);
+    expect((states[1] as ExportFailed).failure, isA<NoCompletedFeatures>());
+  });
+
+  test('tapping export while Exporting is a no-op', () async {
+    final notifier = makeNotifier(assignmentId: 'a1', db: db);
+    final states = <ExportState>[];
+    notifier.addListener(states.add, fireImmediately: false);
+
+    final first = notifier.export();
+    final second = notifier.export();
+
+    await Future.wait([first, second]);
+
+    expect(states.whereType<ExportExporting>(), hasLength(1));
+  });
+
+  test('after Failed state, notifier resets to Idle', () async {
+    final notifier = makeNotifier(assignmentId: 'a1', db: db);
+    await notifier.export();
+    expect(notifier.state, isA<ExportIdle>());
+  });
+}

--- a/test/features/home/shapefile_export_notifier_test.dart
+++ b/test/features/home/shapefile_export_notifier_test.dart
@@ -1,6 +1,8 @@
 // test/features/home/shapefile_export_notifier_test.dart
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:firecheck/core/db/database.dart';
 import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
@@ -8,6 +10,52 @@ import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
 import 'package:firecheck/features/home/data/shapefile_export_notifier.dart';
 import 'package:firecheck/features/home/domain/export_state.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+Future<void> _seedBuilding(
+  AppDatabase db, {
+  required String assignmentId,
+  required String featureId,
+  required String submissionId,
+}) async {
+  final geoJson = jsonEncode({
+    'type': 'Polygon',
+    'coordinates': [
+      [
+        [120.0, 14.0], [121.0, 14.0], [121.0, 15.0], [120.0, 15.0], [120.0, 14.0],
+      ]
+    ],
+  });
+
+  await db.into(db.features).insert(FeaturesCompanion.insert(
+    id: featureId,
+    assignmentId: assignmentId,
+    featureType: 'building',
+    geometryGeojson: geoJson,
+    isNew: const Value(false),
+    status: const Value('complete'),
+    createdAt: DateTime.now(),
+  ),);
+
+  await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+    id: submissionId,
+    featureId: featureId,
+    syncStatus: const Value('ready_to_upload'),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  ),);
+
+  await db.into(db.buildingAttributes).insert(BuildingAttributesCompanion.insert(
+    submissionId: submissionId,
+    cbmsId: const Value('C001'),
+    buildingName: const Value('Test Hall'),
+    ra9514Type: const Value('Group E'),
+    storeys: const Value(3),
+    material: const Value('Concrete'),
+    costAmount: const Value(500000),
+    fireFightingFacilitiesJson: const Value('["sprinkler","extinguisher"]'),
+    fireLoadJson: const Value('["paper","chemicals"]'),
+  ),);
+}
 
 ShapefileExportNotifier makeNotifier({
   required String assignmentId,
@@ -72,6 +120,34 @@ void main() {
   test('after Failed state, notifier resets to Idle', () async {
     final notifier = makeNotifier(assignmentId: 'a1', db: db);
     await notifier.export();
+    expect(notifier.state, isA<ExportIdle>());
+  });
+
+  test('successful export → Exporting then Done then Idle', () async {
+    const assignmentId = 'a-success';
+    await _seedBuilding(db, assignmentId: assignmentId, featureId: 'f1', submissionId: 's1');
+
+    final capturedPaths = <String>[];
+    final notifier = makeNotifier(
+      assignmentId: assignmentId,
+      db: db,
+      capturedPaths: capturedPaths,
+    );
+    final states = <ExportState>[];
+    notifier.addListener(states.add, fireImmediately: false);
+
+    await notifier.export();
+
+    expect(states, [isA<ExportExporting>(), isA<ExportDone>(), isA<ExportIdle>()]);
+  });
+
+  test('after successful export, notifier resets to Idle', () async {
+    const assignmentId = 'a-success-2';
+    await _seedBuilding(db, assignmentId: assignmentId, featureId: 'f1', submissionId: 's1');
+
+    final notifier = makeNotifier(assignmentId: assignmentId, db: db);
+    await notifier.export();
+
     expect(notifier.state, isA<ExportIdle>());
   });
 }


### PR DESCRIPTION
## Summary

- Adds **Export Shapefile** as the 4th action tile on HomeScreen — disabled when `completedFeatures == 0`, shows a spinner while packaging
- Pure Dart binary writers (`ShpWriter`, `DbfWriter`) produce valid Esri `.shp`/`.shx`/`.dbf`/`.prj`/`.cpg` files, mirroring the existing `ShpParser`/`DbfParser` pattern
- `ShapefileExporter` orchestrator queries Drift for completed features, splits by type (buildings → polygons, roads → polylines), runs writers in a `compute` isolate, and ZIPs everything into `firecheck_<assignmentId>_<timestamp>.zip`
- `ShapefileExportNotifier` (`StateNotifier`) drives the `Idle → Exporting → Done/Failed → Idle` state machine; `ExportFailed` surfaces a localised SnackBar
- Empty layers (no completed features of a given type) are omitted from the ZIP
- `doesNotExist` features are included with `NOT_EXIST = T` in the DBF
- JSON array fields (`fireFightingFacilitiesJson`, `fireLoadJson`, `roadFeaturesJson`) serialised as pipe-delimited strings

## Test Plan

- [ ] `flutter test` — all tests pass (527+, zero failures in US-22 files)
- [ ] `flutter analyze` — no issues
- [ ] HomeScreen: Export tile is greyed out with 0 completed features
- [ ] HomeScreen: Export tile is tappable with ≥1 completed feature
- [ ] Tapping Export → spinner appears, share sheet opens with `.zip`
- [ ] Unzip on desktop: contains `buildings.shp/shx/dbf/prj/cpg` (and `roads.*` if road features exist)
- [ ] Open `buildings.shp` in QGIS: polygons render at correct location, attribute table shows all columns with correct values
- [ ] Non-ASCII field values (accented characters, em-dashes) render correctly in QGIS

## Closes

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)