### PR TITLE
feat(export-validation): pre-export shapefile validation gate (US-25)

### DIFF
--- a/docs/superpowers/plans/2026-05-02-shapefile-export-validation.md
+++ b/docs/superpowers/plans/2026-05-02-shapefile-export-validation.md
@@ -1,0 +1,1179 @@
+# Shapefile Export Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gate the Export Shapefile share action behind a two-phase validation: (1) a DB-level check that every layer has complete, exportable features, and (2) a post-export sanity check that the generated archive entries are non-empty.
+
+**Architecture:** A new `ShapefileExportValidator` queries the Drift DB before the export fires, and two new states (`ExportValidating`, `ExportValidationFailed`) are added to the existing state machine. If validation passes, `ShapefileExporter` runs as normal, followed by a lightweight sanity check on the generated layer outputs before they are packed into the ZIP. Validation errors render as a persistent inline list below the export tile on `HomeScreen`; the existing `ExportFailed` snackbar path is unchanged.
+
+**Tech Stack:** Flutter, Dart, Drift (SQLite ORM), Riverpod (`StateNotifier`), `flutter_test`
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `lib/core/sync/shapefile/export/export_validation_result.dart` | `ExportLayer`, `ExportLayerIssue`, `ExportLayerError`, `ExportValidationResult` value objects |
+| Create | `lib/core/sync/shapefile/export/shapefile_export_validator.dart` | DB validation logic — empty-layer check + orphan check |
+| Create | `test/core/sync/shapefile/export/shapefile_export_validator_test.dart` | 6 validator unit tests |
+| Modify | `lib/features/home/domain/export_state.dart` | Add `ExportValidating`, `ExportValidationFailed` |
+| Modify | `lib/core/sync/shapefile/export/shapefile_exporter.dart` | Post-export sanity check after `compute()` |
+| Modify | `test/core/sync/shapefile/export/shapefile_exporter_test.dart` | Add sanity-check integration test |
+| Modify | `lib/features/home/data/shapefile_export_notifier.dart` | Accept `ShapefileExportValidator`; new state transitions |
+| Modify | `test/features/home/shapefile_export_notifier_test.dart` | Update existing tests + add 2 new state-machine tests |
+| Modify | `lib/core/i18n/app_en.arb` | 5 new l10n keys |
+| Modify | `lib/core/i18n/app_tl.arb` | 5 matching Tagalog keys |
+| Modify | `lib/features/home/presentation/home_screen.dart` | Inline error list for `ExportValidationFailed`; `isBusy` guard |
+
+---
+
+### Task 1: Create ExportValidationResult model
+
+**Files:**
+- Create: `lib/core/sync/shapefile/export/export_validation_result.dart`
+
+- [ ] **Step 1: Create the file**
+
+```dart
+// lib/core/sync/shapefile/export/export_validation_result.dart
+
+enum ExportLayer { buildings, roads }
+
+enum ExportLayerIssue { emptyLayer, missingRequiredFields }
+
+class ExportLayerError {
+  const ExportLayerError({required this.layer, required this.issue});
+  final ExportLayer layer;
+  final ExportLayerIssue issue;
+}
+
+class ExportValidationResult {
+  const ExportValidationResult({required this.errors});
+  final List<ExportLayerError> errors;
+  bool get isValid => errors.isEmpty;
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd "/Users/johnlesterescarlan/Personal Projects/firecheck" && flutter analyze lib/core/sync/shapefile/export/export_validation_result.dart`
+
+Expected: `No issues found!`
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd "/Users/johnlesterescarlan/Personal Projects/firecheck"
+git add lib/core/sync/shapefile/export/export_validation_result.dart
+git commit -m "feat(export-validation): add ExportValidationResult model"
+```
+
+---
+
+### Task 2: ShapefileExportValidator (TDD)
+
+**Files:**
+- Create: `test/core/sync/shapefile/export/shapefile_export_validator_test.dart`
+- Create: `lib/core/sync/shapefile/export/shapefile_export_validator.dart`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `test/core/sync/shapefile/export/shapefile_export_validator_test.dart`:
+
+```dart
+import 'dart:convert';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_validation_result.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_export_validator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> _seedBuilding(
+  AppDatabase db, {
+  required String assignmentId,
+  required String featureId,
+  required String submissionId,
+}) async {
+  final geoJson = jsonEncode({
+    'type': 'Polygon',
+    'coordinates': [
+      [
+        [120.0, 14.0], [121.0, 14.0], [121.0, 15.0],
+        [120.0, 15.0], [120.0, 14.0],
+      ],
+    ],
+  });
+  await db.into(db.features).insert(FeaturesCompanion.insert(
+    id: featureId,
+    assignmentId: assignmentId,
+    featureType: 'building',
+    geometryGeojson: geoJson,
+    status: const Value('complete'),
+    createdAt: DateTime.now(),
+  ));
+  await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+    id: submissionId,
+    featureId: featureId,
+    syncStatus: const Value('ready_to_upload'),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  ));
+  await db.into(db.buildingAttributes).insert(
+    BuildingAttributesCompanion.insert(
+      submissionId: submissionId,
+      fireFightingFacilitiesJson: const Value('[]'),
+      fireLoadJson: const Value('[]'),
+    ),
+  );
+}
+
+// Complete building feature WITHOUT a buildingAttributes row.
+// Simulates a feature that would be silently excluded by the exporter's inner join.
+Future<void> _seedOrphanBuilding(
+  AppDatabase db, {
+  required String assignmentId,
+  required String featureId,
+  required String submissionId,
+}) async {
+  final geoJson = jsonEncode({
+    'type': 'Polygon',
+    'coordinates': [
+      [
+        [120.0, 14.0], [121.0, 14.0], [121.0, 15.0],
+        [120.0, 15.0], [120.0, 14.0],
+      ],
+    ],
+  });
+  await db.into(db.features).insert(FeaturesCompanion.insert(
+    id: featureId,
+    assignmentId: assignmentId,
+    featureType: 'building',
+    geometryGeojson: geoJson,
+    status: const Value('complete'),
+    createdAt: DateTime.now(),
+  ));
+  await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+    id: submissionId,
+    featureId: featureId,
+    syncStatus: const Value('ready_to_upload'),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  ));
+  // Intentionally no buildingAttributes row
+}
+
+Future<void> _seedRoad(
+  AppDatabase db, {
+  required String assignmentId,
+  required String featureId,
+  required String submissionId,
+}) async {
+  final geoJson = jsonEncode({
+    'type': 'LineString',
+    'coordinates': [[120.0, 14.0], [121.0, 14.5]],
+  });
+  await db.into(db.features).insert(FeaturesCompanion.insert(
+    id: featureId,
+    assignmentId: assignmentId,
+    featureType: 'road',
+    geometryGeojson: geoJson,
+    status: const Value('complete'),
+    createdAt: DateTime.now(),
+  ));
+  await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+    id: submissionId,
+    featureId: featureId,
+    syncStatus: const Value('ready_to_upload'),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  ));
+  await db.into(db.roadAttributes).insert(
+    RoadAttributesCompanion.insert(
+      submissionId: submissionId,
+      roadFeaturesJson: const Value('[]'),
+    ),
+  );
+}
+
+// Complete road feature WITHOUT a roadAttributes row.
+Future<void> _seedOrphanRoad(
+  AppDatabase db, {
+  required String assignmentId,
+  required String featureId,
+  required String submissionId,
+}) async {
+  final geoJson = jsonEncode({
+    'type': 'LineString',
+    'coordinates': [[120.0, 14.0], [121.0, 14.5]],
+  });
+  await db.into(db.features).insert(FeaturesCompanion.insert(
+    id: featureId,
+    assignmentId: assignmentId,
+    featureType: 'road',
+    geometryGeojson: geoJson,
+    status: const Value('complete'),
+    createdAt: DateTime.now(),
+  ));
+  await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+    id: submissionId,
+    featureId: featureId,
+    syncStatus: const Value('ready_to_upload'),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  ));
+  // Intentionally no roadAttributes row
+}
+
+void main() {
+  late AppDatabase db;
+  setUp(() => db = AppDatabase.forTesting(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  ShapefileExportValidator makeValidator() =>
+      ShapefileExportValidator(db: db);
+
+  test('buildings layer empty → isValid false, buildings/emptyLayer error',
+      () async {
+    await _seedRoad(
+        db, assignmentId: 'a1', featureId: 'r1', submissionId: 'sr1');
+    final result = await makeValidator().validate('a1');
+    expect(result.isValid, isFalse);
+    expect(result.errors, hasLength(1));
+    expect(result.errors.first.layer, ExportLayer.buildings);
+    expect(result.errors.first.issue, ExportLayerIssue.emptyLayer);
+  });
+
+  test('roads layer empty → isValid false, roads/emptyLayer error', () async {
+    await _seedBuilding(
+        db, assignmentId: 'a1', featureId: 'b1', submissionId: 'sb1');
+    final result = await makeValidator().validate('a1');
+    expect(result.isValid, isFalse);
+    expect(result.errors, hasLength(1));
+    expect(result.errors.first.layer, ExportLayer.roads);
+    expect(result.errors.first.issue, ExportLayerIssue.emptyLayer);
+  });
+
+  test('both layers empty → isValid false, two emptyLayer errors', () async {
+    final result = await makeValidator().validate('a1');
+    expect(result.isValid, isFalse);
+    expect(result.errors, hasLength(2));
+    expect(
+      result.errors.map((e) => e.issue),
+      everyElement(ExportLayerIssue.emptyLayer),
+    );
+  });
+
+  test('building orphan → isValid false, buildings/missingRequiredFields',
+      () async {
+    await _seedOrphanBuilding(
+        db, assignmentId: 'a1', featureId: 'b1', submissionId: 'sb1');
+    await _seedRoad(
+        db, assignmentId: 'a1', featureId: 'r1', submissionId: 'sr1');
+    final result = await makeValidator().validate('a1');
+    expect(result.isValid, isFalse);
+    expect(result.errors, hasLength(1));
+    expect(result.errors.first.layer, ExportLayer.buildings);
+    expect(result.errors.first.issue, ExportLayerIssue.missingRequiredFields);
+  });
+
+  test('road orphan → isValid false, roads/missingRequiredFields', () async {
+    await _seedBuilding(
+        db, assignmentId: 'a1', featureId: 'b1', submissionId: 'sb1');
+    await _seedOrphanRoad(
+        db, assignmentId: 'a1', featureId: 'r1', submissionId: 'sr1');
+    final result = await makeValidator().validate('a1');
+    expect(result.isValid, isFalse);
+    expect(result.errors, hasLength(1));
+    expect(result.errors.first.layer, ExportLayer.roads);
+    expect(result.errors.first.issue, ExportLayerIssue.missingRequiredFields);
+  });
+
+  test('all layers complete and valid → isValid true, no errors', () async {
+    await _seedBuilding(
+        db, assignmentId: 'a1', featureId: 'b1', submissionId: 'sb1');
+    await _seedRoad(
+        db, assignmentId: 'a1', featureId: 'r1', submissionId: 'sr1');
+    final result = await makeValidator().validate('a1');
+    expect(result.isValid, isTrue);
+    expect(result.errors, isEmpty);
+  });
+}
+```
+
+- [ ] **Step 2: Run to confirm compilation fails**
+
+Run: `cd "/Users/johnlesterescarlan/Personal Projects/firecheck" && flutter test test/core/sync/shapefile/export/shapefile_export_validator_test.dart`
+
+Expected: Compilation error — `shapefile_export_validator.dart` not found yet.
+
+- [ ] **Step 3: Implement ShapefileExportValidator**
+
+Create `lib/core/sync/shapefile/export/shapefile_export_validator.dart`:
+
+```dart
+import 'package:drift/drift.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_validation_result.dart';
+
+class ShapefileExportValidator {
+  const ShapefileExportValidator({required this.db});
+  final AppDatabase db;
+
+  Future<ExportValidationResult> validate(String assignmentId) async {
+    final errors = <ExportLayerError>[];
+
+    for (final layer in ExportLayer.values) {
+      final featureType =
+          layer == ExportLayer.buildings ? 'building' : 'road';
+
+      final totalComplete = await _countComplete(assignmentId, featureType);
+      if (totalComplete == 0) {
+        errors.add(
+          ExportLayerError(layer: layer, issue: ExportLayerIssue.emptyLayer),
+        );
+        continue;
+      }
+
+      final exportable =
+          await _countExportable(assignmentId, featureType, layer);
+      if (exportable < totalComplete) {
+        errors.add(
+          ExportLayerError(
+            layer: layer,
+            issue: ExportLayerIssue.missingRequiredFields,
+          ),
+        );
+      }
+    }
+
+    return ExportValidationResult(errors: errors);
+  }
+
+  Future<int> _countComplete(
+      String assignmentId, String featureType) async {
+    final rows = await (db.select(db.features)
+          ..where(
+            (f) =>
+                f.assignmentId.equals(assignmentId) &
+                f.featureType.equals(featureType) &
+                f.status.equals('complete'),
+          ))
+        .get();
+    return rows.length;
+  }
+
+  Future<int> _countExportable(
+    String assignmentId,
+    String featureType,
+    ExportLayer layer,
+  ) async {
+    if (layer == ExportLayer.buildings) {
+      return (await (db.select(db.features).join([
+        innerJoin(
+          db.submissions,
+          db.submissions.featureId.equalsExp(db.features.id),
+        ),
+        innerJoin(
+          db.buildingAttributes,
+          db.buildingAttributes.submissionId.equalsExp(db.submissions.id),
+        ),
+      ])
+                ..where(
+                  db.features.assignmentId.equals(assignmentId) &
+                      db.features.featureType.equals(featureType) &
+                      db.features.status.equals('complete'),
+                ))
+              .get())
+          .length;
+    } else {
+      return (await (db.select(db.features).join([
+        innerJoin(
+          db.submissions,
+          db.submissions.featureId.equalsExp(db.features.id),
+        ),
+        innerJoin(
+          db.roadAttributes,
+          db.roadAttributes.submissionId.equalsExp(db.submissions.id),
+        ),
+      ])
+                ..where(
+                  db.features.assignmentId.equals(assignmentId) &
+                      db.features.featureType.equals(featureType) &
+                      db.features.status.equals('complete'),
+                ))
+              .get())
+          .length;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to confirm all 6 pass**
+
+Run: `cd "/Users/johnlesterescarlan/Personal Projects/firecheck" && flutter test test/core/sync/shapefile/export/shapefile_export_validator_test.dart`
+
+Expected: `+6: All tests passed!`
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "/Users/johnlesterescarlan/Personal Projects/firecheck"
+git add lib/core/sync/shapefile/export/shapefile_export_validator.dart \
+        test/core/sync/shapefile/export/shapefile_export_validator_test.dart
+git commit -m "feat(export-validation): add ShapefileExportValidator with 6 tests"
+```
+
+---
+
+### Task 3: Extend ExportState with validation variants
+
+**Files:**
+- Modify: `lib/features/home/domain/export_state.dart`
+
+- [ ] **Step 1: Replace file contents**
+
+```dart
+// lib/features/home/domain/export_state.dart
+import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_validation_result.dart';
+
+sealed class ExportState {
+  const ExportState();
+}
+
+class ExportIdle extends ExportState {
+  const ExportIdle();
+}
+
+class ExportValidating extends ExportState {
+  const ExportValidating();
+}
+
+class ExportValidationFailed extends ExportState {
+  const ExportValidationFailed(this.errors);
+  final List<ExportLayerError> errors;
+}
+
+class ExportExporting extends ExportState {
+  const ExportExporting();
+}
+
+class ExportDone extends ExportState {
+  const ExportDone();
+}
+
+class ExportFailed extends ExportState {
+  const ExportFailed(this.failure);
+  final ExportFailure failure;
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd "/Users/johnlesterescarlan/Personal Projects/firecheck" && flutter analyze lib/features/home/domain/export_state.dart`
+
+Expected: `No issues found!`
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd "/Users/johnlesterescarlan/Personal Projects/firecheck"
+git add lib/features/home/domain/export_state.dart
+git commit -m "feat(export-validation): add ExportValidating and ExportValidationFailed states"
+```
+
+---
+
+### Task 4: Post-export sanity check in ShapefileExporter
+
+**Files:**
+- Modify: `lib/core/sync/shapefile/export/shapefile_exporter.dart`
+- Modify: `test/core/sync/shapefile/export/shapefile_exporter_test.dart`
+
+- [ ] **Step 1: Add the sanity-check integration test**
+
+In `test/core/sync/shapefile/export/shapefile_exporter_test.dart`, add this test inside `void main()` after the existing 5 tests:
+
+```dart
+  test('exported archive entries are non-empty for all required layer files',
+      () async {
+    const assignmentId = 'sanity-check-001';
+    await _seedBuilding(db,
+        assignmentId: assignmentId, featureId: 'b1', submissionId: 'sb1');
+    await _seedRoad(db,
+        assignmentId: assignmentId, featureId: 'r1', submissionId: 'sr1');
+
+    final capturedPaths = <String>[];
+    await makeExporter(capturedPaths: capturedPaths)
+        .export(assignmentId: assignmentId);
+
+    final zipBytes = await File(capturedPaths.first).readAsBytes();
+    final archive = ZipDecoder().decodeBytes(zipBytes);
+
+    for (final ext in ['.shp', '.shx', '.dbf']) {
+      expect(
+        archive.files.firstWhere((f) => f.name == 'buildings$ext').size,
+        greaterThan(0),
+        reason: 'buildings$ext must not be empty',
+      );
+      expect(
+        archive.files.firstWhere((f) => f.name == 'roads$ext').size,
+        greaterThan(0),
+        reason: 'roads$ext must not be empty',
+      );
+    }
+  });
+```
+
+- [ ] **Step 2: Run new test to confirm it passes with current code (positive-path baseline)**
+
+Run: `cd "/Users/johnlesterescarlan/Personal Projects/firecheck" && flutter test test/core/sync/shapefile/export/shapefile_exporter_test.dart --name "exported archive entries"`
+
+Expected: `+1: All tests passed!`
+
+- [ ] **Step 3: Add the sanity check to ShapefileExporter.export()**
+
+In `lib/core/sync/shapefile/export/shapefile_exporter.dart`, locate the `try { outputs = await Future.wait(...) }` block. Add the sanity check immediately after it, before the `// Build ZIP archive` comment:
+
+```dart
+    // Write each layer via compute
+    List<_LayerOutput> outputs;
+    try {
+      outputs = await Future.wait(
+        inputs.map((input) => compute(_writeLayer, input)),
+      );
+    } catch (e) {
+      return WriteError(e.toString());
+    }
+
+    // Guard against exporter bugs producing empty file components.
+    for (final out in outputs) {
+      if (out.shp.isEmpty || out.shx.isEmpty || out.dbf.isEmpty) {
+        return WriteError('Layer ${out.layerName} produced empty components');
+      }
+    }
+
+    // Build ZIP archive
+    final archive = Archive();
+```
+
+- [ ] **Step 4: Run all exporter tests**
+
+Run: `cd "/Users/johnlesterescarlan/Personal Projects/firecheck" && flutter test test/core/sync/shapefile/export/shapefile_exporter_test.dart`
+
+Expected: `+6: All tests passed!`
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "/Users/johnlesterescarlan/Personal Projects/firecheck"
+git add lib/core/sync/shapefile/export/shapefile_exporter.dart \
+        test/core/sync/shapefile/export/shapefile_exporter_test.dart
+git commit -m "feat(export-validation): add post-export sanity check to ShapefileExporter"
+```
+
+---
+
+### Task 5: Update ShapefileExportNotifier
+
+**Files:**
+- Modify: `lib/features/home/data/shapefile_export_notifier.dart`
+- Modify: `test/features/home/shapefile_export_notifier_test.dart`
+
+- [ ] **Step 1: Write the updated test file**
+
+Replace the full contents of `test/features/home/shapefile_export_notifier_test.dart`:
+
+```dart
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_export_validator.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
+import 'package:firecheck/features/home/data/shapefile_export_notifier.dart';
+import 'package:firecheck/features/home/domain/export_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> _seedBuilding(
+  AppDatabase db, {
+  required String assignmentId,
+  required String featureId,
+  required String submissionId,
+}) async {
+  final geoJson = jsonEncode({
+    'type': 'Polygon',
+    'coordinates': [
+      [
+        [120.0, 14.0], [121.0, 14.0], [121.0, 15.0],
+        [120.0, 15.0], [120.0, 14.0],
+      ],
+    ],
+  });
+  await db.into(db.features).insert(FeaturesCompanion.insert(
+    id: featureId,
+    assignmentId: assignmentId,
+    featureType: 'building',
+    geometryGeojson: geoJson,
+    isNew: const Value(false),
+    status: const Value('complete'),
+    createdAt: DateTime.now(),
+  ));
+  await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+    id: submissionId,
+    featureId: featureId,
+    syncStatus: const Value('ready_to_upload'),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  ));
+  await db.into(db.buildingAttributes).insert(
+    BuildingAttributesCompanion.insert(
+      submissionId: submissionId,
+      cbmsId: const Value('C001'),
+      buildingName: const Value('Test Hall'),
+      ra9514Type: const Value('Group E'),
+      storeys: const Value(3),
+      material: const Value('Concrete'),
+      costAmount: const Value(500000),
+      fireFightingFacilitiesJson: const Value('["sprinkler","extinguisher"]'),
+      fireLoadJson: const Value('["paper","chemicals"]'),
+    ),
+  );
+}
+
+Future<void> _seedRoad(
+  AppDatabase db, {
+  required String assignmentId,
+  required String featureId,
+  required String submissionId,
+}) async {
+  final geoJson = jsonEncode({
+    'type': 'LineString',
+    'coordinates': [[120.0, 14.0], [121.0, 14.5]],
+  });
+  await db.into(db.features).insert(FeaturesCompanion.insert(
+    id: featureId,
+    assignmentId: assignmentId,
+    featureType: 'road',
+    geometryGeojson: geoJson,
+    isNew: const Value(false),
+    status: const Value('complete'),
+    createdAt: DateTime.now(),
+  ));
+  await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+    id: submissionId,
+    featureId: featureId,
+    syncStatus: const Value('ready_to_upload'),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  ));
+  await db.into(db.roadAttributes).insert(
+    RoadAttributesCompanion.insert(
+      submissionId: submissionId,
+      roadName: const Value('Main St'),
+      widthMeters: const Value(8),
+      roadFeaturesJson: const Value('["Pedestrian"]'),
+    ),
+  );
+}
+
+ShapefileExportNotifier makeNotifier({
+  required String assignmentId,
+  required AppDatabase db,
+  List<String>? capturedPaths,
+  ShapefileExportValidator? validator,
+}) {
+  final exporter = ShapefileExporter(
+    db: db,
+    shareFile: (path) async { capturedPaths?.add(path); },
+    tempDirOverride: Directory.systemTemp.createTempSync('notifier_test_'),
+  );
+  return ShapefileExportNotifier(
+    assignmentId: assignmentId,
+    exporter: exporter,
+    validator: validator ?? ShapefileExportValidator(db: db),
+  );
+}
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() => db = AppDatabase.forTesting(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  test('initial state is ExportIdle', () {
+    final notifier = makeNotifier(assignmentId: 'a1', db: db);
+    expect(notifier.state, isA<ExportIdle>());
+  });
+
+  test('empty DB → Validating then ValidationFailed then Idle', () async {
+    final notifier = makeNotifier(assignmentId: 'a1', db: db);
+    final states = <ExportState>[];
+    notifier.addListener(states.add, fireImmediately: false);
+
+    await notifier.export();
+
+    expect(states, [
+      isA<ExportValidating>(),
+      isA<ExportValidationFailed>(),
+      isA<ExportIdle>(),
+    ]);
+    expect((states[1] as ExportValidationFailed).errors, isNotEmpty);
+  });
+
+  test('tapping export while Validating or Exporting is a no-op', () async {
+    final notifier = makeNotifier(assignmentId: 'a1', db: db);
+    final states = <ExportState>[];
+    notifier.addListener(states.add, fireImmediately: false);
+
+    final first = notifier.export();
+    final second = notifier.export();
+    await Future.wait([first, second]);
+
+    expect(states.whereType<ExportValidating>(), hasLength(1));
+  });
+
+  test('after ValidationFailed, notifier resets to Idle', () async {
+    final notifier = makeNotifier(assignmentId: 'a1', db: db);
+    await notifier.export();
+    expect(notifier.state, isA<ExportIdle>());
+  });
+
+  test('validation pass → Validating then Exporting then Done then Idle',
+      () async {
+    const assignmentId = 'a-success';
+    await _seedBuilding(
+        db, assignmentId: assignmentId, featureId: 'b1', submissionId: 'sb1');
+    await _seedRoad(
+        db, assignmentId: assignmentId, featureId: 'r1', submissionId: 'sr1');
+
+    final notifier = makeNotifier(assignmentId: assignmentId, db: db);
+    final states = <ExportState>[];
+    notifier.addListener(states.add, fireImmediately: false);
+
+    await notifier.export();
+
+    expect(states, [
+      isA<ExportValidating>(),
+      isA<ExportExporting>(),
+      isA<ExportDone>(),
+      isA<ExportIdle>(),
+    ]);
+  });
+
+  test('after successful export, notifier resets to Idle', () async {
+    const assignmentId = 'a-success-2';
+    await _seedBuilding(
+        db, assignmentId: assignmentId, featureId: 'b1', submissionId: 'sb1');
+    await _seedRoad(
+        db, assignmentId: assignmentId, featureId: 'r1', submissionId: 'sr1');
+
+    final notifier = makeNotifier(assignmentId: assignmentId, db: db);
+    await notifier.export();
+
+    expect(notifier.state, isA<ExportIdle>());
+  });
+}
+```
+
+- [ ] **Step 2: Run to confirm compilation fails**
+
+Run: `cd "/Users/johnlesterescarlan/Personal Projects/firecheck" && flutter test test/features/home/shapefile_export_notifier_test.dart`
+
+Expected: Compilation error — `ShapefileExportNotifier` constructor does not yet accept `validator`.
+
+- [ ] **Step 3: Update ShapefileExportNotifier**
+
+Replace the full contents of `lib/features/home/data/shapefile_export_notifier.dart`:
+
+```dart
+import 'package:firecheck/core/sync/shapefile/export/export_validation_result.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_export_validator.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
+import 'package:firecheck/features/assignment/presentation/assignment_providers.dart';
+import 'package:firecheck/features/home/domain/export_state.dart';
+import 'package:firecheck/features/home/presentation/home_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:share_plus/share_plus.dart';
+
+class ShapefileExportNotifier extends StateNotifier<ExportState> {
+  ShapefileExportNotifier({
+    required String assignmentId,
+    required ShapefileExporter exporter,
+    required ShapefileExportValidator validator,
+  })  : _assignmentId = assignmentId,
+        _exporter = exporter,
+        _validator = validator,
+        super(const ExportIdle());
+
+  final String _assignmentId;
+  final ShapefileExporter _exporter;
+  final ShapefileExportValidator _validator;
+
+  Future<void> export() async {
+    if (state is ExportValidating || state is ExportExporting) return;
+
+    state = const ExportValidating();
+    final result = await _validator.validate(_assignmentId);
+
+    if (!mounted) return;
+    if (!result.isValid) {
+      state = ExportValidationFailed(result.errors);
+      state = const ExportIdle();
+      return;
+    }
+
+    state = const ExportExporting();
+    final failure = await _exporter.export(assignmentId: _assignmentId);
+
+    if (!mounted) return;
+    if (failure != null) {
+      state = ExportFailed(failure);
+      state = const ExportIdle();
+      return;
+    }
+
+    state = const ExportDone();
+    state = const ExportIdle();
+  }
+}
+
+final shapefileExportNotifierProvider =
+    StateNotifierProvider<ShapefileExportNotifier, ExportState>((ref) {
+  final db = ref.watch(appDatabaseProvider);
+  final assignmentAsync = ref.watch(currentAssignmentProvider);
+  final assignmentId = assignmentAsync.value?.id ?? '';
+
+  return ShapefileExportNotifier(
+    assignmentId: assignmentId,
+    exporter: ShapefileExporter(
+      db: db,
+      shareFile: (path) async {
+        await SharePlus.instance.share(ShareParams(files: [XFile(path)]));
+      },
+    ),
+    validator: ShapefileExportValidator(db: db),
+  );
+});
+```
+
+- [ ] **Step 4: Run tests to confirm all 6 pass**
+
+Run: `cd "/Users/johnlesterescarlan/Personal Projects/firecheck" && flutter test test/features/home/shapefile_export_notifier_test.dart`
+
+Expected: `+6: All tests passed!`
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "/Users/johnlesterescarlan/Personal Projects/firecheck"
+git add lib/features/home/data/shapefile_export_notifier.dart \
+        test/features/home/shapefile_export_notifier_test.dart
+git commit -m "feat(export-validation): wire ShapefileExportValidator into ShapefileExportNotifier"
+```
+
+---
+
+### Task 6: L10n keys + HomeScreen inline validation errors
+
+**Files:**
+- Modify: `lib/core/i18n/app_en.arb`
+- Modify: `lib/core/i18n/app_tl.arb`
+- Modify: `lib/features/home/presentation/home_screen.dart`
+
+- [ ] **Step 1: Add new keys to app_en.arb**
+
+In `lib/core/i18n/app_en.arb`, replace the final `}` with these entries followed by a new closing `}`:
+
+```json
+  "exportValidating": "Validating…",
+  "exportValidationBuildingsEmpty": "No buildings recorded. Survey at least one building before exporting.",
+  "exportValidationRoadsEmpty": "No roads recorded. Survey at least one road before exporting.",
+  "exportValidationBuildingsMissingFields": "Some building entries are missing required fields. Complete all building forms before exporting.",
+  "exportValidationRoadsMissingFields": "Some road entries are missing required fields. Complete all road forms before exporting."
+}
+```
+
+- [ ] **Step 2: Add matching keys to app_tl.arb**
+
+In `lib/core/i18n/app_tl.arb`, replace the final `}` with these entries followed by a new closing `}`. (Provide Tagalog translations below; English is used as placeholder — replace with native translations before release.)
+
+```json
+  "exportValidating": "Bine-validate…",
+  "exportValidationBuildingsEmpty": "Walang naitalagang gusali. Mag-survey ng kahit isang gusali bago mag-export.",
+  "exportValidationRoadsEmpty": "Walang naitalagang kalsada. Mag-survey ng kahit isang kalsada bago mag-export.",
+  "exportValidationBuildingsMissingFields": "May ilang gusali na may kulang na impormasyon. Kumpletuhin ang lahat ng form ng gusali bago mag-export.",
+  "exportValidationRoadsMissingFields": "May ilang kalsada na may kulang na impormasyon. Kumpletuhin ang lahat ng form ng kalsada bago mag-export."
+}
+```
+
+- [ ] **Step 3: Run gen-l10n**
+
+Run: `cd "/Users/johnlesterescarlan/Personal Projects/firecheck" && flutter gen-l10n`
+
+Expected: No errors. Confirm the new keys appear in `lib/generated/l10n/app_localizations_en.dart`:
+```bash
+grep -l "exportValidating\|exportValidationBuildings" lib/generated/l10n/app_localizations_en.dart
+```
+Expected: the file is listed.
+
+- [ ] **Step 4: Update HomeScreen**
+
+Replace the full contents of `lib/features/home/presentation/home_screen.dart`:
+
+```dart
+import 'package:firecheck/core/security/biometric_gate_provider.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_validation_result.dart';
+import 'package:firecheck/features/assignment/presentation/assignment_lock_providers.dart';
+import 'package:firecheck/features/assignment/presentation/assignment_lock_state.dart';
+import 'package:firecheck/features/assignment/presentation/submitted_banner.dart';
+import 'package:firecheck/features/home/data/shapefile_export_notifier.dart';
+import 'package:firecheck/features/home/domain/export_state.dart';
+import 'package:firecheck/features/home/presentation/home_providers.dart';
+import 'package:firecheck/generated/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+class HomeScreen extends ConsumerWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context)!;
+    final asyncSnap = ref.watch(progressProvider);
+    final lock = ref.watch(assignmentLockStateProvider).value;
+    final isLocked = lock is Submitted || lock is ClosedRemotely;
+    final exportState = ref.watch(shapefileExportNotifierProvider);
+    final isBusy =
+        exportState is ExportValidating || exportState is ExportExporting;
+
+    ref.listen<ExportState>(shapefileExportNotifierProvider, (prev, next) {
+      if (next is ExportFailed) {
+        final msg = switch (next.failure) {
+          NoCompletedFeatures() => l.exportErrorNoFeatures,
+          WriteError()          => l.exportErrorWriteFailed,
+          ShareError()          => l.exportErrorShareFailed,
+        };
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(msg)),
+        );
+      }
+    });
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('FireCheck')),
+      body: asyncSnap.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+        data: (snap) => Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: [
+              if (lock is Submitted)
+                SubmittedBanner(submittedAt: lock.submittedAt)
+              else
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          l.assignmentProgress,
+                          style: const TextStyle(
+                            fontSize: 12,
+                            color: Colors.grey,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          l.featuresLabel(
+                            snap.completedFeatures,
+                            snap.totalFeatures,
+                          ),
+                          style: const TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        LinearProgressIndicator(
+                          value: snap.totalFeatures == 0
+                              ? 0
+                              : snap.completedFeatures / snap.totalFeatures,
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          l.jobCountsLabel(
+                            snap.queuedJobs,
+                            snap.failedJobs,
+                            snap.deadJobs,
+                          ),
+                          style: const TextStyle(fontSize: 12),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              const SizedBox(height: 12),
+              _ActionTile(
+                title: l.gatherData,
+                subtitle: l.gatherDataSubtitle,
+                onTap: () => context.go('/map'),
+              ),
+              _ActionTile(
+                title: l.getMaps,
+                subtitle: l.getMapsSubtitle,
+                onTap: () => context.go('/get-maps'),
+              ),
+              if (!isLocked)
+                _ActionTile(
+                  title: l.uploadData,
+                  subtitle: l.uploadDataSubtitle,
+                  onTap: () => _onUploadDataTap(context, ref, l),
+                ),
+              _ActionTile(
+                title: switch (exportState) {
+                  ExportValidating() => l.exportValidating,
+                  ExportExporting() => l.exportShapefileExporting,
+                  _ => l.exportShapefile,
+                },
+                subtitle: l.exportShapefileSubtitle,
+                trailing: isBusy
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.chevron_right),
+                onTap: (snap.completedFeatures == 0 || isBusy)
+                    ? null
+                    : () => ref
+                        .read(shapefileExportNotifierProvider.notifier)
+                        .export(),
+              ),
+              if (exportState is ExportValidationFailed)
+                ...exportState.errors.map(
+                  (e) => Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 2,
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(
+                          Icons.error_outline,
+                          size: 14,
+                          color: Colors.red,
+                        ),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            _validationErrorMessage(l, e),
+                            style: const TextStyle(
+                              color: Colors.red,
+                              fontSize: 12,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _validationErrorMessage(AppLocalizations l, ExportLayerError e) =>
+      switch ((e.layer, e.issue)) {
+        (ExportLayer.buildings, ExportLayerIssue.emptyLayer) =>
+          l.exportValidationBuildingsEmpty,
+        (ExportLayer.roads, ExportLayerIssue.emptyLayer) =>
+          l.exportValidationRoadsEmpty,
+        (ExportLayer.buildings, ExportLayerIssue.missingRequiredFields) =>
+          l.exportValidationBuildingsMissingFields,
+        (ExportLayer.roads, ExportLayerIssue.missingRequiredFields) =>
+          l.exportValidationRoadsMissingFields,
+      };
+
+  Future<void> _onUploadDataTap(
+    BuildContext context,
+    WidgetRef ref,
+    AppLocalizations l,
+  ) async {
+    final biometric = ref.read(biometricGateProvider);
+    final available = await biometric.isAvailable();
+    if (!available) {
+      if (context.mounted) context.go('/review');
+      return;
+    }
+    final ok = await biometric.authenticate(reason: l.biometricGateReason);
+    if (!ok) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l.biometricFailedSnackbar)),
+        );
+      }
+      return;
+    }
+    if (context.mounted) context.go('/review');
+  }
+}
+
+class _ActionTile extends StatelessWidget {
+  const _ActionTile({
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+    this.trailing,
+  });
+  final String title;
+  final String subtitle;
+  final VoidCallback? onTap;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        title: Text(title),
+        subtitle: Text(subtitle),
+        trailing: trailing ?? const Icon(Icons.chevron_right),
+        onTap: onTap,
+        enabled: onTap != null,
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 5: Run analyze**
+
+Run: `cd "/Users/johnlesterescarlan/Personal Projects/firecheck" && flutter analyze`
+
+Expected: `No issues found!`
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `cd "/Users/johnlesterescarlan/Personal Projects/firecheck" && flutter test`
+
+Expected: All tests pass (count will be existing tests + 7 new ones added across tasks 2, 4, 5).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd "/Users/johnlesterescarlan/Personal Projects/firecheck"
+git add lib/core/i18n/app_en.arb \
+        lib/core/i18n/app_tl.arb \
+        lib/features/home/presentation/home_screen.dart
+git commit -m "feat(export-validation): add l10n keys and inline validation errors on HomeScreen"
+```

--- a/docs/superpowers/specs/2026-05-02-shapefile-export-validation-design.md
+++ b/docs/superpowers/specs/2026-05-02-shapefile-export-validation-design.md
@@ -1,0 +1,169 @@
+# Shapefile Export Validation (Pre-Share Gate)
+
+## User Story
+
+As an Enumerator, I want the app to verify that my shapefiles are complete before allowing me to export and share them, so that I don't deliver a broken or rejected submission to the course coordinator.
+
+## Interpretation
+
+"Upload" in the original story maps to the **Export Shapefile → Share** action. The enumerator exports their collected data as a shapefile ZIP and shares it with the coordinator. Validation must run before the share sheet fires to prevent broken ZIPs from being delivered.
+
+## Out of Scope
+
+- Validating the geometric integrity of features inside the `.shp` file (topology, self-intersections)
+- Auto-generating missing `.prj` files (exporter always generates `.prj` from EPSG:32651)
+- `.prj` warning + checkbox (`.prj` can never be missing from the export)
+- Server-side re-validation
+
+---
+
+## Architecture
+
+A two-phase validation gate is inserted into the existing export pipeline:
+
+```
+HomeScreen tap
+      │
+      ▼
+ExportValidating          ← NEW state (spinner, no cancel)
+      │
+      ├─ fail ──► ExportValidationFailed(errors)   ← NEW state
+      │                 │
+      │           HomeScreen shows per-layer
+      │           error list below tile (persistent,
+      │           not a dismissable snackbar)
+      │           Auto-resets to ExportIdle.
+      │
+      ▼ pass
+ExportInProgress          (existing)
+      │
+      ▼
+[ShapefileExporter generates ZIP]
+      │
+      ▼
+Post-export sanity check  ← NEW step inside exporter
+      │
+      ├─ fail ──► ExportFailed("Something went wrong, please try again")
+      │
+      ▼ pass
+ExportDone → share sheet fires  (existing)
+```
+
+The existing download-side `ShapefileValidator` (7 rules, `lib/core/sync/shapefile/validation/`) is **not modified**.
+
+---
+
+## New Files
+
+| File | Purpose |
+|---|---|
+| `lib/core/sync/shapefile/export/shapefile_export_validator.dart` | DB validation logic — pure domain, no UI |
+| `lib/core/sync/shapefile/export/export_validation_result.dart` | Result model |
+
+## Modified Files
+
+| File | Change |
+|---|---|
+| `ShapefileExportNotifier` | Two new states; calls validator before export |
+| `ShapefileExporter` | Post-export sanity check on generated ZIP |
+| `HomeScreen` | Renders error list when in `ExportValidationFailed` |
+| `.arb` l10n files | New validation error message keys |
+
+---
+
+## Components
+
+### `ExportValidationResult`
+
+```dart
+class ExportValidationResult {
+  final bool isValid;
+  final List<ExportLayerError> errors;
+}
+
+class ExportLayerError {
+  final ExportLayer layer;       // enum: buildings, roads
+  final ExportLayerIssue issue;  // enum: emptyLayer, missingRequiredFields
+  final String message;          // plain-language, from l10n
+}
+```
+
+### `ShapefileExportValidator`
+
+Single public method:
+
+```dart
+Future<ExportValidationResult> validate(String assignmentId)
+```
+
+Two checks per layer type (buildings, roads):
+
+1. **Empty layer** — `COUNT(*) WHERE assignment_id = ? AND type = ?` → 0 = hard block
+2. **Missing required fields** — `COUNT(*) WHERE assignment_id = ? AND type = ? AND (feat_id IS NULL OR primary_attr IS NULL)` → any null = hard block
+
+`primary_attr` means `bldg_use` for buildings, `road_type` for roads. The validator maps `ExportLayer → required column` internally.
+
+### `ShapefileExportNotifier` — new states
+
+```
+ExportValidating
+ExportValidationFailed(List<ExportLayerError> errors)
+```
+
+Auto-reset to `ExportIdle` after `ExportValidationFailed`, matching the existing `ExportFailed` pattern.
+
+### Post-export sanity check (inside `ShapefileExporter`)
+
+After `ZipEncoder.encode()` returns, scan the in-memory archive:
+- Each expected layer must have `.shp`, `.shx`, `.dbf` entries present
+- Each entry must have `bytes.length > 0`
+- Failure throws `ExportSanityException` → caught by notifier → `ExportFailed`
+
+---
+
+## Error Messages (l10n)
+
+| Condition | Plain-language message |
+|---|---|
+| Buildings layer empty | "No buildings recorded. Survey at least one building before exporting." |
+| Roads layer empty | "No roads recorded. Survey at least one road before exporting." |
+| Buildings have incomplete forms | "Some building entries are missing required fields. Complete all building forms before exporting." |
+| Roads have incomplete forms | "Some road entries are missing required fields. Complete all road forms before exporting." |
+| Exporter sanity failure | "Export failed. Please try again." |
+
+All validation errors appear as a **persistent inline list below the Export Shapefile tile** — not a dismissable snackbar — so the enumerator can read all issues at once. The tile is greyed out while in `ExportValidationFailed`.
+
+---
+
+## Testing
+
+### `ShapefileExportValidator` unit tests (seeded Drift in-memory DB)
+
+- Buildings layer empty → `isValid: false`, `buildings/emptyLayer` error
+- Roads layer empty → `isValid: false`, `roads/emptyLayer` error
+- Both layers empty → `isValid: false`, two errors
+- Buildings with null `bldg_use` → `isValid: false`, `buildings/missingRequiredFields` error
+- Roads with null `road_type` → `isValid: false`, `roads/missingRequiredFields` error
+- All layers complete → `isValid: true`, no errors
+
+### `ShapefileExportNotifier` state machine tests (extend existing 6-test file)
+
+- Validation failure → state sequence: `Idle → Validating → ValidationFailed → Idle` (auto-reset)
+- Validation pass → proceeds to `ExportInProgress` (existing happy path unchanged)
+
+### `ShapefileExporter` sanity check tests (extend existing exporter tests)
+
+- Archive missing `.shx` entry → throws `ExportSanityException`
+- Archive with zero-byte `.dbf` → throws `ExportSanityException`
+- Valid archive → no exception
+
+---
+
+## Definition of Done
+
+- All acceptance criteria pass in QA
+- Validation logic has unit tests covering empty layers and missing required fields
+- State machine tests cover new `ExportValidating` and `ExportValidationFailed` states
+- Sanity check tests cover missing and zero-byte archive entries
+- Error messages reviewed for clarity
+- `flutter analyze` clean

--- a/docs/superpowers/specs/2026-05-02-shapefile-export-validation-design.md
+++ b/docs/superpowers/specs/2026-05-02-shapefile-export-validation-design.md
@@ -84,9 +84,10 @@ class ExportValidationResult {
 class ExportLayerError {
   final ExportLayer layer;       // enum: buildings, roads
   final ExportLayerIssue issue;  // enum: emptyLayer, missingRequiredFields
-  final String message;          // plain-language, from l10n
 }
 ```
+
+`ExportLayerError` carries only enums — no strings. The HomeScreen maps `(layer, issue)` pairs to localized strings, keeping `AppLocalizations` out of the core domain layer.
 
 ### `ShapefileExportValidator`
 

--- a/lib/core/i18n/app_en.arb
+++ b/lib/core/i18n/app_en.arb
@@ -406,5 +406,10 @@
   "exportShapefileExporting": "Packaging…",
   "exportErrorNoFeatures": "No completed features to export.",
   "exportErrorWriteFailed": "Export failed: could not write files. Please try again.",
-  "exportErrorShareFailed": "Export ready but could not open share sheet. Please try again."
+  "exportErrorShareFailed": "Export ready but could not open share sheet. Please try again.",
+  "exportValidating": "Validating…",
+  "exportValidationBuildingsEmpty": "No buildings recorded. Survey at least one building before exporting.",
+  "exportValidationRoadsEmpty": "No roads recorded. Survey at least one road before exporting.",
+  "exportValidationBuildingsMissingFields": "Some building entries are missing required fields. Complete all building forms before exporting.",
+  "exportValidationRoadsMissingFields": "Some road entries are missing required fields. Complete all road forms before exporting."
 }

--- a/lib/core/i18n/app_tl.arb
+++ b/lib/core/i18n/app_tl.arb
@@ -324,5 +324,10 @@
   "reshapeErrorZeroLengthEdge": "Adjacent corners cannot be on the same spot",
   "reshapeLockedSnackbar": "Assignment is closed; reshape unavailable",
   "reshapeLockWhileDirtyBanner": "Assignment was closed by supervisor — your edits cannot be saved",
-  "reshapeLockExit": "Exit"
+  "reshapeLockExit": "Exit",
+  "exportValidating": "Bine-validate…",
+  "exportValidationBuildingsEmpty": "Walang naitalagang gusali. Mag-survey ng kahit isang gusali bago mag-export.",
+  "exportValidationRoadsEmpty": "Walang naitalagang kalsada. Mag-survey ng kahit isang kalsada bago mag-export.",
+  "exportValidationBuildingsMissingFields": "May ilang gusali na may kulang na impormasyon. Kumpletuhin ang lahat ng form ng gusali bago mag-export.",
+  "exportValidationRoadsMissingFields": "May ilang kalsada na may kulang na impormasyon. Kumpletuhin ang lahat ng form ng kalsada bago mag-export."
 }

--- a/lib/core/sync/shapefile/export/export_validation_result.dart
+++ b/lib/core/sync/shapefile/export/export_validation_result.dart
@@ -1,15 +1,17 @@
-// lib/core/sync/shapefile/export/export_validation_result.dart
+import 'package:flutter/foundation.dart';
 
 enum ExportLayer { buildings, roads }
 
 enum ExportLayerIssue { emptyLayer, missingRequiredFields }
 
+@immutable
 class ExportLayerError {
   const ExportLayerError({required this.layer, required this.issue});
   final ExportLayer layer;
   final ExportLayerIssue issue;
 }
 
+@immutable
 class ExportValidationResult {
   const ExportValidationResult({required this.errors});
   final List<ExportLayerError> errors;

--- a/lib/core/sync/shapefile/export/export_validation_result.dart
+++ b/lib/core/sync/shapefile/export/export_validation_result.dart
@@ -1,0 +1,17 @@
+// lib/core/sync/shapefile/export/export_validation_result.dart
+
+enum ExportLayer { buildings, roads }
+
+enum ExportLayerIssue { emptyLayer, missingRequiredFields }
+
+class ExportLayerError {
+  const ExportLayerError({required this.layer, required this.issue});
+  final ExportLayer layer;
+  final ExportLayerIssue issue;
+}
+
+class ExportValidationResult {
+  const ExportValidationResult({required this.errors});
+  final List<ExportLayerError> errors;
+  bool get isValid => errors.isEmpty;
+}

--- a/lib/core/sync/shapefile/export/shapefile_export_validator.dart
+++ b/lib/core/sync/shapefile/export/shapefile_export_validator.dart
@@ -1,0 +1,95 @@
+import 'package:drift/drift.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_validation_result.dart';
+
+class ShapefileExportValidator {
+  const ShapefileExportValidator({required this.db});
+  final AppDatabase db;
+
+  Future<ExportValidationResult> validate(String assignmentId) async {
+    final errors = <ExportLayerError>[];
+
+    for (final layer in ExportLayer.values) {
+      final featureType =
+          layer == ExportLayer.buildings ? 'building' : 'road';
+
+      final totalComplete = await _countComplete(assignmentId, featureType);
+      if (totalComplete == 0) {
+        errors.add(
+          ExportLayerError(layer: layer, issue: ExportLayerIssue.emptyLayer),
+        );
+        continue;
+      }
+
+      final exportable =
+          await _countExportable(assignmentId, featureType, layer);
+      if (exportable < totalComplete) {
+        errors.add(
+          ExportLayerError(
+            layer: layer,
+            issue: ExportLayerIssue.missingRequiredFields,
+          ),
+        );
+      }
+    }
+
+    return ExportValidationResult(errors: errors);
+  }
+
+  Future<int> _countComplete(
+      String assignmentId, String featureType) async {
+    final rows = await (db.select(db.features)
+          ..where(
+            (f) =>
+                f.assignmentId.equals(assignmentId) &
+                f.featureType.equals(featureType) &
+                f.status.equals('complete'),
+          ))
+        .get();
+    return rows.length;
+  }
+
+  Future<int> _countExportable(
+    String assignmentId,
+    String featureType,
+    ExportLayer layer,
+  ) async {
+    if (layer == ExportLayer.buildings) {
+      return (await (db.select(db.features).join([
+        innerJoin(
+          db.submissions,
+          db.submissions.featureId.equalsExp(db.features.id),
+        ),
+        innerJoin(
+          db.buildingAttributes,
+          db.buildingAttributes.submissionId.equalsExp(db.submissions.id),
+        ),
+      ])
+                ..where(
+                  db.features.assignmentId.equals(assignmentId) &
+                      db.features.featureType.equals(featureType) &
+                      db.features.status.equals('complete'),
+                ))
+              .get())
+          .length;
+    } else {
+      return (await (db.select(db.features).join([
+        innerJoin(
+          db.submissions,
+          db.submissions.featureId.equalsExp(db.features.id),
+        ),
+        innerJoin(
+          db.roadAttributes,
+          db.roadAttributes.submissionId.equalsExp(db.submissions.id),
+        ),
+      ])
+                ..where(
+                  db.features.assignmentId.equals(assignmentId) &
+                      db.features.featureType.equals(featureType) &
+                      db.features.status.equals('complete'),
+                ))
+              .get())
+          .length;
+    }
+  }
+}

--- a/lib/core/sync/shapefile/export/shapefile_export_validator.dart
+++ b/lib/core/sync/shapefile/export/shapefile_export_validator.dart
@@ -37,16 +37,18 @@ class ShapefileExportValidator {
   }
 
   Future<int> _countComplete(
-      String assignmentId, String featureType) async {
-    final rows = await (db.select(db.features)
-          ..where(
-            (f) =>
-                f.assignmentId.equals(assignmentId) &
-                f.featureType.equals(featureType) &
-                f.status.equals('complete'),
-          ))
-        .get();
-    return rows.length;
+    String assignmentId,
+    String featureType,
+  ) async {
+    final countExpr = db.features.id.count();
+    final query = db.selectOnly(db.features)
+      ..addColumns([countExpr])
+      ..where(
+        db.features.assignmentId.equals(assignmentId) &
+            db.features.featureType.equals(featureType) &
+            db.features.status.equals('complete'),
+      );
+    return query.map((row) => row.read(countExpr)!).getSingle();
   }
 
   Future<int> _countExportable(
@@ -54,8 +56,10 @@ class ShapefileExportValidator {
     String featureType,
     ExportLayer layer,
   ) async {
+    final countExpr = db.features.id.count();
+
     if (layer == ExportLayer.buildings) {
-      return (await (db.select(db.features).join([
+      final query = db.selectOnly(db.features).join([
         innerJoin(
           db.submissions,
           db.submissions.featureId.equalsExp(db.features.id),
@@ -65,15 +69,15 @@ class ShapefileExportValidator {
           db.buildingAttributes.submissionId.equalsExp(db.submissions.id),
         ),
       ])
-                ..where(
-                  db.features.assignmentId.equals(assignmentId) &
-                      db.features.featureType.equals(featureType) &
-                      db.features.status.equals('complete'),
-                ))
-              .get())
-          .length;
+        ..addColumns([countExpr])
+        ..where(
+          db.features.assignmentId.equals(assignmentId) &
+              db.features.featureType.equals(featureType) &
+              db.features.status.equals('complete'),
+        );
+      return query.map((row) => row.read(countExpr)!).getSingle();
     } else {
-      return (await (db.select(db.features).join([
+      final query = db.selectOnly(db.features).join([
         innerJoin(
           db.submissions,
           db.submissions.featureId.equalsExp(db.features.id),
@@ -83,13 +87,13 @@ class ShapefileExportValidator {
           db.roadAttributes.submissionId.equalsExp(db.submissions.id),
         ),
       ])
-                ..where(
-                  db.features.assignmentId.equals(assignmentId) &
-                      db.features.featureType.equals(featureType) &
-                      db.features.status.equals('complete'),
-                ))
-              .get())
-          .length;
+        ..addColumns([countExpr])
+        ..where(
+          db.features.assignmentId.equals(assignmentId) &
+              db.features.featureType.equals(featureType) &
+              db.features.status.equals('complete'),
+        );
+      return query.map((row) => row.read(countExpr)!).getSingle();
     }
   }
 }

--- a/lib/core/sync/shapefile/export/shapefile_exporter.dart
+++ b/lib/core/sync/shapefile/export/shapefile_exporter.dart
@@ -395,6 +395,13 @@ class ShapefileExporter {
       return WriteError(e.toString());
     }
 
+    // Guard against exporter bugs producing empty file components.
+    for (final out in outputs) {
+      if (out.shp.isEmpty || out.shx.isEmpty || out.dbf.isEmpty) {
+        return WriteError('Layer ${out.layerName} produced empty components');
+      }
+    }
+
     // Build ZIP archive
     final archive = Archive();
     for (final out in outputs) {

--- a/lib/features/home/data/shapefile_export_notifier.dart
+++ b/lib/features/home/data/shapefile_export_notifier.dart
@@ -1,4 +1,5 @@
-// lib/features/home/data/shapefile_export_notifier.dart
+import 'package:firecheck/core/sync/shapefile/export/export_validation_result.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_export_validator.dart';
 import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_providers.dart';
 import 'package:firecheck/features/home/domain/export_state.dart';
@@ -10,17 +11,30 @@ class ShapefileExportNotifier extends StateNotifier<ExportState> {
   ShapefileExportNotifier({
     required String assignmentId,
     required ShapefileExporter exporter,
+    required ShapefileExportValidator validator,
   })  : _assignmentId = assignmentId,
         _exporter = exporter,
+        _validator = validator,
         super(const ExportIdle());
 
   final String _assignmentId;
   final ShapefileExporter _exporter;
+  final ShapefileExportValidator _validator;
 
   Future<void> export() async {
-    if (state is ExportExporting) return;
-    state = const ExportExporting();
+    if (state is ExportValidating || state is ExportExporting) return;
 
+    state = const ExportValidating();
+    final result = await _validator.validate(_assignmentId);
+
+    if (!mounted) return;
+    if (!result.isValid) {
+      state = ExportValidationFailed(result.errors);
+      state = const ExportIdle();
+      return;
+    }
+
+    state = const ExportExporting();
     final failure = await _exporter.export(assignmentId: _assignmentId);
 
     if (!mounted) return;
@@ -49,5 +63,6 @@ final shapefileExportNotifierProvider =
         await SharePlus.instance.share(ShareParams(files: [XFile(path)]));
       },
     ),
+    validator: ShapefileExportValidator(db: db),
   );
 });

--- a/lib/features/home/data/shapefile_export_notifier.dart
+++ b/lib/features/home/data/shapefile_export_notifier.dart
@@ -30,7 +30,6 @@ class ShapefileExportNotifier extends StateNotifier<ExportState> {
     if (!mounted) return;
     if (!result.isValid) {
       state = ExportValidationFailed(result.errors);
-      state = const ExportIdle();
       return;
     }
 

--- a/lib/features/home/domain/export_state.dart
+++ b/lib/features/home/domain/export_state.dart
@@ -1,5 +1,6 @@
 // lib/features/home/domain/export_state.dart
 import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_validation_result.dart';
 
 sealed class ExportState {
   const ExportState();
@@ -7,6 +8,15 @@ sealed class ExportState {
 
 class ExportIdle extends ExportState {
   const ExportIdle();
+}
+
+class ExportValidating extends ExportState {
+  const ExportValidating();
+}
+
+class ExportValidationFailed extends ExportState {
+  const ExportValidationFailed(this.errors);
+  final List<ExportLayerError> errors;
 }
 
 class ExportExporting extends ExportState {

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:firecheck/core/security/biometric_gate_provider.dart';
 import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_validation_result.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_lock_providers.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_lock_state.dart';
 import 'package:firecheck/features/assignment/presentation/submitted_banner.dart';
@@ -21,7 +22,8 @@ class HomeScreen extends ConsumerWidget {
     final lock = ref.watch(assignmentLockStateProvider).value;
     final isLocked = lock is Submitted || lock is ClosedRemotely;
     final exportState = ref.watch(shapefileExportNotifierProvider);
-    final isExporting = exportState is ExportExporting;
+    final isBusy =
+        exportState is ExportValidating || exportState is ExportExporting;
 
     ref.listen<ExportState>(shapefileExportNotifierProvider, (prev, next) {
       if (next is ExportFailed) {
@@ -108,29 +110,71 @@ class HomeScreen extends ConsumerWidget {
                   onTap: () => _onUploadDataTap(context, ref, l),
                 ),
               _ActionTile(
-                title: isExporting
-                    ? l.exportShapefileExporting
-                    : l.exportShapefile,
+                title: switch (exportState) {
+                  ExportValidating() => l.exportValidating,
+                  ExportExporting() => l.exportShapefileExporting,
+                  _ => l.exportShapefile,
+                },
                 subtitle: l.exportShapefileSubtitle,
-                trailing: isExporting
+                trailing: isBusy
                     ? const SizedBox(
                         width: 20,
                         height: 20,
                         child: CircularProgressIndicator(strokeWidth: 2),
                       )
                     : const Icon(Icons.chevron_right),
-                onTap: (snap.completedFeatures == 0 || isExporting)
+                onTap: (snap.completedFeatures == 0 || isBusy)
                     ? null
                     : () => ref
                         .read(shapefileExportNotifierProvider.notifier)
                         .export(),
               ),
+              if (exportState is ExportValidationFailed)
+                ...exportState.errors.map(
+                  (e) => Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 2,
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(
+                          Icons.error_outline,
+                          size: 14,
+                          color: Colors.red,
+                        ),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            _validationErrorMessage(l, e),
+                            style: const TextStyle(
+                              color: Colors.red,
+                              fontSize: 12,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
             ],
           ),
         ),
       ),
     );
   }
+
+  String _validationErrorMessage(AppLocalizations l, ExportLayerError e) =>
+      switch ((e.layer, e.issue)) {
+        (ExportLayer.buildings, ExportLayerIssue.emptyLayer) =>
+          l.exportValidationBuildingsEmpty,
+        (ExportLayer.roads, ExportLayerIssue.emptyLayer) =>
+          l.exportValidationRoadsEmpty,
+        (ExportLayer.buildings, ExportLayerIssue.missingRequiredFields) =>
+          l.exportValidationBuildingsMissingFields,
+        (ExportLayer.roads, ExportLayerIssue.missingRequiredFields) =>
+          l.exportValidationRoadsMissingFields,
+      };
 
   Future<void> _onUploadDataTap(
     BuildContext context,

--- a/lib/generated/l10n/app_localizations.dart
+++ b/lib/generated/l10n/app_localizations.dart
@@ -2119,6 +2119,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Export ready but could not open share sheet. Please try again.'**
   String get exportErrorShareFailed;
+
+  /// No description provided for @exportValidating.
+  ///
+  /// In en, this message translates to:
+  /// **'Validating…'**
+  String get exportValidating;
+
+  /// No description provided for @exportValidationBuildingsEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No buildings recorded. Survey at least one building before exporting.'**
+  String get exportValidationBuildingsEmpty;
+
+  /// No description provided for @exportValidationRoadsEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No roads recorded. Survey at least one road before exporting.'**
+  String get exportValidationRoadsEmpty;
+
+  /// No description provided for @exportValidationBuildingsMissingFields.
+  ///
+  /// In en, this message translates to:
+  /// **'Some building entries are missing required fields. Complete all building forms before exporting.'**
+  String get exportValidationBuildingsMissingFields;
+
+  /// No description provided for @exportValidationRoadsMissingFields.
+  ///
+  /// In en, this message translates to:
+  /// **'Some road entries are missing required fields. Complete all road forms before exporting.'**
+  String get exportValidationRoadsMissingFields;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/generated/l10n/app_localizations_en.dart
+++ b/lib/generated/l10n/app_localizations_en.dart
@@ -1112,4 +1112,23 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get exportErrorShareFailed =>
       'Export ready but could not open share sheet. Please try again.';
+
+  @override
+  String get exportValidating => 'Validating…';
+
+  @override
+  String get exportValidationBuildingsEmpty =>
+      'No buildings recorded. Survey at least one building before exporting.';
+
+  @override
+  String get exportValidationRoadsEmpty =>
+      'No roads recorded. Survey at least one road before exporting.';
+
+  @override
+  String get exportValidationBuildingsMissingFields =>
+      'Some building entries are missing required fields. Complete all building forms before exporting.';
+
+  @override
+  String get exportValidationRoadsMissingFields =>
+      'Some road entries are missing required fields. Complete all road forms before exporting.';
 }

--- a/lib/generated/l10n/app_localizations_tl.dart
+++ b/lib/generated/l10n/app_localizations_tl.dart
@@ -1138,4 +1138,23 @@ class AppLocalizationsTl extends AppLocalizations {
   @override
   String get exportErrorShareFailed =>
       'Export ready but could not open share sheet. Please try again.';
+
+  @override
+  String get exportValidating => 'Bine-validate…';
+
+  @override
+  String get exportValidationBuildingsEmpty =>
+      'Walang naitalagang gusali. Mag-survey ng kahit isang gusali bago mag-export.';
+
+  @override
+  String get exportValidationRoadsEmpty =>
+      'Walang naitalagang kalsada. Mag-survey ng kahit isang kalsada bago mag-export.';
+
+  @override
+  String get exportValidationBuildingsMissingFields =>
+      'May ilang gusali na may kulang na impormasyon. Kumpletuhin ang lahat ng form ng gusali bago mag-export.';
+
+  @override
+  String get exportValidationRoadsMissingFields =>
+      'May ilang kalsada na may kulang na impormasyon. Kumpletuhin ang lahat ng form ng kalsada bago mag-export.';
 }

--- a/test/core/sync/shapefile/export/shapefile_export_validator_test.dart
+++ b/test/core/sync/shapefile/export/shapefile_export_validator_test.dart
@@ -1,0 +1,219 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_validation_result.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_export_validator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> _seedBuilding(
+  AppDatabase db, {
+  required String assignmentId,
+  required String featureId,
+  required String submissionId,
+}) async {
+  final geoJson = jsonEncode({
+    'type': 'Polygon',
+    'coordinates': [
+      [
+        [120.0, 14.0], [121.0, 14.0], [121.0, 15.0],
+        [120.0, 15.0], [120.0, 14.0],
+      ],
+    ],
+  });
+  await db.into(db.features).insert(FeaturesCompanion.insert(
+    id: featureId,
+    assignmentId: assignmentId,
+    featureType: 'building',
+    geometryGeojson: geoJson,
+    status: const Value('complete'),
+    createdAt: DateTime.now(),
+  ));
+  await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+    id: submissionId,
+    featureId: featureId,
+    syncStatus: const Value('ready_to_upload'),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  ));
+  await db.into(db.buildingAttributes).insert(
+    BuildingAttributesCompanion.insert(
+      submissionId: submissionId,
+      fireFightingFacilitiesJson: const Value('[]'),
+      fireLoadJson: const Value('[]'),
+    ),
+  );
+}
+
+// Complete building feature WITHOUT a buildingAttributes row.
+// Simulates a feature that would be silently excluded by the exporter's inner join.
+Future<void> _seedOrphanBuilding(
+  AppDatabase db, {
+  required String assignmentId,
+  required String featureId,
+  required String submissionId,
+}) async {
+  final geoJson = jsonEncode({
+    'type': 'Polygon',
+    'coordinates': [
+      [
+        [120.0, 14.0], [121.0, 14.0], [121.0, 15.0],
+        [120.0, 15.0], [120.0, 14.0],
+      ],
+    ],
+  });
+  await db.into(db.features).insert(FeaturesCompanion.insert(
+    id: featureId,
+    assignmentId: assignmentId,
+    featureType: 'building',
+    geometryGeojson: geoJson,
+    status: const Value('complete'),
+    createdAt: DateTime.now(),
+  ));
+  await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+    id: submissionId,
+    featureId: featureId,
+    syncStatus: const Value('ready_to_upload'),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  ));
+  // Intentionally no buildingAttributes row
+}
+
+Future<void> _seedRoad(
+  AppDatabase db, {
+  required String assignmentId,
+  required String featureId,
+  required String submissionId,
+}) async {
+  final geoJson = jsonEncode({
+    'type': 'LineString',
+    'coordinates': [[120.0, 14.0], [121.0, 14.5]],
+  });
+  await db.into(db.features).insert(FeaturesCompanion.insert(
+    id: featureId,
+    assignmentId: assignmentId,
+    featureType: 'road',
+    geometryGeojson: geoJson,
+    status: const Value('complete'),
+    createdAt: DateTime.now(),
+  ));
+  await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+    id: submissionId,
+    featureId: featureId,
+    syncStatus: const Value('ready_to_upload'),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  ));
+  await db.into(db.roadAttributes).insert(
+    RoadAttributesCompanion.insert(
+      submissionId: submissionId,
+      roadFeaturesJson: const Value('[]'),
+    ),
+  );
+}
+
+// Complete road feature WITHOUT a roadAttributes row.
+Future<void> _seedOrphanRoad(
+  AppDatabase db, {
+  required String assignmentId,
+  required String featureId,
+  required String submissionId,
+}) async {
+  final geoJson = jsonEncode({
+    'type': 'LineString',
+    'coordinates': [[120.0, 14.0], [121.0, 14.5]],
+  });
+  await db.into(db.features).insert(FeaturesCompanion.insert(
+    id: featureId,
+    assignmentId: assignmentId,
+    featureType: 'road',
+    geometryGeojson: geoJson,
+    status: const Value('complete'),
+    createdAt: DateTime.now(),
+  ));
+  await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+    id: submissionId,
+    featureId: featureId,
+    syncStatus: const Value('ready_to_upload'),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  ));
+  // Intentionally no roadAttributes row
+}
+
+void main() {
+  late AppDatabase db;
+  setUp(() => db = AppDatabase.forTesting(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  ShapefileExportValidator makeValidator() =>
+      ShapefileExportValidator(db: db);
+
+  test('buildings layer empty → isValid false, buildings/emptyLayer error',
+      () async {
+    await _seedRoad(
+        db, assignmentId: 'a1', featureId: 'r1', submissionId: 'sr1');
+    final result = await makeValidator().validate('a1');
+    expect(result.isValid, isFalse);
+    expect(result.errors, hasLength(1));
+    expect(result.errors.first.layer, ExportLayer.buildings);
+    expect(result.errors.first.issue, ExportLayerIssue.emptyLayer);
+  });
+
+  test('roads layer empty → isValid false, roads/emptyLayer error', () async {
+    await _seedBuilding(
+        db, assignmentId: 'a1', featureId: 'b1', submissionId: 'sb1');
+    final result = await makeValidator().validate('a1');
+    expect(result.isValid, isFalse);
+    expect(result.errors, hasLength(1));
+    expect(result.errors.first.layer, ExportLayer.roads);
+    expect(result.errors.first.issue, ExportLayerIssue.emptyLayer);
+  });
+
+  test('both layers empty → isValid false, two emptyLayer errors', () async {
+    final result = await makeValidator().validate('a1');
+    expect(result.isValid, isFalse);
+    expect(result.errors, hasLength(2));
+    expect(
+      result.errors.map((e) => e.issue),
+      everyElement(ExportLayerIssue.emptyLayer),
+    );
+  });
+
+  test('building orphan → isValid false, buildings/missingRequiredFields',
+      () async {
+    await _seedOrphanBuilding(
+        db, assignmentId: 'a1', featureId: 'b1', submissionId: 'sb1');
+    await _seedRoad(
+        db, assignmentId: 'a1', featureId: 'r1', submissionId: 'sr1');
+    final result = await makeValidator().validate('a1');
+    expect(result.isValid, isFalse);
+    expect(result.errors, hasLength(1));
+    expect(result.errors.first.layer, ExportLayer.buildings);
+    expect(result.errors.first.issue, ExportLayerIssue.missingRequiredFields);
+  });
+
+  test('road orphan → isValid false, roads/missingRequiredFields', () async {
+    await _seedBuilding(
+        db, assignmentId: 'a1', featureId: 'b1', submissionId: 'sb1');
+    await _seedOrphanRoad(
+        db, assignmentId: 'a1', featureId: 'r1', submissionId: 'sr1');
+    final result = await makeValidator().validate('a1');
+    expect(result.isValid, isFalse);
+    expect(result.errors, hasLength(1));
+    expect(result.errors.first.layer, ExportLayer.roads);
+    expect(result.errors.first.issue, ExportLayerIssue.missingRequiredFields);
+  });
+
+  test('all layers complete and valid → isValid true, no errors', () async {
+    await _seedBuilding(
+        db, assignmentId: 'a1', featureId: 'b1', submissionId: 'sb1');
+    await _seedRoad(
+        db, assignmentId: 'a1', featureId: 'r1', submissionId: 'sr1');
+    final result = await makeValidator().validate('a1');
+    expect(result.isValid, isTrue);
+    expect(result.errors, isEmpty);
+  });
+}

--- a/test/core/sync/shapefile/export/shapefile_exporter_test.dart
+++ b/test/core/sync/shapefile/export/shapefile_exporter_test.dart
@@ -159,6 +159,35 @@ void main() {
     expect(failure, isA<NoCompletedFeatures>());
   });
 
+  test('exported archive entries are non-empty for all required layer files',
+      () async {
+    const assignmentId = 'sanity-check-001';
+    await _seedBuilding(db,
+        assignmentId: assignmentId, featureId: 'b1', submissionId: 'sb1');
+    await _seedRoad(db,
+        assignmentId: assignmentId, featureId: 'r1', submissionId: 'sr1');
+
+    final capturedPaths = <String>[];
+    await makeExporter(capturedPaths: capturedPaths)
+        .export(assignmentId: assignmentId);
+
+    final zipBytes = await File(capturedPaths.first).readAsBytes();
+    final archive = ZipDecoder().decodeBytes(zipBytes);
+
+    for (final ext in ['.shp', '.shx', '.dbf']) {
+      expect(
+        archive.files.firstWhere((f) => f.name == 'buildings$ext').size,
+        greaterThan(0),
+        reason: 'buildings$ext must not be empty',
+      );
+      expect(
+        archive.files.firstWhere((f) => f.name == 'roads$ext').size,
+        greaterThan(0),
+        reason: 'roads$ext must not be empty',
+      );
+    }
+  });
+
   test('doesNotExist building is included in ZIP output', () async {
     const assignmentId = 'assignment-004';
     await _seedBuilding(

--- a/test/features/home/shapefile_export_notifier_test.dart
+++ b/test/features/home/shapefile_export_notifier_test.dart
@@ -121,7 +121,7 @@ void main() {
     expect(notifier.state, isA<ExportIdle>());
   });
 
-  test('empty DB → Validating then ValidationFailed then Idle', () async {
+  test('empty DB → Validating then ValidationFailed (persistent)', () async {
     final notifier = makeNotifier(assignmentId: 'a1', db: db);
     final states = <ExportState>[];
     notifier.addListener(states.add, fireImmediately: false);
@@ -131,7 +131,6 @@ void main() {
     expect(states, [
       isA<ExportValidating>(),
       isA<ExportValidationFailed>(),
-      isA<ExportIdle>(),
     ]);
     expect((states[1] as ExportValidationFailed).errors, isNotEmpty);
   });
@@ -148,10 +147,11 @@ void main() {
     expect(states.whereType<ExportValidating>(), hasLength(1));
   });
 
-  test('after ValidationFailed, notifier resets to Idle', () async {
+  test('after ValidationFailed, state stays ValidationFailed until re-export',
+      () async {
     final notifier = makeNotifier(assignmentId: 'a1', db: db);
     await notifier.export();
-    expect(notifier.state, isA<ExportIdle>());
+    expect(notifier.state, isA<ExportValidationFailed>());
   });
 
   test('validation pass → Validating then Exporting then Done then Idle',

--- a/test/features/home/shapefile_export_notifier_test.dart
+++ b/test/features/home/shapefile_export_notifier_test.dart
@@ -1,11 +1,10 @@
-// test/features/home/shapefile_export_notifier_test.dart
 import 'dart:convert';
 import 'dart:io';
 
 import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:firecheck/core/db/database.dart';
-import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_export_validator.dart';
 import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
 import 'package:firecheck/features/home/data/shapefile_export_notifier.dart';
 import 'package:firecheck/features/home/domain/export_state.dart';
@@ -21,11 +20,11 @@ Future<void> _seedBuilding(
     'type': 'Polygon',
     'coordinates': [
       [
-        [120.0, 14.0], [121.0, 14.0], [121.0, 15.0], [120.0, 15.0], [120.0, 14.0],
-      ]
+        [120.0, 14.0], [121.0, 14.0], [121.0, 15.0],
+        [120.0, 15.0], [120.0, 14.0],
+      ],
     ],
   });
-
   await db.into(db.features).insert(FeaturesCompanion.insert(
     id: featureId,
     assignmentId: assignmentId,
@@ -34,54 +33,87 @@ Future<void> _seedBuilding(
     isNew: const Value(false),
     status: const Value('complete'),
     createdAt: DateTime.now(),
-  ),);
-
+  ));
   await db.into(db.submissions).insert(SubmissionsCompanion.insert(
     id: submissionId,
     featureId: featureId,
     syncStatus: const Value('ready_to_upload'),
     createdAt: DateTime.now(),
     updatedAt: DateTime.now(),
-  ),);
+  ));
+  await db.into(db.buildingAttributes).insert(
+    BuildingAttributesCompanion.insert(
+      submissionId: submissionId,
+      cbmsId: const Value('C001'),
+      buildingName: const Value('Test Hall'),
+      ra9514Type: const Value('Group E'),
+      storeys: const Value(3),
+      material: const Value('Concrete'),
+      costAmount: const Value(500000),
+      fireFightingFacilitiesJson: const Value('["sprinkler","extinguisher"]'),
+      fireLoadJson: const Value('["paper","chemicals"]'),
+    ),
+  );
+}
 
-  await db.into(db.buildingAttributes).insert(BuildingAttributesCompanion.insert(
-    submissionId: submissionId,
-    cbmsId: const Value('C001'),
-    buildingName: const Value('Test Hall'),
-    ra9514Type: const Value('Group E'),
-    storeys: const Value(3),
-    material: const Value('Concrete'),
-    costAmount: const Value(500000),
-    fireFightingFacilitiesJson: const Value('["sprinkler","extinguisher"]'),
-    fireLoadJson: const Value('["paper","chemicals"]'),
-  ),);
+Future<void> _seedRoad(
+  AppDatabase db, {
+  required String assignmentId,
+  required String featureId,
+  required String submissionId,
+}) async {
+  final geoJson = jsonEncode({
+    'type': 'LineString',
+    'coordinates': [[120.0, 14.0], [121.0, 14.5]],
+  });
+  await db.into(db.features).insert(FeaturesCompanion.insert(
+    id: featureId,
+    assignmentId: assignmentId,
+    featureType: 'road',
+    geometryGeojson: geoJson,
+    isNew: const Value(false),
+    status: const Value('complete'),
+    createdAt: DateTime.now(),
+  ));
+  await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+    id: submissionId,
+    featureId: featureId,
+    syncStatus: const Value('ready_to_upload'),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  ));
+  await db.into(db.roadAttributes).insert(
+    RoadAttributesCompanion.insert(
+      submissionId: submissionId,
+      roadName: const Value('Main St'),
+      widthMeters: const Value(8),
+      roadFeaturesJson: const Value('["Pedestrian"]'),
+    ),
+  );
 }
 
 ShapefileExportNotifier makeNotifier({
   required String assignmentId,
   required AppDatabase db,
   List<String>? capturedPaths,
+  ShapefileExportValidator? validator,
 }) {
   final exporter = ShapefileExporter(
     db: db,
-    shareFile: (path) async {
-      capturedPaths?.add(path);
-    },
+    shareFile: (path) async { capturedPaths?.add(path); },
     tempDirOverride: Directory.systemTemp.createTempSync('notifier_test_'),
   );
   return ShapefileExportNotifier(
     assignmentId: assignmentId,
     exporter: exporter,
+    validator: validator ?? ShapefileExportValidator(db: db),
   );
 }
 
 void main() {
   late AppDatabase db;
 
-  setUp(() {
-    db = AppDatabase.forTesting(NativeDatabase.memory());
-  });
-
+  setUp(() => db = AppDatabase.forTesting(NativeDatabase.memory()));
   tearDown(() => db.close());
 
   test('initial state is ExportIdle', () {
@@ -89,7 +121,7 @@ void main() {
     expect(notifier.state, isA<ExportIdle>());
   });
 
-  test('export with no features transitions Exporting then Failed', () async {
+  test('empty DB → Validating then ValidationFailed then Idle', () async {
     final notifier = makeNotifier(assignmentId: 'a1', db: db);
     final states = <ExportState>[];
     notifier.addListener(states.add, fireImmediately: false);
@@ -97,53 +129,59 @@ void main() {
     await notifier.export();
 
     expect(states, [
-      isA<ExportExporting>(),
-      isA<ExportFailed>(),
+      isA<ExportValidating>(),
+      isA<ExportValidationFailed>(),
       isA<ExportIdle>(),
     ]);
-    expect((states[1] as ExportFailed).failure, isA<NoCompletedFeatures>());
+    expect((states[1] as ExportValidationFailed).errors, isNotEmpty);
   });
 
-  test('tapping export while Exporting is a no-op', () async {
+  test('tapping export while Validating or Exporting is a no-op', () async {
     final notifier = makeNotifier(assignmentId: 'a1', db: db);
     final states = <ExportState>[];
     notifier.addListener(states.add, fireImmediately: false);
 
     final first = notifier.export();
     final second = notifier.export();
-
     await Future.wait([first, second]);
 
-    expect(states.whereType<ExportExporting>(), hasLength(1));
+    expect(states.whereType<ExportValidating>(), hasLength(1));
   });
 
-  test('after Failed state, notifier resets to Idle', () async {
+  test('after ValidationFailed, notifier resets to Idle', () async {
     final notifier = makeNotifier(assignmentId: 'a1', db: db);
     await notifier.export();
     expect(notifier.state, isA<ExportIdle>());
   });
 
-  test('successful export → Exporting then Done then Idle', () async {
+  test('validation pass → Validating then Exporting then Done then Idle',
+      () async {
     const assignmentId = 'a-success';
-    await _seedBuilding(db, assignmentId: assignmentId, featureId: 'f1', submissionId: 's1');
+    await _seedBuilding(
+        db, assignmentId: assignmentId, featureId: 'b1', submissionId: 'sb1');
+    await _seedRoad(
+        db, assignmentId: assignmentId, featureId: 'r1', submissionId: 'sr1');
 
-    final capturedPaths = <String>[];
-    final notifier = makeNotifier(
-      assignmentId: assignmentId,
-      db: db,
-      capturedPaths: capturedPaths,
-    );
+    final notifier = makeNotifier(assignmentId: assignmentId, db: db);
     final states = <ExportState>[];
     notifier.addListener(states.add, fireImmediately: false);
 
     await notifier.export();
 
-    expect(states, [isA<ExportExporting>(), isA<ExportDone>(), isA<ExportIdle>()]);
+    expect(states, [
+      isA<ExportValidating>(),
+      isA<ExportExporting>(),
+      isA<ExportDone>(),
+      isA<ExportIdle>(),
+    ]);
   });
 
   test('after successful export, notifier resets to Idle', () async {
     const assignmentId = 'a-success-2';
-    await _seedBuilding(db, assignmentId: assignmentId, featureId: 'f1', submissionId: 's1');
+    await _seedBuilding(
+        db, assignmentId: assignmentId, featureId: 'b1', submissionId: 'sb1');
+    await _seedRoad(
+        db, assignmentId: assignmentId, featureId: 'r1', submissionId: 'sr1');
 
     final notifier = makeNotifier(assignmentId: assignmentId, db: db);
     await notifier.export();

--- a/test/features/map/map_screen_reshape_test.dart
+++ b/test/features/map/map_screen_reshape_test.dart
@@ -299,25 +299,29 @@ void main() {
       final db = AppDatabase.forTesting(NativeDatabase.memory());
       addTearDown(db.close);
       // Persist the feature so saveReshape's UPDATE finds a row.
+      // runAsync lets the NativeDatabase background isolate complete its writes
+      // outside the fakeAsync zone (avoids pumpAndSettle livelock in full suite).
       final feature = fakeFeature();
-      await db.into(db.assignments).insert(
-            AssignmentsCompanion.insert(
-              id: 'a1',
-              enumeratorId: 'admin',
-              campaignId: 'c1',
-              boundaryPolygonGeojson: fakeAssignment().boundaryPolygonGeojson,
-              createdAt: DateTime.now(),
-            ),
-          );
-      await db.into(db.features).insert(
-            FeaturesCompanion.insert(
-              id: feature.id,
-              assignmentId: feature.assignmentId,
-              featureType: feature.featureType,
-              geometryGeojson: feature.geometryGeojson,
-              createdAt: feature.createdAt,
-            ),
-          );
+      await tester.runAsync(() async {
+        await db.into(db.assignments).insert(
+              AssignmentsCompanion.insert(
+                id: 'a1',
+                enumeratorId: 'admin',
+                campaignId: 'c1',
+                boundaryPolygonGeojson: fakeAssignment().boundaryPolygonGeojson,
+                createdAt: DateTime.now(),
+              ),
+            );
+        await db.into(db.features).insert(
+              FeaturesCompanion.insert(
+                id: feature.id,
+                assignmentId: feature.assignmentId,
+                featureType: feature.featureType,
+                geometryGeojson: feature.geometryGeojson,
+                createdAt: feature.createdAt,
+              ),
+            );
+      });
 
       final fake = FakeMapRenderer();
       final container = await pumpMap(
@@ -329,9 +333,13 @@ void main() {
       );
 
       await fake.simulatePolygonLongPress(feature);
-      await tester.pumpAndSettle();
+      // NativeDatabase background isolate makes pumpAndSettle hang when other
+      // tests have left isolates active. Use explicit frame pumps instead.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
       await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
-      await tester.pumpAndSettle();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
 
       // Drive the controller into a dirty state by performing a small valid
       // move directly (avoids dependency on overlay layout):
@@ -343,11 +351,12 @@ void main() {
       await tester.pump();
 
       await tester.tap(find.byKey(const Key('reshape.banner.save')));
-      // Drift's NativeDatabase does real async I/O; pumpAndSettle in FakeAsync
-      // hangs on the post-save rebuild. Pump a handful of frames instead.
-      for (var i = 0; i < 20; i++) {
-        await tester.pump(const Duration(milliseconds: 20));
-      }
+      // Let the NativeDatabase transaction complete in real time, then pump UI.
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 300)),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
 
       // Mode is inactive in the controller.
       expect(container.read(reshapeModeControllerProvider).isActive, isFalse);
@@ -355,13 +364,17 @@ void main() {
       expect(find.byKey(const Key('reshape.banner.save')), findsNothing);
 
       // Revision + sync_job persisted.
-      final revisions = await db.select(db.featureGeometryRevisions).get();
+      final revisions = await tester.runAsync(
+        () => db.select(db.featureGeometryRevisions).get(),
+      );
       expect(revisions, hasLength(1));
-      expect(revisions.first.featureId, feature.id);
+      expect(revisions!.first.featureId, feature.id);
       expect(revisions.first.syncStatus, 'ready_to_upload');
-      final jobs = await db.select(db.syncJobs).get();
+      final jobs = await tester.runAsync(
+        () => db.select(db.syncJobs).get(),
+      );
       expect(jobs, hasLength(1));
-      expect(jobs.first.entityType, 'feature_geometry_update');
+      expect(jobs!.first.entityType, 'feature_geometry_update');
       expect(jobs.first.entityId, revisions.first.id);
     });
 
@@ -383,15 +396,18 @@ void main() {
       await tester.tap(find.byKey(const Key('reshape.actionsheet.reshape')));
       await tester.pumpAndSettle();
 
-      // Drive into a transverse bowtie. Starting from a 4-vertex CCW square,
-      // swap two diagonally-opposite corners.
+      // Drive into a bowtie by swapping the middle two vertices (indices 1 and 2).
+      // Original ring: [SW, SE, NE, NW]. After swap: [SW, NE, SE, NW].
+      // Edges SW→NE and SE→NW are the two diagonals of the rectangle and cross
+      // at its centre — that is the self-intersection.
+      // (Swapping indices 0 and 2 only reverses the winding — no crossing.)
       final n = container.read(reshapeModeControllerProvider.notifier);
       final ring = container.read(reshapeModeControllerProvider).workingRings[0];
-      final c0 = ring[0];
+      final c1 = ring[1];
       final c2 = ring[2];
       n
-        ..moveVertex(0, 0, c2) // 0 -> 2
-        ..moveVertex(0, 2, c0); // 2 -> 0 — produces a bowtie
+        ..moveVertex(0, 1, c2) // vertex 1 (SE) → NE position
+        ..moveVertex(0, 2, c1); // vertex 2 (NE) → SE position — diagonals cross
       await tester.pump();
 
       await tester.tap(find.byKey(const Key('reshape.banner.save')));


### PR DESCRIPTION
## Summary

- Adds a two-phase validation gate before the Export Shapefile share sheet fires
- **Phase 1 (DB):** Checks both layers have ≥1 complete feature and no orphaned attributes (missing `bldg_use`/`road_type`) — shows a persistent inline error list below the tile on failure
- **Phase 2 (archive):** Post-export sanity check inside `ShapefileExporter` — each layer's `.shp`/`.shx`/`.dbf` entries must be non-empty, otherwise throws `WriteError`
- Fixed pre-existing test failures: T21 NativeDatabase livelock (`pumpAndSettle` hangs in full suite) and T21 bowtie vertex-swap logic bug
- Fixed `ExportValidationFailed` being silently swallowed by an immediate synchronous reset to `ExportIdle`

## New states

```
ExportIdle → ExportValidating → ExportValidationFailed  (persistent, errors shown inline)
                              ↘ ExportExporting → ExportDone → ExportIdle
```

## Test plan

- [ ] Tap Export Shapefile with no complete features → spinner → inline error list appears and stays visible
- [ ] Error list shows the correct per-layer message(s) for empty layer / missing fields
- [ ] Tap Export Shapefile again after seeing errors → re-validates (spinner reappears)
- [ ] With ≥1 complete building + ≥1 complete road → validation passes → share sheet fires
- [ ] `flutter test` — 538 pass, 0 fail
- [ ] `flutter analyze` — 0 errors, 0 warnings

## Known limitation

Road features (LineString) are not yet rendered on the map — tracked in #26. The export validation correctly blocks when no roads are complete; roads cannot be surveyed until #26 is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)