### PR TITLE
feat(upload): bulk upload photos and shapefiles to Drive on Wi-Fi (US-29)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ app.*.map.json
 # Superpowers brainstorm cache (local mockups + server state)
 .superpowers/
 
+# Git worktrees
+.worktrees/
+
 # Claude Code local settings + scheduler state
 .claude/settings.local.json
 .claude/scheduled_tasks.lock

--- a/docs/superpowers/plans/2026-05-02-drive-bulk-upload.md
+++ b/docs/superpowers/plans/2026-05-02-drive-bulk-upload.md
@@ -1,0 +1,2678 @@
+# Drive Bulk Upload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a Google Drive bulk upload pipeline so enumerators can push completed photos and shapefiles to a shared organizational Drive folder when on Wi-Fi.
+
+**Architecture:** A new `DriveUploadJobs` Drift table (DB v8) acts as the persistent upload queue. `EnqueueAssignmentUseCase` generates shapefile ZIPs and populates the queue. `DriveUploadWorker` processes jobs (mirrors `SyncWorker`). `DriveUploadController` gates uploads to Wi-Fi only. UI = home banner + `UploadQueueScreen`.
+
+**Tech Stack:** Drift ^2.18, googleapis ^13, google_sign_in ^6, connectivity_plus ^5, workmanager ^0.9, flutter_secure_storage ^9, flutter_riverpod ^2.5
+
+---
+
+## File Map
+
+**New files:**
+- `lib/core/db/tables/drive_upload_jobs.dart`
+- `lib/core/drive/drive_upload_job_status.dart`
+- `lib/core/drive/drive_upload_repository.dart`
+- `lib/core/drive/drive_upload_api.dart`
+- `lib/core/drive/fake_drive_upload_api.dart`
+- `lib/core/drive/google_drive_upload_api.dart`
+- `lib/core/drive/drive_upload_preferences.dart`
+- `lib/core/drive/drive_upload_worker.dart`
+- `lib/core/drive/drive_upload_controller.dart`
+- `lib/core/drive/drive_upload_workmanager.dart`
+- `lib/core/drive/enqueue_assignment_use_case.dart`
+- `lib/core/drive/drive_upload_providers.dart`
+- `lib/features/upload/presentation/upload_banner.dart`
+- `lib/features/upload/presentation/upload_queue_notifier.dart`
+- `lib/features/upload/presentation/upload_queue_screen.dart`
+
+**Modified files:**
+- `lib/core/db/database.dart` — add DriveUploadJobs + v8 migration
+- `lib/core/sync/shapefile/export/shapefile_exporter.dart` — add `exportToFile()`
+- `lib/features/auth/data/google_auth_repository.dart` — add drive.file scope request
+- `lib/core/router/app_router.dart` — add `/uploads` route
+- `lib/features/home/presentation/home_screen.dart` — add upload banner
+
+---
+
+## Task 1: DriveUploadJobs Drift table + DB v8 migration
+
+**Files:**
+- Create: `lib/core/db/tables/drive_upload_jobs.dart`
+- Modify: `lib/core/db/database.dart`
+- Test: `test/core/db/drive_upload_jobs_table_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/core/db/drive_upload_jobs_table_test.dart
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('drive_upload_jobs table is accessible and accepts inserts', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    expect(db.driveUploadJobs, isNotNull);
+
+    final id = await db.into(db.driveUploadJobs).insertReturning(
+          DriveUploadJobsCompanion.insert(
+            id: '1',
+            assignmentId: 'a-001',
+            filePath: '/photos/p1.jpg',
+            fileType: 'photo',
+            fileName: 'p1.jpg',
+            fileSizeBytes: 1024,
+            capturedAt: DateTime(2026, 5, 2),
+            createdAt: DateTime(2026, 5, 2),
+          ),
+        );
+
+    expect(id.status, 'pending');
+    expect(id.retryCount, 0);
+    expect(id.resumableUri, isNull);
+  });
+}
+```
+
+- [ ] **Step 2: Run test — expect compile error (DriveUploadJobs not defined)**
+
+```bash
+flutter test test/core/db/drive_upload_jobs_table_test.dart
+```
+
+Expected: compile error — `DriveUploadJobs` not found.
+
+- [ ] **Step 3: Create the Drift table**
+
+```dart
+// lib/core/db/tables/drive_upload_jobs.dart
+import 'package:drift/drift.dart';
+
+@TableIndex(name: 'drive_upload_jobs_status_idx', columns: {#status, #nextRetryAt})
+@TableIndex(name: 'drive_upload_jobs_assignment_idx', columns: {#assignmentId})
+class DriveUploadJobs extends Table {
+  TextColumn get id => text()();
+  TextColumn get assignmentId => text()();
+  TextColumn get filePath => text()();
+  TextColumn get fileType => text()(); // 'photo' | 'shapefile'
+  TextColumn get fileName => text()();
+  IntColumn get fileSizeBytes => integer()();
+  DateTimeColumn get capturedAt => dateTime()();
+  TextColumn get status =>
+      text().withDefault(const Constant('pending'))(); // pending|uploading|completed|failed|dead
+  TextColumn get resumableUri => text().nullable()();
+  TextColumn get driveFileId => text().nullable()();
+  IntColumn get retryCount => integer().withDefault(const Constant(0))();
+  TextColumn get failureReason => text().nullable()();
+  DateTimeColumn get nextRetryAt => dateTime().nullable()();
+  DateTimeColumn get createdAt => dateTime()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+```
+
+- [ ] **Step 4: Add table to AppDatabase and write v8 migration**
+
+In `lib/core/db/database.dart`, add the import and update in two places:
+
+```dart
+// Add import at top:
+import 'package:firecheck/core/db/tables/drive_upload_jobs.dart';
+
+// Update @DriftDatabase tables list — add DriveUploadJobs:
+@DriftDatabase(
+  tables: [
+    Enumerators,
+    Assignments,
+    Features,
+    FeatureGeometryRevisions,
+    Submissions,
+    BuildingAttributes,
+    RoadAttributes,
+    HouseholdSurveys,
+    Photos,
+    Ra9514Types,
+    SyncJobs,
+    OfflineTilePacks,
+    DriveUploadJobs,   // ← new
+  ],
+)
+
+// Update schemaVersion:
+@override
+int get schemaVersion => 8;   // was 7
+
+// Add v8 migration inside onUpgrade — after the existing `if (from < 7)` block:
+if (from < 8) {
+  await m.createTable(driveUploadJobs);
+  await m.createIndex(driveUploadJobsStatusIdx);
+  await m.createIndex(driveUploadJobsAssignmentIdx);
+}
+```
+
+- [ ] **Step 5: Run build_runner to regenerate database.g.dart**
+
+```bash
+dart run build_runner build --delete-conflicting-outputs
+```
+
+Expected: `database.g.dart` updated with no errors.
+
+- [ ] **Step 6: Run test — expect PASS**
+
+```bash
+flutter test test/core/db/drive_upload_jobs_table_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run full test suite — expect no regressions**
+
+```bash
+flutter test
+```
+
+Expected: all existing tests still pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/core/db/tables/drive_upload_jobs.dart lib/core/db/database.dart lib/core/db/database.g.dart test/core/db/drive_upload_jobs_table_test.dart
+git commit -m "feat(db): add DriveUploadJobs table and v8 migration"
+```
+
+---
+
+## Task 2: DriveUploadJobStatus + DriveUploadRepository
+
+**Files:**
+- Create: `lib/core/drive/drive_upload_job_status.dart`
+- Create: `lib/core/drive/drive_upload_repository.dart`
+- Test: `test/core/drive/drive_upload_repository_test.dart`
+
+- [ ] **Step 1: Create status constants**
+
+```dart
+// lib/core/drive/drive_upload_job_status.dart
+class DriveUploadJobStatus {
+  DriveUploadJobStatus._();
+
+  static const pending = 'pending';
+  static const uploading = 'uploading';
+  static const completed = 'completed';
+  static const failed = 'failed';
+  static const dead = 'dead';
+
+  static const typePhoto = 'photo';
+  static const typeShapefile = 'shapefile';
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+```dart
+// test/core/drive/drive_upload_repository_test.dart
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+AppDatabase _db() => AppDatabase.forTesting(NativeDatabase.memory());
+
+void main() {
+  group('DriveUploadRepository', () {
+    test('insertJob creates a pending job', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(
+        id: 'j1',
+        assignmentId: 'a1',
+        filePath: '/photos/p1.jpg',
+        fileType: DriveUploadJobStatus.typePhoto,
+        fileName: 'p1.jpg',
+        fileSizeBytes: 1024,
+        capturedAt: DateTime(2026, 5, 2),
+      );
+
+      final jobs = await repo.getPendingJobs();
+      expect(jobs.length, 1);
+      expect(jobs.first.status, DriveUploadJobStatus.pending);
+    });
+
+    test('getPendingJobs excludes completed and future-retry jobs', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+      await repo.insertJob(id: 'j2', assignmentId: 'a1', filePath: '/p2.jpg',
+          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p2.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+
+      await repo.markCompleted('j1', driveFileId: 'drive-1');
+      await repo.markFailed('j2',
+          reason: 'network', retryCount: 1,
+          nextRetryAt: DateTime.now().add(const Duration(hours: 1)));
+
+      final jobs = await repo.getPendingJobs();
+      expect(jobs, isEmpty);
+    });
+
+    test('getPendingJobs includes failed jobs whose retry time has passed', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+      await repo.markFailed('j1',
+          reason: 'err', retryCount: 1,
+          nextRetryAt: DateTime.now().subtract(const Duration(seconds: 1)));
+
+      final jobs = await repo.getPendingJobs();
+      expect(jobs.length, 1);
+    });
+
+    test('markDead sets status=dead and failureReason', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+      await repo.markDead('j1', reason: 'file missing');
+
+      final all = await db.select(db.driveUploadJobs).get();
+      expect(all.first.status, DriveUploadJobStatus.dead);
+      expect(all.first.failureReason, 'file missing');
+    });
+
+    test('resetForRetry resets retryCount and status to pending', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+      await repo.markDead('j1', reason: 'err');
+      await repo.resetForRetry('j1');
+
+      final all = await db.select(db.driveUploadJobs).get();
+      expect(all.first.status, DriveUploadJobStatus.pending);
+      expect(all.first.retryCount, 0);
+      expect(all.first.failureReason, isNull);
+    });
+
+    test('resetFailedToPending resets failed jobs only, not dead', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+      await repo.insertJob(id: 'j2', assignmentId: 'a1', filePath: '/p2.jpg',
+          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p2.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+
+      await repo.markFailed('j1', reason: 'net', retryCount: 1,
+          nextRetryAt: DateTime.now().add(const Duration(hours: 1)));
+      await repo.markDead('j2', reason: 'perma');
+
+      await repo.resetFailedToPending();
+
+      final all = await db.select(db.driveUploadJobs).get();
+      final j1 = all.firstWhere((j) => j.id == 'j1');
+      final j2 = all.firstWhere((j) => j.id == 'j2');
+      expect(j1.status, DriveUploadJobStatus.pending);
+      expect(j2.status, DriveUploadJobStatus.dead); // unchanged
+    });
+
+    test('jobExistsForFilePath returns true when non-completed job exists', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+
+      expect(await repo.jobExistsForFilePath('/p1.jpg'), isTrue);
+      expect(await repo.jobExistsForFilePath('/other.jpg'), isFalse);
+    });
+
+    test('shapefileJobExistsForAssignment returns false when only completed', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/a1.zip',
+          fileType: DriveUploadJobStatus.typeShapefile, fileName: 'a1.zip',
+          fileSizeBytes: 1000, capturedAt: DateTime(2026));
+      await repo.markCompleted('j1', driveFileId: 'drive-1');
+
+      expect(await repo.shapefileJobExistsForAssignment('a1'), isFalse);
+    });
+  });
+}
+```
+
+- [ ] **Step 3: Run test — expect compile error (DriveUploadRepository not found)**
+
+```bash
+flutter test test/core/drive/drive_upload_repository_test.dart
+```
+
+- [ ] **Step 4: Implement DriveUploadRepository**
+
+```dart
+// lib/core/drive/drive_upload_repository.dart
+import 'package:drift/drift.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+
+class DriveUploadRepository {
+  DriveUploadRepository(this._db);
+  final AppDatabase _db;
+
+  Future<void> insertJob({
+    required String id,
+    required String assignmentId,
+    required String filePath,
+    required String fileType,
+    required String fileName,
+    required int fileSizeBytes,
+    required DateTime capturedAt,
+  }) async {
+    await _db.into(_db.driveUploadJobs).insert(
+          DriveUploadJobsCompanion.insert(
+            id: id,
+            assignmentId: assignmentId,
+            filePath: filePath,
+            fileType: fileType,
+            fileName: fileName,
+            fileSizeBytes: fileSizeBytes,
+            capturedAt: capturedAt,
+            createdAt: DateTime.now(),
+          ),
+        );
+  }
+
+  Future<List<DriveUploadJob>> getPendingJobs({DateTime? now}) async {
+    final cutoff = now ?? DateTime.now();
+    return (_db.select(_db.driveUploadJobs)
+          ..where(
+            (t) =>
+                t.status.isIn([
+                  DriveUploadJobStatus.pending,
+                  DriveUploadJobStatus.failed,
+                ]) &
+                (t.nextRetryAt.isNull() |
+                    t.nextRetryAt.isSmallerOrEqualValue(cutoff)),
+          )
+          ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]))
+        .get();
+  }
+
+  Stream<List<DriveUploadJob>> watchQueue() {
+    return (_db.select(_db.driveUploadJobs)
+          ..where((t) => t.status.isNotIn([DriveUploadJobStatus.completed]))
+          ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]))
+        .watch();
+  }
+
+  Stream<int> watchPendingCount() {
+    return watchQueue().map((jobs) => jobs.length);
+  }
+
+  Future<void> markUploading(String id) async {
+    await (_db.update(_db.driveUploadJobs)..where((t) => t.id.equals(id)))
+        .write(const DriveUploadJobsCompanion(
+      status: Value(DriveUploadJobStatus.uploading),
+    ));
+  }
+
+  Future<void> markCompleted(String id, {required String driveFileId}) async {
+    await (_db.update(_db.driveUploadJobs)..where((t) => t.id.equals(id)))
+        .write(DriveUploadJobsCompanion(
+      status: const Value(DriveUploadJobStatus.completed),
+      driveFileId: Value(driveFileId),
+      resumableUri: const Value(null),
+    ));
+  }
+
+  Future<void> markFailed(
+    String id, {
+    required String reason,
+    required int retryCount,
+    required DateTime nextRetryAt,
+  }) async {
+    await (_db.update(_db.driveUploadJobs)..where((t) => t.id.equals(id)))
+        .write(DriveUploadJobsCompanion(
+      status: const Value(DriveUploadJobStatus.failed),
+      failureReason: Value(reason),
+      retryCount: Value(retryCount),
+      nextRetryAt: Value(nextRetryAt),
+    ));
+  }
+
+  Future<void> markDead(String id, {required String reason}) async {
+    await (_db.update(_db.driveUploadJobs)..where((t) => t.id.equals(id)))
+        .write(DriveUploadJobsCompanion(
+      status: const Value(DriveUploadJobStatus.dead),
+      failureReason: Value(reason),
+    ));
+  }
+
+  Future<void> setResumableUri(String id, String uri) async {
+    await (_db.update(_db.driveUploadJobs)..where((t) => t.id.equals(id)))
+        .write(DriveUploadJobsCompanion(resumableUri: Value(uri)));
+  }
+
+  Future<void> resetForRetry(String id) async {
+    await (_db.update(_db.driveUploadJobs)..where((t) => t.id.equals(id)))
+        .write(const DriveUploadJobsCompanion(
+      status: Value(DriveUploadJobStatus.pending),
+      retryCount: Value(0),
+      failureReason: Value(null),
+      nextRetryAt: Value(null),
+    ));
+  }
+
+  Future<void> resetFailedToPending() async {
+    await (_db.update(_db.driveUploadJobs)
+          ..where((t) => t.status.equals(DriveUploadJobStatus.failed)))
+        .write(const DriveUploadJobsCompanion(
+      status: Value(DriveUploadJobStatus.pending),
+      nextRetryAt: Value(null),
+    ));
+  }
+
+  Future<bool> jobExistsForFilePath(String filePath) async {
+    final row = await (_db.select(_db.driveUploadJobs)
+          ..where((t) =>
+              t.filePath.equals(filePath) &
+              t.status.isNotIn([DriveUploadJobStatus.completed]))
+          ..limit(1))
+        .getSingleOrNull();
+    return row != null;
+  }
+
+  Future<bool> shapefileJobExistsForAssignment(String assignmentId) async {
+    final row = await (_db.select(_db.driveUploadJobs)
+          ..where((t) =>
+              t.assignmentId.equals(assignmentId) &
+              t.fileType.equals(DriveUploadJobStatus.typeShapefile) &
+              t.status.isNotIn([DriveUploadJobStatus.completed]))
+          ..limit(1))
+        .getSingleOrNull();
+    return row != null;
+  }
+}
+```
+
+- [ ] **Step 5: Run test — expect PASS**
+
+```bash
+flutter test test/core/drive/drive_upload_repository_test.dart
+```
+
+Expected: all 7 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/core/drive/drive_upload_job_status.dart lib/core/drive/drive_upload_repository.dart test/core/drive/drive_upload_repository_test.dart
+git commit -m "feat(drive): add DriveUploadJobStatus and DriveUploadRepository"
+```
+
+---
+
+## Task 3: DriveUploadApi interface + FakeDriveUploadApi
+
+**Files:**
+- Create: `lib/core/drive/drive_upload_api.dart`
+- Create: `lib/core/drive/fake_drive_upload_api.dart`
+
+No unit tests at this step — the interface and fake are exercised by Task 5 (worker tests).
+
+- [ ] **Step 1: Create the abstract interface**
+
+```dart
+// lib/core/drive/drive_upload_api.dart
+
+/// Upload surface for Google Drive. Separate from the read-only DriveApi
+/// to keep download and upload concerns independent.
+abstract interface class DriveUploadApi {
+  /// Returns the Drive folder ID. Queries existing folder first; creates if absent.
+  Future<String> createOrGetFolder(String name, String parentId);
+
+  /// Uploads [localPath] into [driveParentId] and returns the Drive file ID.
+  /// Pass [resumableUri] to resume an interrupted large-file upload.
+  Future<String> uploadFile({
+    required String localPath,
+    required String driveParentId,
+    required String fileName,
+    String? resumableUri,
+    void Function(int sent, int total)? onProgress,
+  });
+}
+```
+
+- [ ] **Step 2: Create the test double**
+
+```dart
+// lib/core/drive/fake_drive_upload_api.dart
+import 'package:firecheck/core/drive/drive_upload_api.dart';
+
+class FakeDriveUploadApi implements DriveUploadApi {
+  FakeDriveUploadApi({
+    this.throwOnUpload = false,
+    this.throwOnFolder = false,
+  });
+
+  final bool throwOnUpload;
+  final bool throwOnFolder;
+
+  final List<String> uploadedPaths = [];
+  final Map<String, String> _folderIds = {};
+  int _fileCounter = 0;
+
+  @override
+  Future<String> createOrGetFolder(String name, String parentId) async {
+    if (throwOnFolder) throw Exception('folder creation failed');
+    final key = '$parentId/$name';
+    return _folderIds[key] ??= 'folder-${_folderIds.length + 1}';
+  }
+
+  @override
+  Future<String> uploadFile({
+    required String localPath,
+    required String driveParentId,
+    required String fileName,
+    String? resumableUri,
+    void Function(int sent, int total)? onProgress,
+  }) async {
+    if (throwOnUpload) throw Exception('upload failed');
+    uploadedPaths.add(localPath);
+    _fileCounter++;
+    onProgress?.call(100, 100);
+    return 'drive-file-$_fileCounter';
+  }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/core/drive/drive_upload_api.dart lib/core/drive/fake_drive_upload_api.dart
+git commit -m "feat(drive): add DriveUploadApi interface and FakeDriveUploadApi"
+```
+
+---
+
+## Task 4: ShapefileExporter.exportToFile()
+
+**Files:**
+- Modify: `lib/core/sync/shapefile/export/shapefile_exporter.dart`
+- Test: `test/core/sync/shapefile/export/shapefile_exporter_export_to_file_test.dart`
+
+The existing `export()` method writes to `getTemporaryDirectory()`. Temp files can be cleaned by the OS before upload completes. `exportToFile()` writes to `getApplicationDocumentsDirectory()` for a stable path.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/core/sync/shapefile/export/shapefile_exporter_export_to_file_test.dart
+import 'dart:io';
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('shapefile_test_');
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  test('exportToFile returns NoCompletedFeatures when assignment has no complete features', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    // Insert assignment + feature without completion
+    await db.into(db.assignments).insert(AssignmentsCompanion.insert(
+      id: 'a1',
+      enumeratorId: 'e1',
+      campaignId: 'c1',
+      boundaryPolygonGeojson: '{}',
+      createdAt: DateTime(2026),
+    ));
+
+    final exporter = ShapefileExporter(db: db, tempDirOverride: tempDir);
+    final (failure, path) = await exporter.exportToFile(assignmentId: 'a1');
+
+    expect(failure, isA<NoCompletedFeatures>());
+    expect(path, isNull);
+  });
+
+  test('exportToFile writes ZIP to tempDirOverride and returns path', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    // Seed a complete building feature
+    await db.into(db.assignments).insert(AssignmentsCompanion.insert(
+      id: 'a1', enumeratorId: 'e1', campaignId: 'c1',
+      boundaryPolygonGeojson: '{}', createdAt: DateTime(2026),
+    ));
+    await db.into(db.features).insert(FeaturesCompanion.insert(
+      id: 'f1', assignmentId: 'a1', featureType: 'building',
+      geometryGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}',
+      status: const Value('complete'),
+      createdAt: DateTime(2026),
+    ));
+    await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+      id: 's1', featureId: 'f1', createdAt: DateTime(2026), updatedAt: DateTime(2026),
+    ));
+    await db.into(db.buildingAttributes).insert(BuildingAttributesCompanion.insert(
+      submissionId: 's1',
+      fireFightingFacilitiesJson: const Value('[]'),
+      fireLoadJson: const Value('[]'),
+      costIsExact: const Value(false),
+    ));
+
+    final exporter = ShapefileExporter(db: db, tempDirOverride: tempDir);
+    final (failure, path) = await exporter.exportToFile(assignmentId: 'a1');
+
+    expect(failure, isNull);
+    expect(path, isNotNull);
+    expect(p.extension(path!), '.zip');
+    expect(File(path).existsSync(), isTrue);
+  });
+}
+```
+
+- [ ] **Step 2: Run test — expect compile error (exportToFile not defined)**
+
+```bash
+flutter test test/core/sync/shapefile/export/shapefile_exporter_export_to_file_test.dart
+```
+
+- [ ] **Step 3: Refactor ShapefileExporter to add exportToFile()**
+
+Read `lib/core/sync/shapefile/export/shapefile_exporter.dart` fully before editing. The existing `export()` method (lines 336–453) directly builds the archive and writes to temp. Extract the shared work into two new private methods, then add `exportToFile()`.
+
+Replace the body of `export()` and add the three new methods. The existing method signature and return type must not change.
+
+Find this section (lines 336–453):
+```dart
+Future<ExportFailure?> export({required String assignmentId}) async {
+    // Query all completed features with their submissions and attributes.
+    final buildingRows = await _queryBuildings(assignmentId);
+    final roadRows = await _queryRoads(assignmentId);
+    ...
+    return null;
+  }
+```
+
+Replace with:
+
+```dart
+Future<ExportFailure?> export({required String assignmentId}) async {
+  final tempDir = tempDirOverride ?? await getTemporaryDirectory();
+  final (failure, _) = await _buildAndWriteZip(
+    assignmentId: assignmentId,
+    destDir: tempDir,
+    callShareFile: true,
+  );
+  return failure;
+}
+
+/// Exports to [getApplicationDocumentsDirectory] (stable path). Returns the
+/// zip path on success — callers must not delete the file until upload confirms.
+Future<(ExportFailure?, String?)> exportToFile({
+  required String assignmentId,
+}) async {
+  final destDir = tempDirOverride ?? await getApplicationDocumentsDirectory();
+  return _buildAndWriteZip(
+    assignmentId: assignmentId,
+    destDir: destDir,
+    callShareFile: false,
+  );
+}
+
+Future<(ExportFailure?, String?)> _buildAndWriteZip({
+  required String assignmentId,
+  required Directory destDir,
+  required bool callShareFile,
+}) async {
+  final buildingRows = await _queryBuildings(assignmentId);
+  final roadRows = await _queryRoads(assignmentId);
+
+  if (buildingRows.isEmpty && roadRows.isEmpty) {
+    return (const NoCompletedFeatures(), null);
+  }
+
+  final inputs = <_LayerInput>[];
+  if (buildingRows.isNotEmpty) {
+    inputs.add(_LayerInput(
+      layerName: 'buildings',
+      isPolygon: true,
+      features: buildingRows
+          .map((r) => _FeatureRow(
+                featureId: r.featureId,
+                geometryGeojson: r.geometryGeojson,
+              ))
+          .toList(),
+      buildingRows: buildingRows.map((r) => r.buildingRow).toList(),
+      roadRows: const [],
+    ));
+  }
+  if (roadRows.isNotEmpty) {
+    inputs.add(_LayerInput(
+      layerName: 'roads',
+      isPolygon: false,
+      features: roadRows
+          .map((r) => _FeatureRow(
+                featureId: r.featureId,
+                geometryGeojson: r.geometryGeojson,
+              ))
+          .toList(),
+      buildingRows: const [],
+      roadRows: roadRows.map((r) => r.roadRow).toList(),
+    ));
+  }
+
+  List<_LayerOutput> outputs;
+  try {
+    outputs = await Future.wait(inputs.map((i) => compute(_writeLayer, i)));
+  } catch (e) {
+    return (WriteError(e.toString()), null);
+  }
+
+  for (final out in outputs) {
+    if (out.shp.isEmpty || out.shx.isEmpty || out.dbf.isEmpty) {
+      return (WriteError('Layer ${out.layerName} produced empty components'), null);
+    }
+  }
+
+  final archive = Archive();
+  for (final out in outputs) {
+    final name = out.layerName;
+    archive
+      ..addFile(ArchiveFile('$name.shp', out.shp.length, out.shp))
+      ..addFile(ArchiveFile('$name.shx', out.shx.length, out.shx))
+      ..addFile(ArchiveFile('$name.dbf', out.dbf.length, out.dbf))
+      ..addFile(ArchiveFile('$name.prj', _prjContent.length, _prjContent.codeUnits))
+      ..addFile(ArchiveFile('$name.cpg', _cpgContent.length, _cpgContent.codeUnits));
+  }
+
+  final zipBytes = ZipEncoder().encode(archive);
+  if (zipBytes == null) {
+    return (const WriteError('ZIP encoding produced no output'), null);
+  }
+
+  final timestamp = DateFormat('yyyyMMdd_HHmmss').format(DateTime.now());
+  final zipName = 'firecheck_${assignmentId}_$timestamp.zip';
+  final zipPath = p.join(destDir.path, zipName);
+
+  try {
+    await File(zipPath).writeAsBytes(zipBytes);
+  } catch (e) {
+    return (WriteError(e.toString()), null);
+  }
+
+  if (callShareFile && shareFile != null) {
+    try {
+      await shareFile!(zipPath);
+    } catch (e) {
+      return (ShareError(e.toString()), null);
+    }
+  }
+
+  return (null, zipPath);
+}
+```
+
+Also add this import at the top if not already present:
+```dart
+import 'package:path_provider/path_provider.dart';
+```
+
+- [ ] **Step 4: Run new tests + full suite**
+
+```bash
+flutter test test/core/sync/shapefile/export/shapefile_exporter_export_to_file_test.dart
+flutter test
+```
+
+Expected: new tests PASS, existing shapefile exporter tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/sync/shapefile/export/shapefile_exporter.dart test/core/sync/shapefile/export/shapefile_exporter_export_to_file_test.dart
+git commit -m "feat(export): add exportToFile() for stable-path zip used by drive upload"
+```
+
+---
+
+## Task 5: EnqueueAssignmentUseCase
+
+**Files:**
+- Create: `lib/core/drive/enqueue_assignment_use_case.dart`
+- Test: `test/core/drive/enqueue_assignment_use_case_test.dart`
+
+Generates the shapefile ZIP, then writes one `DriveUploadJob` per photo and one for the ZIP. Idempotent — calling twice doesn't double-queue.
+
+- [ ] **Step 1: Write the failing tests**
+
+```dart
+// test/core/drive/enqueue_assignment_use_case_test.dart
+import 'dart:io';
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/drive/enqueue_assignment_use_case.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('enqueue_test_');
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  Future<AppDatabase> _seedDb() async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    await db.into(db.assignments).insert(AssignmentsCompanion.insert(
+      id: 'a1', enumeratorId: 'e1', campaignId: 'c1',
+      boundaryPolygonGeojson: '{}', createdAt: DateTime(2026),
+    ));
+    await db.into(db.features).insert(FeaturesCompanion.insert(
+      id: 'f1', assignmentId: 'a1', featureType: 'building',
+      geometryGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}',
+      status: const Value('complete'), createdAt: DateTime(2026),
+    ));
+    await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+      id: 's1', featureId: 'f1', createdAt: DateTime(2026), updatedAt: DateTime(2026),
+    ));
+    await db.into(db.buildingAttributes).insert(BuildingAttributesCompanion.insert(
+      submissionId: 's1',
+      fireFightingFacilitiesJson: const Value('[]'),
+      fireLoadJson: const Value('[]'),
+      costIsExact: const Value(false),
+    ));
+    await db.into(db.photos).insert(PhotosCompanion.insert(
+      id: 'ph1', submissionId: 's1',
+      localPath: '${tempDir.path}/photo1.jpg',
+      capturedAt: DateTime(2026), createdAt: DateTime(2026),
+    ));
+    // Create the photo file so File.length() succeeds
+    await File('${tempDir.path}/photo1.jpg').writeAsBytes([0xFF, 0xD8]);
+    return db;
+  }
+
+  test('enqueue creates shapefile job + photo job', () async {
+    final db = await _seedDb();
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    final exporter = ShapefileExporter(db: db, tempDirOverride: tempDir);
+    final useCase = EnqueueAssignmentUseCase(
+      db: db,
+      repo: repo,
+      exporter: exporter,
+    );
+
+    final count = await useCase.execute(assignmentId: 'a1');
+
+    expect(count, 2); // 1 shapefile + 1 photo
+    final jobs = await repo.getPendingJobs();
+    expect(jobs.length, 2);
+    expect(jobs.any((j) => j.fileType == DriveUploadJobStatus.typeShapefile), isTrue);
+    expect(jobs.any((j) => j.fileType == DriveUploadJobStatus.typePhoto), isTrue);
+  });
+
+  test('enqueue is idempotent — second call adds no new jobs', () async {
+    final db = await _seedDb();
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    final exporter = ShapefileExporter(db: db, tempDirOverride: tempDir);
+    final useCase = EnqueueAssignmentUseCase(db: db, repo: repo, exporter: exporter);
+
+    await useCase.execute(assignmentId: 'a1');
+    final secondCount = await useCase.execute(assignmentId: 'a1');
+
+    expect(secondCount, 0);
+    final jobs = await db.select(db.driveUploadJobs).get();
+    expect(jobs.length, 2); // still 2, no duplicates
+  });
+}
+```
+
+- [ ] **Step 2: Run test — expect compile error**
+
+```bash
+flutter test test/core/drive/enqueue_assignment_use_case_test.dart
+```
+
+- [ ] **Step 3: Implement EnqueueAssignmentUseCase**
+
+```dart
+// lib/core/drive/enqueue_assignment_use_case.dart
+import 'dart:io';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
+import 'package:uuid/uuid.dart';
+
+class EnqueueAssignmentUseCase {
+  EnqueueAssignmentUseCase({
+    required AppDatabase db,
+    required DriveUploadRepository repo,
+    required ShapefileExporter exporter,
+  })  : _db = db,
+        _repo = repo,
+        _exporter = exporter;
+
+  final AppDatabase _db;
+  final DriveUploadRepository _repo;
+  final ShapefileExporter _exporter;
+  static const _uuid = Uuid();
+
+  /// Returns the number of new jobs created (0 if already fully enqueued).
+  Future<int> execute({required String assignmentId}) async {
+    var created = 0;
+
+    // ── Shapefile ────────────────────────────────────────────────────────────
+    final shapefileExists =
+        await _repo.shapefileJobExistsForAssignment(assignmentId);
+    if (!shapefileExists) {
+      final (failure, zipPath) =
+          await _exporter.exportToFile(assignmentId: assignmentId);
+      if (failure == null && zipPath != null) {
+        final file = File(zipPath);
+        final size = file.existsSync() ? await file.length() : 0;
+        await _repo.insertJob(
+          id: _uuid.v4(),
+          assignmentId: assignmentId,
+          filePath: zipPath,
+          fileType: DriveUploadJobStatus.typeShapefile,
+          fileName: zipPath.split('/').last,
+          fileSizeBytes: size,
+          capturedAt: DateTime.now(),
+        );
+        created++;
+      }
+    }
+
+    // ── Photos ───────────────────────────────────────────────────────────────
+    final photos = await _photosForAssignment(assignmentId);
+    for (final photo in photos) {
+      final exists = await _repo.jobExistsForFilePath(photo.localPath);
+      if (exists) continue;
+      final file = File(photo.localPath);
+      final size = file.existsSync() ? await file.length() : 0;
+      await _repo.insertJob(
+        id: _uuid.v4(),
+        assignmentId: assignmentId,
+        filePath: photo.localPath,
+        fileType: DriveUploadJobStatus.typePhoto,
+        fileName: photo.localPath.split('/').last,
+        fileSizeBytes: size,
+        capturedAt: photo.capturedAt,
+      );
+      created++;
+    }
+
+    return created;
+  }
+
+  Future<List<Photo>> _photosForAssignment(String assignmentId) async {
+    final featureIds = await (_db.selectOnly(_db.features)
+          ..addColumns([_db.features.id])
+          ..where(_db.features.assignmentId.equals(assignmentId)))
+        .map((row) => row.read(_db.features.id)!)
+        .get();
+
+    if (featureIds.isEmpty) return [];
+
+    final submissionIds = await (_db.selectOnly(_db.submissions)
+          ..addColumns([_db.submissions.id])
+          ..where(_db.submissions.featureId.isIn(featureIds)))
+        .map((row) => row.read(_db.submissions.id)!)
+        .get();
+
+    if (submissionIds.isEmpty) return [];
+
+    return (_db.select(_db.photos)
+          ..where((t) => t.submissionId.isIn(submissionIds)))
+        .get();
+  }
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+flutter test test/core/drive/enqueue_assignment_use_case_test.dart
+```
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+flutter test
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/core/drive/enqueue_assignment_use_case.dart test/core/drive/enqueue_assignment_use_case_test.dart
+git commit -m "feat(drive): add EnqueueAssignmentUseCase for shapefile+photo queue population"
+```
+
+---
+
+## Task 6: DriveUploadWorker
+
+**Files:**
+- Create: `lib/core/drive/drive_upload_worker.dart`
+- Test: `test/core/drive/drive_upload_worker_test.dart`
+
+- [ ] **Step 1: Write the failing tests**
+
+```dart
+// test/core/drive/drive_upload_worker_test.dart
+import 'dart:io';
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/drive/drive_upload_worker.dart';
+import 'package:firecheck/core/drive/fake_drive_upload_api.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('worker_test_');
+  });
+  tearDown(() async {
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  Future<String> _seedPhoto(AppDatabase db, DriveUploadRepository repo, String id) async {
+    final path = '${tempDir.path}/$id.jpg';
+    await File(path).writeAsBytes([0xFF, 0xD8]);
+    await repo.insertJob(
+      id: id, assignmentId: 'a1', filePath: path,
+      fileType: DriveUploadJobStatus.typePhoto, fileName: '$id.jpg',
+      fileSizeBytes: 2, capturedAt: DateTime(2026),
+    );
+    return path;
+  }
+
+  test('drain marks job completed on successful upload', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    final api = FakeDriveUploadApi();
+    await _seedPhoto(db, repo, 'j1');
+
+    final worker = DriveUploadWorker(
+      api: api,
+      repo: repo,
+      db: db,
+      rootFolderId: 'root-folder',
+    );
+    await worker.drain();
+
+    final jobs = await db.select(db.driveUploadJobs).get();
+    expect(jobs.first.status, DriveUploadJobStatus.completed);
+    expect(jobs.first.driveFileId, isNotNull);
+    expect(api.uploadedPaths.length, 1);
+  });
+
+  test('drain marks job failed on transient error (retryCount increments)', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    final api = FakeDriveUploadApi(throwOnUpload: true);
+    await _seedPhoto(db, repo, 'j1');
+
+    final worker = DriveUploadWorker(
+      api: api,
+      repo: repo,
+      db: db,
+      rootFolderId: 'root-folder',
+    );
+    await worker.drain();
+
+    final jobs = await db.select(db.driveUploadJobs).get();
+    expect(jobs.first.status, DriveUploadJobStatus.failed);
+    expect(jobs.first.retryCount, 1);
+    expect(jobs.first.nextRetryAt, isNotNull);
+  });
+
+  test('drain marks job dead after 3 failures', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    final api = FakeDriveUploadApi(throwOnUpload: true);
+    await _seedPhoto(db, repo, 'j1');
+
+    final worker = DriveUploadWorker(
+      api: api,
+      repo: repo,
+      db: db,
+      rootFolderId: 'root-folder',
+    );
+
+    // Drain 3× with retry time set to past each time
+    for (var i = 0; i < 3; i++) {
+      // Reset nextRetryAt to past so it's eligible
+      await db.customStatement(
+        'UPDATE drive_upload_jobs SET next_retry_at = NULL WHERE id = ?',
+        ['j1'],
+      );
+      await worker.drain();
+    }
+
+    final jobs = await db.select(db.driveUploadJobs).get();
+    expect(jobs.first.status, DriveUploadJobStatus.dead);
+  });
+
+  test('drain skips job whose local file is missing', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    final api = FakeDriveUploadApi();
+    await repo.insertJob(
+      id: 'j1', assignmentId: 'a1',
+      filePath: '/nonexistent/missing.jpg',
+      fileType: DriveUploadJobStatus.typePhoto, fileName: 'missing.jpg',
+      fileSizeBytes: 0, capturedAt: DateTime(2026),
+    );
+
+    final worker = DriveUploadWorker(
+      api: api,
+      repo: repo,
+      db: db,
+      rootFolderId: 'root-folder',
+    );
+    await worker.drain();
+
+    final jobs = await db.select(db.driveUploadJobs).get();
+    expect(jobs.first.status, DriveUploadJobStatus.dead);
+    expect(jobs.first.failureReason, contains('missing'));
+    expect(api.uploadedPaths, isEmpty);
+  });
+}
+```
+
+- [ ] **Step 2: Run test — expect compile error**
+
+```bash
+flutter test test/core/drive/drive_upload_worker_test.dart
+```
+
+- [ ] **Step 3: Implement DriveUploadWorker**
+
+```dart
+// lib/core/drive/drive_upload_worker.dart
+import 'dart:io';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_api.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:intl/intl.dart';
+
+class DriveUploadWorker {
+  DriveUploadWorker({
+    required this.api,
+    required this.repo,
+    required this.db,
+    required this.rootFolderId,
+  });
+
+  final DriveUploadApi api;
+  final DriveUploadRepository repo;
+  final AppDatabase db;
+  final String rootFolderId;
+
+  static const _maxConcurrent = 3;
+  bool _running = false;
+
+  // Session-scoped folder ID cache; not persisted across app restarts.
+  final _folderCache = <String, String>{};
+
+  Future<void> drain() async {
+    if (_running) return;
+    _running = true;
+    try {
+      while (true) {
+        final jobs = await repo.getPendingJobs();
+        if (jobs.isEmpty) return;
+        await Future.wait(jobs.take(_maxConcurrent).map(_processOne));
+      }
+    } finally {
+      _running = false;
+    }
+  }
+
+  Future<void> _processOne(DriveUploadJob job) async {
+    final file = File(job.filePath);
+    if (!file.existsSync()) {
+      await repo.markDead(job.id, reason: 'file missing: ${job.filePath}');
+      return;
+    }
+
+    await repo.markUploading(job.id);
+
+    try {
+      final parentId = await _resolveParentFolder(job);
+      final driveFileId = await api.uploadFile(
+        localPath: job.filePath,
+        driveParentId: parentId,
+        fileName: job.fileName,
+        resumableUri: job.resumableUri,
+      );
+      await repo.markCompleted(job.id, driveFileId: driveFileId);
+    } on Exception catch (e) {
+      final attempts = job.retryCount + 1;
+      final next = _nextRetryAt(attempts);
+      if (next == null) {
+        await repo.markDead(job.id, reason: e.toString());
+      } else {
+        await repo.markFailed(
+          job.id,
+          reason: e.toString(),
+          retryCount: attempts,
+          nextRetryAt: next,
+        );
+      }
+    }
+  }
+
+  Future<String> _resolveParentFolder(DriveUploadJob job) async {
+    final assignment = await (db.select(db.assignments)
+          ..where((t) => t.id.equals(job.assignmentId)))
+        .getSingle();
+    final enumeratorId = assignment.enumeratorId;
+    final dateKey = DateFormat('yyyy-MM-dd').format(job.capturedAt);
+    final subfolderName = job.fileType == DriveUploadJobStatus.typePhoto
+        ? 'photos'
+        : 'shapefiles';
+
+    final cacheKey = '$enumeratorId/$dateKey/$subfolderName';
+    if (_folderCache.containsKey(cacheKey)) {
+      return _folderCache[cacheKey]!;
+    }
+
+    final enumeratorFolderId =
+        await api.createOrGetFolder(enumeratorId, rootFolderId);
+    final dateFolderId =
+        await api.createOrGetFolder(dateKey, enumeratorFolderId);
+    final subFolderId =
+        await api.createOrGetFolder(subfolderName, dateFolderId);
+
+    _folderCache[cacheKey] = subFolderId;
+    return subFolderId;
+  }
+
+  DateTime? _nextRetryAt(int attempts) {
+    final base = DateTime.now();
+    return switch (attempts) {
+      1 => base.add(const Duration(seconds: 30)),
+      2 => base.add(const Duration(minutes: 2)),
+      3 => base.add(const Duration(minutes: 10)),
+      _ => null,
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+flutter test test/core/drive/drive_upload_worker_test.dart
+```
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+flutter test
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/core/drive/drive_upload_worker.dart test/core/drive/drive_upload_worker_test.dart
+git commit -m "feat(drive): add DriveUploadWorker with retry/dead logic"
+```
+
+---
+
+## Task 7: DriveUploadPreferences
+
+**Files:**
+- Create: `lib/core/drive/drive_upload_preferences.dart`
+- Test: `test/core/drive/drive_upload_preferences_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/core/drive/drive_upload_preferences_test.dart
+import 'package:firecheck/core/drive/drive_upload_preferences.dart';
+import 'package:firecheck/core/security/secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('autoUploadEnabled defaults to false', () async {
+    final prefs = DriveUploadPreferences(InMemorySecureStorage());
+    expect(await prefs.isAutoUploadEnabled(), isFalse);
+  });
+
+  test('setAutoUpload persists and reads back', () async {
+    final prefs = DriveUploadPreferences(InMemorySecureStorage());
+    await prefs.setAutoUploadEnabled(enabled: true);
+    expect(await prefs.isAutoUploadEnabled(), isTrue);
+    await prefs.setAutoUploadEnabled(enabled: false);
+    expect(await prefs.isAutoUploadEnabled(), isFalse);
+  });
+}
+```
+
+- [ ] **Step 2: Run test — expect compile error**
+
+```bash
+flutter test test/core/drive/drive_upload_preferences_test.dart
+```
+
+- [ ] **Step 3: Implement**
+
+```dart
+// lib/core/drive/drive_upload_preferences.dart
+import 'package:firecheck/core/security/secure_storage.dart';
+
+class DriveUploadPreferences {
+  DriveUploadPreferences(this._storage);
+  final SecureStorage _storage;
+
+  static const _keyAutoUpload = 'drive_auto_upload_enabled';
+
+  Future<bool> isAutoUploadEnabled() async {
+    final val = await _storage.read(_keyAutoUpload);
+    return val == 'true';
+  }
+
+  Future<void> setAutoUploadEnabled({required bool enabled}) =>
+      _storage.write(_keyAutoUpload, enabled ? 'true' : 'false');
+}
+```
+
+- [ ] **Step 4: Run test + full suite — expect PASS**
+
+```bash
+flutter test test/core/drive/drive_upload_preferences_test.dart && flutter test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/drive/drive_upload_preferences.dart test/core/drive/drive_upload_preferences_test.dart
+git commit -m "feat(drive): add DriveUploadPreferences for auto-upload toggle"
+```
+
+---
+
+## Task 8: DriveUploadController
+
+**Files:**
+- Create: `lib/core/drive/drive_upload_controller.dart`
+- Test: `test/core/drive/drive_upload_controller_test.dart`
+
+Mirrors `SyncController` but gates on Wi-Fi (`ConnectivityResult.wifi`) rather than any connection.
+
+- [ ] **Step 1: Write the failing tests**
+
+```dart
+// test/core/drive/drive_upload_controller_test.dart
+import 'dart:async';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:firecheck/core/drive/drive_upload_controller.dart';
+import 'package:firecheck/core/drive/drive_upload_preferences.dart';
+import 'package:firecheck/core/security/secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('triggerNow calls onDrain', () async {
+    var drainCalled = 0;
+    final prefs = DriveUploadPreferences(InMemorySecureStorage());
+    final ctrl = DriveUploadController(
+      onDrain: () async => drainCalled++,
+      preferences: prefs,
+    );
+
+    await ctrl.triggerNow();
+    expect(drainCalled, 1);
+  });
+
+  test('Wi-Fi connectivity event triggers drain when auto-upload is on', () async {
+    final controller = StreamController<List<ConnectivityResult>>();
+    var drainCalled = 0;
+    final storage = InMemorySecureStorage();
+    final prefs = DriveUploadPreferences(storage);
+    await prefs.setAutoUploadEnabled(enabled: true);
+
+    final ctrl = DriveUploadController(
+      onDrain: () async => drainCalled++,
+      preferences: prefs,
+      connectivityStream: controller.stream,
+    );
+    await ctrl.start();
+
+    controller.add([ConnectivityResult.wifi]);
+    await Future.delayed(Duration.zero);
+
+    expect(drainCalled, greaterThanOrEqualTo(1));
+    await ctrl.stop();
+    await controller.close();
+  });
+
+  test('mobile connectivity does not trigger drain', () async {
+    final controller = StreamController<List<ConnectivityResult>>();
+    var drainCalled = 0;
+    final prefs = DriveUploadPreferences(InMemorySecureStorage());
+    await prefs.setAutoUploadEnabled(enabled: true);
+
+    final ctrl = DriveUploadController(
+      onDrain: () async => drainCalled++,
+      preferences: prefs,
+      connectivityStream: controller.stream,
+    );
+    await ctrl.start();
+
+    controller.add([ConnectivityResult.mobile]);
+    await Future.delayed(Duration.zero);
+
+    expect(drainCalled, 0);
+    await ctrl.stop();
+    await controller.close();
+  });
+
+  test('Wi-Fi event does not trigger drain when auto-upload is off', () async {
+    final streamCtrl = StreamController<List<ConnectivityResult>>();
+    var drainCalled = 0;
+    final prefs = DriveUploadPreferences(InMemorySecureStorage());
+    // auto-upload default is false
+
+    final ctrl = DriveUploadController(
+      onDrain: () async => drainCalled++,
+      preferences: prefs,
+      connectivityStream: streamCtrl.stream,
+    );
+    await ctrl.start();
+
+    streamCtrl.add([ConnectivityResult.wifi]);
+    await Future.delayed(Duration.zero);
+
+    expect(drainCalled, 0);
+    await ctrl.stop();
+    await streamCtrl.close();
+  });
+}
+```
+
+- [ ] **Step 2: Run test — expect compile error**
+
+```bash
+flutter test test/core/drive/drive_upload_controller_test.dart
+```
+
+- [ ] **Step 3: Implement**
+
+```dart
+// lib/core/drive/drive_upload_controller.dart
+import 'dart:async';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:firecheck/core/drive/drive_upload_preferences.dart';
+
+class DriveUploadController {
+  DriveUploadController({
+    required Future<void> Function() onDrain,
+    required DriveUploadPreferences preferences,
+    Stream<List<ConnectivityResult>>? connectivityStream,
+  })  : _onDrain = onDrain,
+        _preferences = preferences,
+        _connectivityStream = connectivityStream ??
+            Connectivity()
+                .onConnectivityChanged
+                .map((r) => <ConnectivityResult>[r]);
+
+  final Future<void> Function() _onDrain;
+  final DriveUploadPreferences _preferences;
+  final Stream<List<ConnectivityResult>> _connectivityStream;
+  StreamSubscription<List<ConnectivityResult>>? _sub;
+
+  Future<void> start() async {
+    _sub = _connectivityStream.listen((results) async {
+      final isWifi = results.any((r) => r == ConnectivityResult.wifi);
+      if (!isWifi) return;
+      final autoEnabled = await _preferences.isAutoUploadEnabled();
+      if (autoEnabled) await _onDrain();
+    });
+  }
+
+  Future<void> triggerNow() => _onDrain();
+
+  Future<void> stop() async {
+    await _sub?.cancel();
+    _sub = null;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests + full suite — expect PASS**
+
+```bash
+flutter test test/core/drive/drive_upload_controller_test.dart && flutter test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/drive/drive_upload_controller.dart test/core/drive/drive_upload_controller_test.dart
+git commit -m "feat(drive): add DriveUploadController with Wi-Fi-only trigger"
+```
+
+---
+
+## Task 9: DriveUploadWorkmanager dispatcher
+
+**Files:**
+- Create: `lib/core/drive/drive_upload_workmanager.dart`
+
+No automated tests (WorkManager requires a real device). Verify by running the app and checking that uploads trigger in the background.
+
+- [ ] **Step 1: Implement the WorkManager dispatcher**
+
+```dart
+// lib/core/drive/drive_upload_workmanager.dart
+import 'dart:async';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_worker.dart';
+import 'package:firecheck/core/drive/google_drive_upload_api.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:workmanager/workmanager.dart';
+
+const _periodicTaskName = 'firecheck.drive_upload.periodic';
+
+@pragma('vm:entry-point')
+void driveUploadCallbackDispatcher() {
+  Workmanager().executeTask((task, inputData) async {
+    try {
+      // Only proceed if Wi-Fi is available.
+      final connectivity = await Connectivity().checkConnectivity();
+      final isWifi = connectivity.contains(ConnectivityResult.wifi);
+      if (!isWifi) return true;
+
+      await dotenv.load();
+      final rootFolderId = dotenv.env['DRIVE_UPLOAD_FOLDER_ID'] ?? '';
+      if (rootFolderId.isEmpty) return false;
+
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      final signIn = GoogleSignIn(
+        scopes: [
+          'https://www.googleapis.com/auth/drive.file',
+        ],
+      );
+      final uploadApi = GoogleDriveUploadApi(googleSignIn: signIn);
+      final worker = DriveUploadWorker(
+        api: uploadApi,
+        repo: DriveUploadRepository(db),
+        db: db,
+        rootFolderId: rootFolderId,
+      );
+      await worker.drain();
+      await db.close();
+      return true;
+    } on Object {
+      return false;
+    }
+  });
+}
+
+Future<void> registerPeriodicDriveUpload() async {
+  await Workmanager().initialize(driveUploadCallbackDispatcher);
+  await Workmanager().registerPeriodicTask(
+    _periodicTaskName,
+    'firecheck.drive_upload',
+    frequency: const Duration(minutes: 15),
+    constraints: Constraints(networkType: NetworkType.connected),
+  );
+}
+
+Future<void> cancelPeriodicDriveUpload() async {
+  await Workmanager().cancelByUniqueName(_periodicTaskName);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add lib/core/drive/drive_upload_workmanager.dart
+git commit -m "feat(drive): add DriveUploadWorkmanager background dispatcher"
+```
+
+---
+
+## Task 10: Google auth scope + GoogleDriveUploadApi
+
+**Files:**
+- Modify: `lib/features/auth/data/google_auth_repository.dart`
+- Create: `lib/core/drive/google_drive_upload_api.dart`
+- Test: `test/features/auth/google_auth_repository_drive_scope_test.dart`
+
+- [ ] **Step 1: Read the existing GoogleAuthRepository**
+
+```bash
+cat lib/features/auth/data/google_auth_repository.dart
+```
+
+Locate the `GoogleSignIn` instantiation. The scopes list is passed to `GoogleSignIn(scopes: [...])`. Note the exact location.
+
+- [ ] **Step 2: Write the failing test**
+
+```dart
+// test/features/auth/google_auth_repository_drive_scope_test.dart
+import 'package:firecheck/features/auth/data/google_auth_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+class _MockGoogleSignIn extends Mock implements GoogleSignIn {}
+
+void main() {
+  test('requestDriveUploadScope calls requestScopes with drive.file scope', () async {
+    final mockSignIn = _MockGoogleSignIn();
+    when(() => mockSignIn.requestScopes(any())).thenAnswer((_) async => true);
+
+    final repo = GoogleAuthRepository(googleSignIn: mockSignIn);
+    final result = await repo.requestDriveUploadScope();
+
+    expect(result, isTrue);
+    verify(() => mockSignIn.requestScopes(
+      [GoogleAuthRepository.driveFileScope],
+    )).called(1);
+  });
+}
+```
+
+- [ ] **Step 3: Run test — expect compile error**
+
+```bash
+flutter test test/features/auth/google_auth_repository_drive_scope_test.dart
+```
+
+- [ ] **Step 4: Add requestDriveUploadScope() to GoogleAuthRepository**
+
+Add to `lib/features/auth/data/google_auth_repository.dart`:
+
+```dart
+// Add static constant (inside the class):
+static const driveFileScope =
+    'https://www.googleapis.com/auth/drive.file';
+
+// Add method:
+Future<bool> requestDriveUploadScope() async {
+  try {
+    return await _googleSignIn.requestScopes([driveFileScope]);
+  } on Object {
+    return false;
+  }
+}
+```
+
+`_googleSignIn` is the `GoogleSignIn` field in the existing class. Use whatever name it already has.
+
+- [ ] **Step 5: Run test — expect PASS**
+
+```bash
+flutter test test/features/auth/google_auth_repository_drive_scope_test.dart
+```
+
+- [ ] **Step 6: Implement GoogleDriveUploadApi**
+
+```dart
+// lib/core/drive/google_drive_upload_api.dart
+import 'dart:io';
+import 'package:extension_google_sign_in_as_googleapis_auth/extension_google_sign_in_as_googleapis_auth.dart';
+import 'package:firecheck/core/drive/drive_upload_api.dart';
+import 'package:firecheck/core/errors/failure.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:googleapis/drive/v3.dart' as gdrive;
+
+class GoogleDriveUploadApi implements DriveUploadApi {
+  GoogleDriveUploadApi({required GoogleSignIn googleSignIn})
+      : _googleSignIn = googleSignIn;
+
+  final GoogleSignIn _googleSignIn;
+
+  Future<gdrive.DriveApi> _api() async {
+    final client = await _googleSignIn.authenticatedClient();
+    if (client == null) throw const AuthFailure('Not signed in to Google');
+    return gdrive.DriveApi(client);
+  }
+
+  @override
+  Future<String> createOrGetFolder(String name, String parentId) async {
+    final api = await _api();
+    final existing = await api.files.list(
+      q: "name = '$name' "
+          "and mimeType = 'application/vnd.google-apps.folder' "
+          "and '$parentId' in parents "
+          "and trashed = false",
+      spaces: 'drive',
+      $fields: 'files(id)',
+    );
+    if (existing.files?.isNotEmpty == true) {
+      return existing.files!.first.id!;
+    }
+    final folder = await api.files.create(
+      gdrive.File()
+        ..name = name
+        ..mimeType = 'application/vnd.google-apps.folder'
+        ..parents = [parentId],
+      $fields: 'id',
+    );
+    return folder.id!;
+  }
+
+  @override
+  Future<String> uploadFile({
+    required String localPath,
+    required String driveParentId,
+    required String fileName,
+    String? resumableUri,
+    void Function(int sent, int total)? onProgress,
+  }) async {
+    final api = await _api();
+    final file = File(localPath);
+    final fileSize = await file.length();
+    final mimeType = fileName.toLowerCase().endsWith('.jpg')
+        ? 'image/jpeg'
+        : 'application/zip';
+
+    final media = gdrive.Media(
+      file.openRead(),
+      fileSize,
+      contentType: mimeType,
+    );
+    final metadata = gdrive.File()
+      ..name = fileName
+      ..parents = [driveParentId];
+
+    final created = await api.files.create(
+      metadata,
+      uploadMedia: media,
+      $fields: 'id',
+    );
+    onProgress?.call(fileSize, fileSize);
+    return created.id!;
+  }
+}
+```
+
+- [ ] **Step 7: Run full suite**
+
+```bash
+flutter test
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/features/auth/data/google_auth_repository.dart lib/core/drive/google_drive_upload_api.dart test/features/auth/google_auth_repository_drive_scope_test.dart
+git commit -m "feat(auth,drive): add drive.file scope request and GoogleDriveUploadApi"
+```
+
+---
+
+## Task 11: DriveUploadProviders + DriveUploadNotifier
+
+**Files:**
+- Create: `lib/core/drive/drive_upload_providers.dart`
+- Create: `lib/features/upload/presentation/upload_queue_notifier.dart`
+- Test: `test/features/upload/upload_queue_notifier_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/upload/upload_queue_notifier_test.dart
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/drive/drive_upload_worker.dart';
+import 'package:firecheck/core/drive/fake_drive_upload_api.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('pendingCount reflects queue', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    await repo.insertJob(
+      id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+      fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+      fileSizeBytes: 100, capturedAt: DateTime(2026),
+    );
+
+    final container = ProviderContainer(overrides: [
+      driveUploadRepoProvider.overrideWithValue(repo),
+      driveUploadWorkerProvider.overrideWithValue(
+        DriveUploadWorker(
+          api: FakeDriveUploadApi(),
+          repo: repo,
+          db: db,
+          rootFolderId: 'root',
+        ),
+      ),
+    ]);
+    addTearDown(container.dispose);
+
+    // Allow stream to settle
+    await Future.delayed(Duration.zero);
+    final state = container.read(driveUploadNotifierProvider);
+    expect(state.pendingCount, 1);
+  });
+}
+```
+
+- [ ] **Step 2: Run test — expect compile error**
+
+```bash
+flutter test test/features/upload/upload_queue_notifier_test.dart
+```
+
+- [ ] **Step 3: Implement DriveUploadNotifier**
+
+```dart
+// lib/features/upload/presentation/upload_queue_notifier.dart
+import 'dart:async';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/drive/drive_upload_worker.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class DriveUploadState {
+  const DriveUploadState({
+    required this.jobs,
+  });
+
+  final List<DriveUploadJob> jobs;
+
+  int get pendingCount =>
+      jobs.where((j) => j.status != DriveUploadJobStatus.completed).length;
+
+  int get totalPendingBytes => jobs
+      .where((j) => j.status != DriveUploadJobStatus.completed)
+      .fold(0, (sum, j) => sum + j.fileSizeBytes);
+
+  int get completedCount =>
+      jobs.where((j) => j.status == DriveUploadJobStatus.completed).length;
+
+  bool get isUploading =>
+      jobs.any((j) => j.status == DriveUploadJobStatus.uploading);
+}
+
+class DriveUploadNotifier extends StateNotifier<DriveUploadState> {
+  DriveUploadNotifier({
+    required DriveUploadRepository repo,
+    required DriveUploadWorker worker,
+  })  : _repo = repo,
+        _worker = worker,
+        super(const DriveUploadState(jobs: [])) {
+    _sub = repo.watchQueue().listen((jobs) {
+      state = DriveUploadState(jobs: jobs);
+    });
+  }
+
+  final DriveUploadRepository _repo;
+  final DriveUploadWorker _worker;
+  StreamSubscription<List<DriveUploadJob>>? _sub;
+
+  Future<void> uploadAll() async {
+    await _repo.resetFailedToPending();
+    await _worker.drain();
+  }
+
+  Future<void> retryJob(String jobId) async {
+    await _repo.resetForRetry(jobId);
+    await _worker.drain();
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+}
+```
+
+- [ ] **Step 4: Implement DriveUploadProviders**
+
+```dart
+// lib/core/drive/drive_upload_providers.dart
+import 'package:firecheck/core/drive/drive_upload_preferences.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/drive/drive_upload_worker.dart';
+import 'package:firecheck/core/drive/google_drive_upload_api.dart';
+import 'package:firecheck/features/auth/presentation/google_auth_providers.dart';
+import 'package:firecheck/features/home/presentation/home_providers.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final driveUploadRepoProvider = Provider<DriveUploadRepository>((ref) {
+  return DriveUploadRepository(ref.watch(appDatabaseProvider));
+});
+
+final driveUploadWorkerProvider = Provider<DriveUploadWorker>((ref) {
+  final rootFolderId = dotenv.env['DRIVE_UPLOAD_FOLDER_ID'] ?? '';
+  return DriveUploadWorker(
+    api: GoogleDriveUploadApi(
+      googleSignIn: ref.watch(googleSignInProvider),
+    ),
+    repo: ref.watch(driveUploadRepoProvider),
+    db: ref.watch(appDatabaseProvider),
+    rootFolderId: rootFolderId,
+  );
+});
+
+final driveUploadPreferencesProvider = Provider<DriveUploadPreferences>((ref) {
+  return DriveUploadPreferences(ref.watch(secureStorageProvider));
+});
+
+final driveUploadNotifierProvider =
+    StateNotifierProvider<DriveUploadNotifier, DriveUploadState>((ref) {
+  return DriveUploadNotifier(
+    repo: ref.watch(driveUploadRepoProvider),
+    worker: ref.watch(driveUploadWorkerProvider),
+  );
+});
+```
+
+`googleSignInProvider` and `secureStorageProvider` are existing providers. Check `lib/features/auth/presentation/google_auth_providers.dart` and `lib/features/auth/presentation/auth_providers.dart` for the exact provider names and add imports accordingly.
+
+- [ ] **Step 5: Run test + full suite**
+
+```bash
+flutter test test/features/upload/upload_queue_notifier_test.dart && flutter test
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/core/drive/drive_upload_providers.dart lib/features/upload/presentation/upload_queue_notifier.dart test/features/upload/upload_queue_notifier_test.dart
+git commit -m "feat(drive): add DriveUploadNotifier, state, and Riverpod providers"
+```
+
+---
+
+## Task 12: UploadBanner widget
+
+**Files:**
+- Create: `lib/features/upload/presentation/upload_banner.dart`
+- Test: `test/features/upload/upload_banner_test.dart`
+
+- [ ] **Step 1: Write the failing tests**
+
+```dart
+// test/features/upload/upload_banner_test.dart
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_providers.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/drive/drive_upload_worker.dart';
+import 'package:firecheck/core/drive/fake_drive_upload_api.dart';
+import 'package:firecheck/features/upload/presentation/upload_banner.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(Widget child, List<Override> overrides) {
+  return ProviderScope(
+    overrides: overrides,
+    child: MaterialApp(home: Scaffold(body: child)),
+  );
+}
+
+void main() {
+  testWidgets('banner is hidden when no pending jobs', (tester) async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+
+    await tester.pumpWidget(_wrap(const UploadBanner(), [
+      driveUploadNotifierProvider.overrideWith(
+        (ref) => DriveUploadNotifier(
+          repo: repo,
+          worker: DriveUploadWorker(
+            api: FakeDriveUploadApi(), repo: repo, db: db, rootFolderId: 'r',
+          ),
+        ),
+      ),
+    ]));
+    await tester.pump();
+
+    expect(find.byType(UploadBanner), findsOneWidget);
+    expect(find.text(RegExp(r'file')), findsNothing);
+  });
+
+  testWidgets('banner shows pending count when jobs exist', (tester) async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    await repo.insertJob(
+      id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+      fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+      fileSizeBytes: 1024 * 1024, capturedAt: DateTime(2026),
+    );
+
+    await tester.pumpWidget(_wrap(const UploadBanner(), [
+      driveUploadNotifierProvider.overrideWith(
+        (ref) => DriveUploadNotifier(
+          repo: repo,
+          worker: DriveUploadWorker(
+            api: FakeDriveUploadApi(), repo: repo, db: db, rootFolderId: 'r',
+          ),
+        ),
+      ),
+    ]));
+    await tester.pump();
+
+    expect(find.textContaining('1'), findsAtLeastNWidgets(1));
+  });
+}
+```
+
+- [ ] **Step 2: Run test — expect compile error**
+
+```bash
+flutter test test/features/upload/upload_banner_test.dart
+```
+
+- [ ] **Step 3: Implement UploadBanner**
+
+```dart
+// lib/features/upload/presentation/upload_banner.dart
+import 'package:firecheck/core/drive/drive_upload_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+class UploadBanner extends ConsumerWidget {
+  const UploadBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(driveUploadNotifierProvider);
+    if (state.pendingCount == 0) return const SizedBox.shrink();
+
+    final totalMb =
+        (state.totalPendingBytes / 1024 / 1024).toStringAsFixed(1);
+
+    return Card(
+      color: Theme.of(context).colorScheme.primary,
+      margin: EdgeInsets.zero,
+      child: ListTile(
+        leading: Icon(Icons.cloud_upload,
+            color: Theme.of(context).colorScheme.onPrimary),
+        title: Text(
+          '${state.pendingCount} file${state.pendingCount == 1 ? '' : 's'} ready to upload',
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.onPrimary,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        subtitle: Text(
+          '$totalMb MB',
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.onPrimary.withOpacity(0.8),
+          ),
+        ),
+        trailing: Icon(Icons.chevron_right,
+            color: Theme.of(context).colorScheme.onPrimary),
+        onTap: () => context.push('/uploads'),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run tests + full suite**
+
+```bash
+flutter test test/features/upload/upload_banner_test.dart && flutter test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/upload/presentation/upload_banner.dart test/features/upload/upload_banner_test.dart
+git commit -m "feat(upload): add UploadBanner widget"
+```
+
+---
+
+## Task 13: UploadQueueScreen
+
+**Files:**
+- Create: `lib/features/upload/presentation/upload_queue_screen.dart`
+- Test: `test/features/upload/upload_queue_screen_test.dart`
+
+- [ ] **Step 1: Write the failing tests**
+
+```dart
+// test/features/upload/upload_queue_screen_test.dart
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_preferences.dart';
+import 'package:firecheck/core/drive/drive_upload_providers.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/drive/drive_upload_worker.dart';
+import 'package:firecheck/core/drive/fake_drive_upload_api.dart';
+import 'package:firecheck/core/security/secure_storage.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(List<Override> overrides) {
+  return ProviderScope(
+    overrides: overrides,
+    child: const MaterialApp(home: UploadQueueScreen()),
+  );
+}
+
+List<Override> _overrides(AppDatabase db, DriveUploadRepository repo) => [
+      driveUploadNotifierProvider.overrideWith(
+        (ref) => DriveUploadNotifier(
+          repo: repo,
+          worker: DriveUploadWorker(
+            api: FakeDriveUploadApi(), repo: repo, db: db, rootFolderId: 'r',
+          ),
+        ),
+      ),
+      driveUploadPreferencesProvider.overrideWithValue(
+        DriveUploadPreferences(InMemorySecureStorage()),
+      ),
+    ];
+
+void main() {
+  testWidgets('shows empty message when no pending files', (tester) async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+
+    await tester.pumpWidget(_wrap(_overrides(db, repo)));
+    await tester.pump();
+
+    expect(find.text('No pending uploads'), findsOneWidget);
+  });
+
+  testWidgets('shows file rows when jobs exist', (tester) async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    await repo.insertJob(
+      id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+      fileType: DriveUploadJobStatus.typePhoto, fileName: 'photo1.jpg',
+      fileSizeBytes: 2048, capturedAt: DateTime(2026),
+    );
+
+    await tester.pumpWidget(_wrap(_overrides(db, repo)));
+    await tester.pump();
+
+    expect(find.text('photo1.jpg'), findsOneWidget);
+    expect(find.textContaining('PENDING'), findsOneWidget);
+  });
+
+  testWidgets('Upload All button is present and enabled with pending jobs',
+      (tester) async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    await repo.insertJob(
+      id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+      fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+      fileSizeBytes: 100, capturedAt: DateTime(2026),
+    );
+
+    await tester.pumpWidget(_wrap(_overrides(db, repo)));
+    await tester.pump();
+
+    final btn = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+    expect(btn.onPressed, isNotNull);
+  });
+}
+```
+
+- [ ] **Step 2: Run test — expect compile error**
+
+```bash
+flutter test test/features/upload/upload_queue_screen_test.dart
+```
+
+- [ ] **Step 3: Implement UploadQueueScreen**
+
+```dart
+// lib/features/upload/presentation/upload_queue_screen.dart
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_preferences.dart';
+import 'package:firecheck/core/drive/drive_upload_providers.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class UploadQueueScreen extends ConsumerStatefulWidget {
+  const UploadQueueScreen({super.key});
+
+  @override
+  ConsumerState<UploadQueueScreen> createState() => _UploadQueueScreenState();
+}
+
+class _UploadQueueScreenState extends ConsumerState<UploadQueueScreen> {
+  bool _autoUpload = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPrefs();
+  }
+
+  Future<void> _loadPrefs() async {
+    final prefs = ref.read(driveUploadPreferencesProvider);
+    final val = await prefs.isAutoUploadEnabled();
+    if (mounted) setState(() => _autoUpload = val);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(driveUploadNotifierProvider);
+    final notifier = ref.read(driveUploadNotifierProvider.notifier);
+    final prefs = ref.read(driveUploadPreferencesProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Uploads')),
+      body: Column(
+        children: [
+          // Summary bar
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: [
+                Text(
+                  '${state.pendingCount} file${state.pendingCount == 1 ? '' : 's'}'
+                  ' · ${(state.totalPendingBytes / 1024 / 1024).toStringAsFixed(1)} MB',
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+                const Spacer(),
+                const Text('Auto-upload'),
+                const SizedBox(width: 8),
+                Switch(
+                  value: _autoUpload,
+                  onChanged: (val) async {
+                    await prefs.setAutoUploadEnabled(enabled: val);
+                    setState(() => _autoUpload = val);
+                  },
+                ),
+              ],
+            ),
+          ),
+
+          // Progress bar (shown while uploading)
+          if (state.isUploading)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Uploading… ${state.completedCount} of '
+                    '${state.jobs.length}',
+                    style: const TextStyle(color: Colors.blue),
+                  ),
+                  const SizedBox(height: 4),
+                  LinearProgressIndicator(
+                    value: state.jobs.isEmpty
+                        ? 0
+                        : state.completedCount / state.jobs.length,
+                  ),
+                  const SizedBox(height: 8),
+                ],
+              ),
+            ),
+
+          // File list
+          Expanded(
+            child: state.jobs.isEmpty
+                ? const Center(child: Text('No pending uploads'))
+                : ListView.separated(
+                    itemCount: state.jobs.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, i) {
+                      final job = state.jobs[i];
+                      return _JobTile(
+                        job: job,
+                        onRetry: () => notifier.retryJob(job.id),
+                      );
+                    },
+                  ),
+          ),
+
+          // Upload All button
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: state.isUploading || state.pendingCount == 0
+                    ? null
+                    : notifier.uploadAll,
+                child: const Text('Upload All'),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _JobTile extends StatelessWidget {
+  const _JobTile({required this.job, required this.onRetry});
+  final DriveUploadJob job;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final isFailed = job.status == DriveUploadJobStatus.failed ||
+        job.status == DriveUploadJobStatus.dead;
+    final icon = job.fileType == DriveUploadJobStatus.typePhoto
+        ? Icons.image
+        : Icons.folder_zip;
+
+    return ListTile(
+      leading: Icon(icon),
+      title: Text(job.fileName),
+      subtitle: isFailed
+          ? Text(
+              job.failureReason ?? 'Upload failed · Tap to retry',
+              style: const TextStyle(color: Colors.red, fontSize: 12),
+            )
+          : Text(
+              '${job.assignmentId} · ${(job.fileSizeBytes / 1024).toStringAsFixed(0)} KB',
+              style: const TextStyle(fontSize: 12),
+            ),
+      trailing: _statusChip(job.status),
+      onTap: isFailed ? onRetry : null,
+    );
+  }
+
+  Widget _statusChip(String status) {
+    final (label, color) = switch (status) {
+      DriveUploadJobStatus.pending => ('PENDING', Colors.grey),
+      DriveUploadJobStatus.uploading => ('UPLOADING', Colors.blue),
+      DriveUploadJobStatus.completed => ('✓ DONE', Colors.green),
+      DriveUploadJobStatus.failed || DriveUploadJobStatus.dead =>
+        ('FAILED', Colors.red),
+      _ => (status.toUpperCase(), Colors.grey),
+    };
+    return Text(
+      label,
+      style: TextStyle(
+        fontSize: 10,
+        fontWeight: FontWeight.bold,
+        color: color,
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run tests + full suite**
+
+```bash
+flutter test test/features/upload/upload_queue_screen_test.dart && flutter test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/upload/presentation/upload_queue_screen.dart test/features/upload/upload_queue_screen_test.dart
+git commit -m "feat(upload): add UploadQueueScreen with per-file status and Upload All"
+```
+
+---
+
+## Task 14: Router + HomeScreen integration
+
+**Files:**
+- Modify: `lib/core/router/app_router.dart`
+- Modify: `lib/features/home/presentation/home_screen.dart`
+- Test: `test/features/home/home_screen_upload_banner_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/home/home_screen_upload_banner_test.dart
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_providers.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/drive/drive_upload_worker.dart';
+import 'package:firecheck/core/drive/fake_drive_upload_api.dart';
+import 'package:firecheck/features/upload/presentation/upload_banner.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('HomeScreen shows UploadBanner when pending jobs exist',
+      (tester) async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    await repo.insertJob(
+      id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+      fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+      fileSizeBytes: 1024, capturedAt: DateTime(2026),
+    );
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        driveUploadNotifierProvider.overrideWith(
+          (ref) => DriveUploadNotifier(
+            repo: repo,
+            worker: DriveUploadWorker(
+              api: FakeDriveUploadApi(), repo: repo, db: db, rootFolderId: 'r',
+            ),
+          ),
+        ),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(body: UploadBanner()),
+      ),
+    ));
+    await tester.pump();
+
+    expect(find.textContaining('file'), findsAtLeastNWidgets(1));
+  });
+}
+```
+
+- [ ] **Step 2: Run test — expect PASS (UploadBanner already works)**
+
+```bash
+flutter test test/features/home/home_screen_upload_banner_test.dart
+```
+
+- [ ] **Step 3: Add /uploads route to app_router.dart**
+
+In `lib/core/router/app_router.dart`, add this import:
+
+```dart
+import 'package:firecheck/features/upload/presentation/upload_queue_screen.dart';
+```
+
+Inside the `routes` list, add after the `/review` route:
+
+```dart
+GoRoute(
+  path: '/uploads',
+  builder: (context, state) => const UploadQueueScreen(),
+),
+```
+
+- [ ] **Step 4: Add UploadBanner to HomeScreen**
+
+In `lib/features/home/presentation/home_screen.dart`, add this import:
+
+```dart
+import 'package:firecheck/features/upload/presentation/upload_banner.dart';
+```
+
+In the `Column` children inside `HomeScreen.build()`, add `const UploadBanner()` as the first child (before the progress card):
+
+Find:
+```dart
+children: [
+  if (lock is Submitted)
+    SubmittedBanner(submittedAt: lock.submittedAt)
+  else
+    Card(
+```
+
+Replace with:
+```dart
+children: [
+  const UploadBanner(),
+  const SizedBox(height: 8),
+  if (lock is Submitted)
+    SubmittedBanner(submittedAt: lock.submittedAt)
+  else
+    Card(
+```
+
+- [ ] **Step 5: Add DRIVE_UPLOAD_FOLDER_ID to .env**
+
+Open `.env` and add:
+
+```
+DRIVE_UPLOAD_FOLDER_ID=your_shared_drive_folder_id_here
+```
+
+Replace `your_shared_drive_folder_id_here` with the actual Drive folder ID for the shared organizational `/FieldData/` folder.
+
+- [ ] **Step 6: Run full suite**
+
+```bash
+flutter test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/core/router/app_router.dart lib/features/home/presentation/home_screen.dart test/features/home/home_screen_upload_banner_test.dart
+git commit -m "feat(upload): wire UploadBanner into HomeScreen and add /uploads route"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec requirement | Task |
+|---|---|
+| Wi-Fi detection, no cellular uploads | Task 8 (DriveUploadController Wi-Fi gate) |
+| Pending queue visibility (name, size, date, assignment) | Task 13 (_JobTile) |
+| Total count + size before upload | Task 13 (summary bar) |
+| Manual "Upload All" | Task 13 (ElevatedButton → notifier.uploadAll) |
+| Auto-upload on Wi-Fi toggle | Task 13 (Switch) + Task 7 (preferences) |
+| Per-file status chips | Task 13 (_statusChip) |
+| Overall progress indicator | Task 13 (LinearProgressIndicator) |
+| Background upload (WorkManager) | Task 9 |
+| Drive folder structure | Task 6 (_resolveParentFolder) |
+| Error handling / retry (3×) | Task 6 (_nextRetryAt, markDead) |
+| Dead jobs require manual retry | Task 2 (resetForRetry), Task 13 (onTap) |
+| Upload All resets failed, not dead | Task 2 (resetFailedToPending) |
+| Local files never deleted | No deletion code anywhere — confirmed |
+| Auth scope request | Task 10 (requestDriveUploadScope) |
+| Auth expiry re-auth flow | Not explicitly implemented; GoogleDriveUploadApi will throw AuthFailure which marks the job failed — the UI shows FAILED and user retries. Full re-auth prompt is a follow-up. |
+| Resumable uploads (>5 MB) | GoogleDriveUploadApi uses googleapis media upload; resumable URI persistence is a follow-up |
+| Queue survives app restart | Drift table persists — confirmed |
+| Shapefile generation at enqueue time | Task 5 (EnqueueAssignmentUseCase) |
+
+**Two items deferred (not in scope for this plan):**
+1. **Auth expiry snackbar with re-sign-in action** — failed jobs surface in UI; user can re-authenticate via the existing Google auth flow and tap retry.
+2. **Resumable URI persistence** — googleapis handles large files internally; explicit URI storage is a follow-up once the basic flow is verified.
+
+---
+
+## Execution Options
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-02-drive-bulk-upload.md`.
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks.
+
+**2. Inline Execution** — execute in this session using executing-plans with batch checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-02-drive-bulk-upload-design.md
+++ b/docs/superpowers/specs/2026-05-02-drive-bulk-upload-design.md
@@ -1,0 +1,199 @@
+# Drive Bulk Upload Design
+
+**Date:** 2026-05-02
+**Story:** US-29 — As an Enumerator, I want to upload my completed photos and shapefiles to Google Drive when I have a Wi-Fi connection, so that my supervisor can review them in one place.
+
+---
+
+## 1. Architecture
+
+Seven components in three layers:
+
+```
+UI Layer
+  HomeScreen (pending banner)  →  UploadQueueScreen
+
+Domain Layer
+  DriveUploadNotifier (Riverpod)
+  CompleteAssignmentUseCase       — triggers queue population on assignment completion
+
+Infrastructure Layer
+  DriveUploadRepository           — Drift CRUD over DriveUploadJobs table
+  DriveUploadWorker               — processes queue, retries, calls DriveApi
+  DriveUploadJobs (Drift table)   — persistent upload queue
+  DriveApi (extended)             — adds uploadFile() and createFolder()
+  ShapefileExporter (existing)    — called by CompleteAssignmentUseCase
+  connectivity_plus (existing)    — Wi-Fi detection
+  WorkManager (existing)          — periodic background tick
+```
+
+**Happy-path data flow:**
+
+1. Enumerator completes assignment → `CompleteAssignmentUseCase` calls `ShapefileExporter` to generate a ZIP, then writes one `DriveUploadJob` row per photo and one for the shapefile ZIP.
+2. `DriveUploadWorker` picks up `pending` jobs — triggered by Wi-Fi connect (if auto-upload is on) or manually via "Upload All".
+3. Worker calls `DriveApi.uploadFile()`. Files >5 MB use a resumable session; the session URI is stored in `resumable_uri` before streaming begins so interrupted uploads resume rather than restart.
+4. On success: `status = completed`, `drive_file_id` recorded, `resumable_uri` cleared.
+5. On transient failure: `retry_count` incremented, `next_retry_at` set, `status = failed`.
+6. After 3 failures: `status = dead`, `failure_reason` recorded.
+7. `DriveUploadNotifier` watches the table via Drift stream and updates UI in real time.
+
+---
+
+## 2. Data Model
+
+### `DriveUploadJobs` Drift table
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `TextColumn` | UUID primary key |
+| `assignment_id` | `TextColumn` | FK to Assignments |
+| `file_path` | `TextColumn` | Absolute path on device |
+| `file_type` | `TextColumn` | `photo` or `shapefile` |
+| `file_name` | `TextColumn` | Display name |
+| `file_size_bytes` | `IntColumn` | Used for queue summary |
+| `captured_at` | `DateTimeColumn` | Photo EXIF date or shapefile export time |
+| `status` | `TextColumn` | `pending` \| `uploading` \| `completed` \| `failed` \| `dead` |
+| `resumable_uri` | `TextColumn?` | Drive resumable upload session URI |
+| `drive_file_id` | `TextColumn?` | Drive file ID after success |
+| `retry_count` | `IntColumn` | Default 0 |
+| `failure_reason` | `TextColumn?` | Last error message |
+| `next_retry_at` | `DateTimeColumn?` | Null until first failure |
+| `created_at` | `DateTimeColumn` | When job was enqueued |
+
+### Drive folder structure
+
+```
+/FieldData/
+  {enumerator_id}/
+    {YYYY-MM-DD}/
+      photos/
+        {assignment_id}_{filename}.jpg
+      shapefiles/
+        {assignment_id}.zip
+```
+
+The root folder ID (`/FieldData/`) is stored in `.env` as `DRIVE_UPLOAD_FOLDER_ID`. Before each upload, the worker resolves subfolder IDs by querying Drive for existing folders with the expected name/parent; it creates them if missing. Resolved IDs are cached in memory for the lifetime of the worker run (not persisted — Drive API calls are cheap and idempotent).
+
+### Preferences
+
+Stored in `flutter_secure_storage`:
+- `drive_auto_upload_enabled` — `"true"` / `"false"`, default `"false"`
+
+---
+
+## 3. Upload Pipeline
+
+### `DriveUploadWorker`
+
+- Processes up to 3 concurrent uploads (matches `SyncWorker` limit).
+- On each run: fetches `pending` and `failed` jobs where `next_retry_at` is null or in the past, sorted oldest-first.
+- Per job: calls `DriveApi.uploadFile()`. Stores `resumable_uri` in the job row before streaming begins. On interruption, resumes from the stored URI on next run.
+- On success: `status = completed`, `drive_file_id` recorded.
+- On transient failure: `retry_count++`, `next_retry_at` set, `status = failed`.
+- After 3 failures: `status = dead`, `failure_reason` recorded.
+- On auth expiry (401): pauses queue (all `uploading` → `pending`), fires `DriveAuthExpired` event.
+
+**Retry schedule:** 30 s → 2 min → 10 min (matches `RetrySchedule` in existing sync engine).
+
+**Trigger sources:**
+1. **Wi-Fi connect** — `connectivity_plus` listener detects `ConnectivityResult.wifi`; starts worker if `drive_auto_upload_enabled = true`.
+2. **Manual** — "Upload All" button resets all `failed` jobs (not `dead`) to `pending` and starts worker. Per-item tap on any `FAILED` row (including `dead`) resets that job's `retry_count = 0` and `status = pending`.
+3. **WorkManager periodic tick** — runs every ~15 min in background; only proceeds if on Wi-Fi.
+
+### `DriveApi` additions
+
+```dart
+Future<String> createFolder(String name, String parentId);
+
+Future<String> uploadFile({
+  required String localPath,
+  required String driveParentId,
+  required String fileName,
+  String? resumableUri,
+  void Function(int sent, int total)? onProgress,
+});
+```
+
+`uploadFile` returns the Drive file ID on success. Files >5 MB use the Drive v3 resumable upload protocol. `resumableUri` is passed when resuming an interrupted upload.
+
+---
+
+## 4. UI
+
+### Home screen banner
+
+- Visible only when `DriveUploadJobs` has at least one non-completed job.
+- Shows: file count, total size, connectivity status (Wi-Fi / No Wi-Fi).
+- Tapping opens `UploadQueueScreen`.
+- Shows "No Wi-Fi" warning variant when offline.
+
+### Upload Queue screen
+
+**Summary bar (top):**
+- Total file count and size of non-completed jobs.
+- Auto-upload toggle (backed by `flutter_secure_storage`).
+
+**Progress bar (shown during active upload):**
+- "Uploading… 12 of 23" with percentage and filled bar.
+
+**File list:**
+- Each row: file icon (photo 🖼 / shapefile 📦), file name, assignment ID, size, capture date.
+- Status chip: `PENDING`, `UPLOADING`, `✓ DONE`, `FAILED`.
+- Both `failed` (auto-retry eligible) and `dead` (exhausted retries) jobs display as `FAILED`.
+- Failed rows show failure reason inline and are tappable to manually retry (resets `retry_count = 0`, `status = pending`).
+- "Upload All" resets only `failed` jobs (not `dead`). Dead jobs require an explicit per-item tap to retry.
+
+**"Upload All" button:**
+- Disabled when already uploading or no Wi-Fi is available.
+
+---
+
+## 5. Authentication
+
+**Scope:** Add `https://www.googleapis.com/auth/drive.file` to the `GoogleSignIn` scopes list. `drive.file` grants access only to files created by this app.
+
+**First-time consent:** If the enumerator hasn't granted Drive access before, `requestScopes()` triggers the OS consent dialog on the first upload attempt. This happens once; the session is persisted by `flutter_secure_storage`.
+
+**Re-auth flow:** On 401 from the Drive API:
+1. Worker pauses — all `uploading` jobs revert to `pending`.
+2. `DriveAuthExpired` event fires via a `StreamController`.
+3. UI shows snackbar: "Sign in again to resume uploads" with "Sign In" action.
+4. After successful re-auth, worker resumes automatically.
+
+---
+
+## 6. Error Handling
+
+| Failure type | Worker action | UI surface |
+|---|---|---|
+| Network drop mid-upload | Store `resumable_uri`, `status = failed`, schedule retry | `FAILED · Network dropped` |
+| Auth expired (401) | Pause queue, fire `DriveAuthExpired` | Snackbar + "Sign In" action |
+| File not found on disk | `status = dead`, `failure_reason = "File missing"` | `FAILED · File missing` |
+| Drive quota exceeded (403) | All pending jobs → `dead` | Banner: "Drive storage full" |
+| File >5 GB (Drive limit) | `status = dead` at enqueue time | `FAILED · File too large` |
+| Transient server error (5xx) | Retry up to 3×, then `dead` | `FAILED · Server error` |
+
+Local files are never deleted. The job row is what gets marked complete; the original file stays on device regardless of upload outcome.
+
+---
+
+## 7. Out of Scope
+
+- Real-time syncing during data collection
+- Editing or deleting files already uploaded to Drive
+- Supervisor review workflow
+- Cellular data uploads
+- Backfilling queue for assignments completed before this feature ships (separate migration story)
+
+---
+
+## 8. Definition of Done
+
+- All acceptance criteria pass on Android and iOS.
+- Tested with ≥50 mixed files (photos + shapefiles).
+- Tested under simulated Wi-Fi drop and reconnect.
+- Resumable upload verified: partial upload resumes rather than restarts after interruption.
+- Drive folder structure verified by supervisor account.
+- Auto-upload toggle persists across app restarts.
+- Re-auth flow tested with expired token.
+- Logging in place for all failure types.

--- a/lib/core/db/database.dart
+++ b/lib/core/db/database.dart
@@ -13,6 +13,7 @@ import 'package:firecheck/core/db/tables/photos.dart';
 import 'package:firecheck/core/db/tables/ra_9514_types.dart';
 import 'package:firecheck/core/db/tables/road_attributes.dart';
 import 'package:firecheck/core/db/tables/submissions.dart';
+import 'package:firecheck/core/db/tables/drive_upload_jobs.dart';
 import 'package:firecheck/core/db/tables/sync_jobs.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -33,6 +34,7 @@ part 'database.g.dart';
     Ra9514Types,
     SyncJobs,
     OfflineTilePacks,
+    DriveUploadJobs,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -42,7 +44,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 7;
+  int get schemaVersion => 8;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -85,6 +87,12 @@ class AppDatabase extends _$AppDatabase {
             // v6 → v7: drive_modified_time and drive_folder_id for US-17 Get Maps.
             await m.addColumn(assignments, assignments.driveModifiedTime);
             await m.addColumn(assignments, assignments.driveFolderId);
+          }
+          if (from < 8) {
+            // v7 → v8: drive_upload_jobs table for US-29 upload to Drive.
+            await m.createTable(driveUploadJobs);
+            await m.createIndex(driveUploadJobsStatusIdx);
+            await m.createIndex(driveUploadJobsAssignmentIdx);
           }
         },
         beforeOpen: (details) async {

--- a/lib/core/db/database.g.dart
+++ b/lib/core/db/database.g.dart
@@ -5447,6 +5447,707 @@ class OfflineTilePacksCompanion extends UpdateCompanion<OfflineTilePack> {
   }
 }
 
+class $DriveUploadJobsTable extends DriveUploadJobs
+    with TableInfo<$DriveUploadJobsTable, DriveUploadJob> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $DriveUploadJobsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+      'id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _assignmentIdMeta =
+      const VerificationMeta('assignmentId');
+  @override
+  late final GeneratedColumn<String> assignmentId = GeneratedColumn<String>(
+      'assignment_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _filePathMeta =
+      const VerificationMeta('filePath');
+  @override
+  late final GeneratedColumn<String> filePath = GeneratedColumn<String>(
+      'file_path', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _fileTypeMeta =
+      const VerificationMeta('fileType');
+  @override
+  late final GeneratedColumn<String> fileType = GeneratedColumn<String>(
+      'file_type', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _fileNameMeta =
+      const VerificationMeta('fileName');
+  @override
+  late final GeneratedColumn<String> fileName = GeneratedColumn<String>(
+      'file_name', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _fileSizeBytesMeta =
+      const VerificationMeta('fileSizeBytes');
+  @override
+  late final GeneratedColumn<int> fileSizeBytes = GeneratedColumn<int>(
+      'file_size_bytes', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _capturedAtMeta =
+      const VerificationMeta('capturedAt');
+  @override
+  late final GeneratedColumn<DateTime> capturedAt = GeneratedColumn<DateTime>(
+      'captured_at', aliasedName, false,
+      type: DriftSqlType.dateTime, requiredDuringInsert: true);
+  static const VerificationMeta _statusMeta = const VerificationMeta('status');
+  @override
+  late final GeneratedColumn<String> status = GeneratedColumn<String>(
+      'status', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('pending'));
+  static const VerificationMeta _resumableUriMeta =
+      const VerificationMeta('resumableUri');
+  @override
+  late final GeneratedColumn<String> resumableUri = GeneratedColumn<String>(
+      'resumable_uri', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _driveFileIdMeta =
+      const VerificationMeta('driveFileId');
+  @override
+  late final GeneratedColumn<String> driveFileId = GeneratedColumn<String>(
+      'drive_file_id', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _retryCountMeta =
+      const VerificationMeta('retryCount');
+  @override
+  late final GeneratedColumn<int> retryCount = GeneratedColumn<int>(
+      'retry_count', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(0));
+  static const VerificationMeta _failureReasonMeta =
+      const VerificationMeta('failureReason');
+  @override
+  late final GeneratedColumn<String> failureReason = GeneratedColumn<String>(
+      'failure_reason', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _nextRetryAtMeta =
+      const VerificationMeta('nextRetryAt');
+  @override
+  late final GeneratedColumn<DateTime> nextRetryAt = GeneratedColumn<DateTime>(
+      'next_retry_at', aliasedName, true,
+      type: DriftSqlType.dateTime, requiredDuringInsert: false);
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+      'created_at', aliasedName, false,
+      type: DriftSqlType.dateTime, requiredDuringInsert: true);
+  @override
+  List<GeneratedColumn> get $columns => [
+        id,
+        assignmentId,
+        filePath,
+        fileType,
+        fileName,
+        fileSizeBytes,
+        capturedAt,
+        status,
+        resumableUri,
+        driveFileId,
+        retryCount,
+        failureReason,
+        nextRetryAt,
+        createdAt
+      ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'drive_upload_jobs';
+  @override
+  VerificationContext validateIntegrity(Insertable<DriveUploadJob> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('assignment_id')) {
+      context.handle(
+          _assignmentIdMeta,
+          assignmentId.isAcceptableOrUnknown(
+              data['assignment_id']!, _assignmentIdMeta));
+    } else if (isInserting) {
+      context.missing(_assignmentIdMeta);
+    }
+    if (data.containsKey('file_path')) {
+      context.handle(_filePathMeta,
+          filePath.isAcceptableOrUnknown(data['file_path']!, _filePathMeta));
+    } else if (isInserting) {
+      context.missing(_filePathMeta);
+    }
+    if (data.containsKey('file_type')) {
+      context.handle(_fileTypeMeta,
+          fileType.isAcceptableOrUnknown(data['file_type']!, _fileTypeMeta));
+    } else if (isInserting) {
+      context.missing(_fileTypeMeta);
+    }
+    if (data.containsKey('file_name')) {
+      context.handle(_fileNameMeta,
+          fileName.isAcceptableOrUnknown(data['file_name']!, _fileNameMeta));
+    } else if (isInserting) {
+      context.missing(_fileNameMeta);
+    }
+    if (data.containsKey('file_size_bytes')) {
+      context.handle(
+          _fileSizeBytesMeta,
+          fileSizeBytes.isAcceptableOrUnknown(
+              data['file_size_bytes']!, _fileSizeBytesMeta));
+    } else if (isInserting) {
+      context.missing(_fileSizeBytesMeta);
+    }
+    if (data.containsKey('captured_at')) {
+      context.handle(
+          _capturedAtMeta,
+          capturedAt.isAcceptableOrUnknown(
+              data['captured_at']!, _capturedAtMeta));
+    } else if (isInserting) {
+      context.missing(_capturedAtMeta);
+    }
+    if (data.containsKey('status')) {
+      context.handle(_statusMeta,
+          status.isAcceptableOrUnknown(data['status']!, _statusMeta));
+    }
+    if (data.containsKey('resumable_uri')) {
+      context.handle(
+          _resumableUriMeta,
+          resumableUri.isAcceptableOrUnknown(
+              data['resumable_uri']!, _resumableUriMeta));
+    }
+    if (data.containsKey('drive_file_id')) {
+      context.handle(
+          _driveFileIdMeta,
+          driveFileId.isAcceptableOrUnknown(
+              data['drive_file_id']!, _driveFileIdMeta));
+    }
+    if (data.containsKey('retry_count')) {
+      context.handle(
+          _retryCountMeta,
+          retryCount.isAcceptableOrUnknown(
+              data['retry_count']!, _retryCountMeta));
+    }
+    if (data.containsKey('failure_reason')) {
+      context.handle(
+          _failureReasonMeta,
+          failureReason.isAcceptableOrUnknown(
+              data['failure_reason']!, _failureReasonMeta));
+    }
+    if (data.containsKey('next_retry_at')) {
+      context.handle(
+          _nextRetryAtMeta,
+          nextRetryAt.isAcceptableOrUnknown(
+              data['next_retry_at']!, _nextRetryAtMeta));
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  DriveUploadJob map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return DriveUploadJob(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}id'])!,
+      assignmentId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}assignment_id'])!,
+      filePath: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}file_path'])!,
+      fileType: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}file_type'])!,
+      fileName: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}file_name'])!,
+      fileSizeBytes: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}file_size_bytes'])!,
+      capturedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}captured_at'])!,
+      status: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}status'])!,
+      resumableUri: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}resumable_uri']),
+      driveFileId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}drive_file_id']),
+      retryCount: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}retry_count'])!,
+      failureReason: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}failure_reason']),
+      nextRetryAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}next_retry_at']),
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+    );
+  }
+
+  @override
+  $DriveUploadJobsTable createAlias(String alias) {
+    return $DriveUploadJobsTable(attachedDatabase, alias);
+  }
+}
+
+class DriveUploadJob extends DataClass implements Insertable<DriveUploadJob> {
+  final String id;
+  final String assignmentId;
+  final String filePath;
+  final String fileType;
+  final String fileName;
+  final int fileSizeBytes;
+  final DateTime capturedAt;
+  final String status;
+  final String? resumableUri;
+  final String? driveFileId;
+  final int retryCount;
+  final String? failureReason;
+  final DateTime? nextRetryAt;
+  final DateTime createdAt;
+  const DriveUploadJob(
+      {required this.id,
+      required this.assignmentId,
+      required this.filePath,
+      required this.fileType,
+      required this.fileName,
+      required this.fileSizeBytes,
+      required this.capturedAt,
+      required this.status,
+      this.resumableUri,
+      this.driveFileId,
+      required this.retryCount,
+      this.failureReason,
+      this.nextRetryAt,
+      required this.createdAt});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['assignment_id'] = Variable<String>(assignmentId);
+    map['file_path'] = Variable<String>(filePath);
+    map['file_type'] = Variable<String>(fileType);
+    map['file_name'] = Variable<String>(fileName);
+    map['file_size_bytes'] = Variable<int>(fileSizeBytes);
+    map['captured_at'] = Variable<DateTime>(capturedAt);
+    map['status'] = Variable<String>(status);
+    if (!nullToAbsent || resumableUri != null) {
+      map['resumable_uri'] = Variable<String>(resumableUri);
+    }
+    if (!nullToAbsent || driveFileId != null) {
+      map['drive_file_id'] = Variable<String>(driveFileId);
+    }
+    map['retry_count'] = Variable<int>(retryCount);
+    if (!nullToAbsent || failureReason != null) {
+      map['failure_reason'] = Variable<String>(failureReason);
+    }
+    if (!nullToAbsent || nextRetryAt != null) {
+      map['next_retry_at'] = Variable<DateTime>(nextRetryAt);
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    return map;
+  }
+
+  DriveUploadJobsCompanion toCompanion(bool nullToAbsent) {
+    return DriveUploadJobsCompanion(
+      id: Value(id),
+      assignmentId: Value(assignmentId),
+      filePath: Value(filePath),
+      fileType: Value(fileType),
+      fileName: Value(fileName),
+      fileSizeBytes: Value(fileSizeBytes),
+      capturedAt: Value(capturedAt),
+      status: Value(status),
+      resumableUri: resumableUri == null && nullToAbsent
+          ? const Value.absent()
+          : Value(resumableUri),
+      driveFileId: driveFileId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(driveFileId),
+      retryCount: Value(retryCount),
+      failureReason: failureReason == null && nullToAbsent
+          ? const Value.absent()
+          : Value(failureReason),
+      nextRetryAt: nextRetryAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(nextRetryAt),
+      createdAt: Value(createdAt),
+    );
+  }
+
+  factory DriveUploadJob.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return DriveUploadJob(
+      id: serializer.fromJson<String>(json['id']),
+      assignmentId: serializer.fromJson<String>(json['assignmentId']),
+      filePath: serializer.fromJson<String>(json['filePath']),
+      fileType: serializer.fromJson<String>(json['fileType']),
+      fileName: serializer.fromJson<String>(json['fileName']),
+      fileSizeBytes: serializer.fromJson<int>(json['fileSizeBytes']),
+      capturedAt: serializer.fromJson<DateTime>(json['capturedAt']),
+      status: serializer.fromJson<String>(json['status']),
+      resumableUri: serializer.fromJson<String?>(json['resumableUri']),
+      driveFileId: serializer.fromJson<String?>(json['driveFileId']),
+      retryCount: serializer.fromJson<int>(json['retryCount']),
+      failureReason: serializer.fromJson<String?>(json['failureReason']),
+      nextRetryAt: serializer.fromJson<DateTime?>(json['nextRetryAt']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'assignmentId': serializer.toJson<String>(assignmentId),
+      'filePath': serializer.toJson<String>(filePath),
+      'fileType': serializer.toJson<String>(fileType),
+      'fileName': serializer.toJson<String>(fileName),
+      'fileSizeBytes': serializer.toJson<int>(fileSizeBytes),
+      'capturedAt': serializer.toJson<DateTime>(capturedAt),
+      'status': serializer.toJson<String>(status),
+      'resumableUri': serializer.toJson<String?>(resumableUri),
+      'driveFileId': serializer.toJson<String?>(driveFileId),
+      'retryCount': serializer.toJson<int>(retryCount),
+      'failureReason': serializer.toJson<String?>(failureReason),
+      'nextRetryAt': serializer.toJson<DateTime?>(nextRetryAt),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+    };
+  }
+
+  DriveUploadJob copyWith(
+          {String? id,
+          String? assignmentId,
+          String? filePath,
+          String? fileType,
+          String? fileName,
+          int? fileSizeBytes,
+          DateTime? capturedAt,
+          String? status,
+          Value<String?> resumableUri = const Value.absent(),
+          Value<String?> driveFileId = const Value.absent(),
+          int? retryCount,
+          Value<String?> failureReason = const Value.absent(),
+          Value<DateTime?> nextRetryAt = const Value.absent(),
+          DateTime? createdAt}) =>
+      DriveUploadJob(
+        id: id ?? this.id,
+        assignmentId: assignmentId ?? this.assignmentId,
+        filePath: filePath ?? this.filePath,
+        fileType: fileType ?? this.fileType,
+        fileName: fileName ?? this.fileName,
+        fileSizeBytes: fileSizeBytes ?? this.fileSizeBytes,
+        capturedAt: capturedAt ?? this.capturedAt,
+        status: status ?? this.status,
+        resumableUri:
+            resumableUri.present ? resumableUri.value : this.resumableUri,
+        driveFileId: driveFileId.present ? driveFileId.value : this.driveFileId,
+        retryCount: retryCount ?? this.retryCount,
+        failureReason:
+            failureReason.present ? failureReason.value : this.failureReason,
+        nextRetryAt: nextRetryAt.present ? nextRetryAt.value : this.nextRetryAt,
+        createdAt: createdAt ?? this.createdAt,
+      );
+  DriveUploadJob copyWithCompanion(DriveUploadJobsCompanion data) {
+    return DriveUploadJob(
+      id: data.id.present ? data.id.value : this.id,
+      assignmentId: data.assignmentId.present
+          ? data.assignmentId.value
+          : this.assignmentId,
+      filePath: data.filePath.present ? data.filePath.value : this.filePath,
+      fileType: data.fileType.present ? data.fileType.value : this.fileType,
+      fileName: data.fileName.present ? data.fileName.value : this.fileName,
+      fileSizeBytes: data.fileSizeBytes.present
+          ? data.fileSizeBytes.value
+          : this.fileSizeBytes,
+      capturedAt:
+          data.capturedAt.present ? data.capturedAt.value : this.capturedAt,
+      status: data.status.present ? data.status.value : this.status,
+      resumableUri: data.resumableUri.present
+          ? data.resumableUri.value
+          : this.resumableUri,
+      driveFileId:
+          data.driveFileId.present ? data.driveFileId.value : this.driveFileId,
+      retryCount:
+          data.retryCount.present ? data.retryCount.value : this.retryCount,
+      failureReason: data.failureReason.present
+          ? data.failureReason.value
+          : this.failureReason,
+      nextRetryAt:
+          data.nextRetryAt.present ? data.nextRetryAt.value : this.nextRetryAt,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('DriveUploadJob(')
+          ..write('id: $id, ')
+          ..write('assignmentId: $assignmentId, ')
+          ..write('filePath: $filePath, ')
+          ..write('fileType: $fileType, ')
+          ..write('fileName: $fileName, ')
+          ..write('fileSizeBytes: $fileSizeBytes, ')
+          ..write('capturedAt: $capturedAt, ')
+          ..write('status: $status, ')
+          ..write('resumableUri: $resumableUri, ')
+          ..write('driveFileId: $driveFileId, ')
+          ..write('retryCount: $retryCount, ')
+          ..write('failureReason: $failureReason, ')
+          ..write('nextRetryAt: $nextRetryAt, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      id,
+      assignmentId,
+      filePath,
+      fileType,
+      fileName,
+      fileSizeBytes,
+      capturedAt,
+      status,
+      resumableUri,
+      driveFileId,
+      retryCount,
+      failureReason,
+      nextRetryAt,
+      createdAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is DriveUploadJob &&
+          other.id == this.id &&
+          other.assignmentId == this.assignmentId &&
+          other.filePath == this.filePath &&
+          other.fileType == this.fileType &&
+          other.fileName == this.fileName &&
+          other.fileSizeBytes == this.fileSizeBytes &&
+          other.capturedAt == this.capturedAt &&
+          other.status == this.status &&
+          other.resumableUri == this.resumableUri &&
+          other.driveFileId == this.driveFileId &&
+          other.retryCount == this.retryCount &&
+          other.failureReason == this.failureReason &&
+          other.nextRetryAt == this.nextRetryAt &&
+          other.createdAt == this.createdAt);
+}
+
+class DriveUploadJobsCompanion extends UpdateCompanion<DriveUploadJob> {
+  final Value<String> id;
+  final Value<String> assignmentId;
+  final Value<String> filePath;
+  final Value<String> fileType;
+  final Value<String> fileName;
+  final Value<int> fileSizeBytes;
+  final Value<DateTime> capturedAt;
+  final Value<String> status;
+  final Value<String?> resumableUri;
+  final Value<String?> driveFileId;
+  final Value<int> retryCount;
+  final Value<String?> failureReason;
+  final Value<DateTime?> nextRetryAt;
+  final Value<DateTime> createdAt;
+  final Value<int> rowid;
+  const DriveUploadJobsCompanion({
+    this.id = const Value.absent(),
+    this.assignmentId = const Value.absent(),
+    this.filePath = const Value.absent(),
+    this.fileType = const Value.absent(),
+    this.fileName = const Value.absent(),
+    this.fileSizeBytes = const Value.absent(),
+    this.capturedAt = const Value.absent(),
+    this.status = const Value.absent(),
+    this.resumableUri = const Value.absent(),
+    this.driveFileId = const Value.absent(),
+    this.retryCount = const Value.absent(),
+    this.failureReason = const Value.absent(),
+    this.nextRetryAt = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  DriveUploadJobsCompanion.insert({
+    required String id,
+    required String assignmentId,
+    required String filePath,
+    required String fileType,
+    required String fileName,
+    required int fileSizeBytes,
+    required DateTime capturedAt,
+    this.status = const Value.absent(),
+    this.resumableUri = const Value.absent(),
+    this.driveFileId = const Value.absent(),
+    this.retryCount = const Value.absent(),
+    this.failureReason = const Value.absent(),
+    this.nextRetryAt = const Value.absent(),
+    required DateTime createdAt,
+    this.rowid = const Value.absent(),
+  })  : id = Value(id),
+        assignmentId = Value(assignmentId),
+        filePath = Value(filePath),
+        fileType = Value(fileType),
+        fileName = Value(fileName),
+        fileSizeBytes = Value(fileSizeBytes),
+        capturedAt = Value(capturedAt),
+        createdAt = Value(createdAt);
+  static Insertable<DriveUploadJob> custom({
+    Expression<String>? id,
+    Expression<String>? assignmentId,
+    Expression<String>? filePath,
+    Expression<String>? fileType,
+    Expression<String>? fileName,
+    Expression<int>? fileSizeBytes,
+    Expression<DateTime>? capturedAt,
+    Expression<String>? status,
+    Expression<String>? resumableUri,
+    Expression<String>? driveFileId,
+    Expression<int>? retryCount,
+    Expression<String>? failureReason,
+    Expression<DateTime>? nextRetryAt,
+    Expression<DateTime>? createdAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (assignmentId != null) 'assignment_id': assignmentId,
+      if (filePath != null) 'file_path': filePath,
+      if (fileType != null) 'file_type': fileType,
+      if (fileName != null) 'file_name': fileName,
+      if (fileSizeBytes != null) 'file_size_bytes': fileSizeBytes,
+      if (capturedAt != null) 'captured_at': capturedAt,
+      if (status != null) 'status': status,
+      if (resumableUri != null) 'resumable_uri': resumableUri,
+      if (driveFileId != null) 'drive_file_id': driveFileId,
+      if (retryCount != null) 'retry_count': retryCount,
+      if (failureReason != null) 'failure_reason': failureReason,
+      if (nextRetryAt != null) 'next_retry_at': nextRetryAt,
+      if (createdAt != null) 'created_at': createdAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  DriveUploadJobsCompanion copyWith(
+      {Value<String>? id,
+      Value<String>? assignmentId,
+      Value<String>? filePath,
+      Value<String>? fileType,
+      Value<String>? fileName,
+      Value<int>? fileSizeBytes,
+      Value<DateTime>? capturedAt,
+      Value<String>? status,
+      Value<String?>? resumableUri,
+      Value<String?>? driveFileId,
+      Value<int>? retryCount,
+      Value<String?>? failureReason,
+      Value<DateTime?>? nextRetryAt,
+      Value<DateTime>? createdAt,
+      Value<int>? rowid}) {
+    return DriveUploadJobsCompanion(
+      id: id ?? this.id,
+      assignmentId: assignmentId ?? this.assignmentId,
+      filePath: filePath ?? this.filePath,
+      fileType: fileType ?? this.fileType,
+      fileName: fileName ?? this.fileName,
+      fileSizeBytes: fileSizeBytes ?? this.fileSizeBytes,
+      capturedAt: capturedAt ?? this.capturedAt,
+      status: status ?? this.status,
+      resumableUri: resumableUri ?? this.resumableUri,
+      driveFileId: driveFileId ?? this.driveFileId,
+      retryCount: retryCount ?? this.retryCount,
+      failureReason: failureReason ?? this.failureReason,
+      nextRetryAt: nextRetryAt ?? this.nextRetryAt,
+      createdAt: createdAt ?? this.createdAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (assignmentId.present) {
+      map['assignment_id'] = Variable<String>(assignmentId.value);
+    }
+    if (filePath.present) {
+      map['file_path'] = Variable<String>(filePath.value);
+    }
+    if (fileType.present) {
+      map['file_type'] = Variable<String>(fileType.value);
+    }
+    if (fileName.present) {
+      map['file_name'] = Variable<String>(fileName.value);
+    }
+    if (fileSizeBytes.present) {
+      map['file_size_bytes'] = Variable<int>(fileSizeBytes.value);
+    }
+    if (capturedAt.present) {
+      map['captured_at'] = Variable<DateTime>(capturedAt.value);
+    }
+    if (status.present) {
+      map['status'] = Variable<String>(status.value);
+    }
+    if (resumableUri.present) {
+      map['resumable_uri'] = Variable<String>(resumableUri.value);
+    }
+    if (driveFileId.present) {
+      map['drive_file_id'] = Variable<String>(driveFileId.value);
+    }
+    if (retryCount.present) {
+      map['retry_count'] = Variable<int>(retryCount.value);
+    }
+    if (failureReason.present) {
+      map['failure_reason'] = Variable<String>(failureReason.value);
+    }
+    if (nextRetryAt.present) {
+      map['next_retry_at'] = Variable<DateTime>(nextRetryAt.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('DriveUploadJobsCompanion(')
+          ..write('id: $id, ')
+          ..write('assignmentId: $assignmentId, ')
+          ..write('filePath: $filePath, ')
+          ..write('fileType: $fileType, ')
+          ..write('fileName: $fileName, ')
+          ..write('fileSizeBytes: $fileSizeBytes, ')
+          ..write('capturedAt: $capturedAt, ')
+          ..write('status: $status, ')
+          ..write('resumableUri: $resumableUri, ')
+          ..write('driveFileId: $driveFileId, ')
+          ..write('retryCount: $retryCount, ')
+          ..write('failureReason: $failureReason, ')
+          ..write('nextRetryAt: $nextRetryAt, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -5466,6 +6167,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $SyncJobsTable syncJobs = $SyncJobsTable(this);
   late final $OfflineTilePacksTable offlineTilePacks =
       $OfflineTilePacksTable(this);
+  late final $DriveUploadJobsTable driveUploadJobs =
+      $DriveUploadJobsTable(this);
   late final Index featuresAssignmentIdIdx = Index('features_assignment_id_idx',
       'CREATE INDEX features_assignment_id_idx ON features (assignment_id)');
   late final Index fgrFeatureIdIdx = Index('fgr_feature_id_idx',
@@ -5481,6 +6184,12 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       'CREATE INDEX photos_submission_id_idx ON photos (submission_id)');
   late final Index syncJobsStatusRetryIdx = Index('sync_jobs_status_retry_idx',
       'CREATE INDEX sync_jobs_status_retry_idx ON sync_jobs (status, next_retry_at)');
+  late final Index driveUploadJobsStatusIdx = Index(
+      'drive_upload_jobs_status_idx',
+      'CREATE INDEX drive_upload_jobs_status_idx ON drive_upload_jobs (status, next_retry_at)');
+  late final Index driveUploadJobsAssignmentIdx = Index(
+      'drive_upload_jobs_assignment_idx',
+      'CREATE INDEX drive_upload_jobs_assignment_idx ON drive_upload_jobs (assignment_id)');
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -5498,13 +6207,16 @@ abstract class _$AppDatabase extends GeneratedDatabase {
         ra9514Types,
         syncJobs,
         offlineTilePacks,
+        driveUploadJobs,
         featuresAssignmentIdIdx,
         fgrFeatureIdIdx,
         fgrSyncStatusIdx,
         submissionsFeatureIdIdx,
         buildingAttrsRa9514TypeIdx,
         photosSubmissionIdIdx,
-        syncJobsStatusRetryIdx
+        syncJobsStatusRetryIdx,
+        driveUploadJobsStatusIdx,
+        driveUploadJobsAssignmentIdx
       ];
 }
 
@@ -8141,6 +8853,319 @@ typedef $$OfflineTilePacksTableProcessedTableManager = ProcessedTableManager<
     ),
     OfflineTilePack,
     PrefetchHooks Function()>;
+typedef $$DriveUploadJobsTableCreateCompanionBuilder = DriveUploadJobsCompanion
+    Function({
+  required String id,
+  required String assignmentId,
+  required String filePath,
+  required String fileType,
+  required String fileName,
+  required int fileSizeBytes,
+  required DateTime capturedAt,
+  Value<String> status,
+  Value<String?> resumableUri,
+  Value<String?> driveFileId,
+  Value<int> retryCount,
+  Value<String?> failureReason,
+  Value<DateTime?> nextRetryAt,
+  required DateTime createdAt,
+  Value<int> rowid,
+});
+typedef $$DriveUploadJobsTableUpdateCompanionBuilder = DriveUploadJobsCompanion
+    Function({
+  Value<String> id,
+  Value<String> assignmentId,
+  Value<String> filePath,
+  Value<String> fileType,
+  Value<String> fileName,
+  Value<int> fileSizeBytes,
+  Value<DateTime> capturedAt,
+  Value<String> status,
+  Value<String?> resumableUri,
+  Value<String?> driveFileId,
+  Value<int> retryCount,
+  Value<String?> failureReason,
+  Value<DateTime?> nextRetryAt,
+  Value<DateTime> createdAt,
+  Value<int> rowid,
+});
+
+class $$DriveUploadJobsTableFilterComposer
+    extends Composer<_$AppDatabase, $DriveUploadJobsTable> {
+  $$DriveUploadJobsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get assignmentId => $composableBuilder(
+      column: $table.assignmentId, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get filePath => $composableBuilder(
+      column: $table.filePath, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get fileType => $composableBuilder(
+      column: $table.fileType, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get fileName => $composableBuilder(
+      column: $table.fileName, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get fileSizeBytes => $composableBuilder(
+      column: $table.fileSizeBytes, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get capturedAt => $composableBuilder(
+      column: $table.capturedAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get status => $composableBuilder(
+      column: $table.status, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get resumableUri => $composableBuilder(
+      column: $table.resumableUri, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get driveFileId => $composableBuilder(
+      column: $table.driveFileId, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get retryCount => $composableBuilder(
+      column: $table.retryCount, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get failureReason => $composableBuilder(
+      column: $table.failureReason, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get nextRetryAt => $composableBuilder(
+      column: $table.nextRetryAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+      column: $table.createdAt, builder: (column) => ColumnFilters(column));
+}
+
+class $$DriveUploadJobsTableOrderingComposer
+    extends Composer<_$AppDatabase, $DriveUploadJobsTable> {
+  $$DriveUploadJobsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get assignmentId => $composableBuilder(
+      column: $table.assignmentId,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get filePath => $composableBuilder(
+      column: $table.filePath, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get fileType => $composableBuilder(
+      column: $table.fileType, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get fileName => $composableBuilder(
+      column: $table.fileName, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get fileSizeBytes => $composableBuilder(
+      column: $table.fileSizeBytes,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get capturedAt => $composableBuilder(
+      column: $table.capturedAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get status => $composableBuilder(
+      column: $table.status, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get resumableUri => $composableBuilder(
+      column: $table.resumableUri,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get driveFileId => $composableBuilder(
+      column: $table.driveFileId, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get retryCount => $composableBuilder(
+      column: $table.retryCount, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get failureReason => $composableBuilder(
+      column: $table.failureReason,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get nextRetryAt => $composableBuilder(
+      column: $table.nextRetryAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+      column: $table.createdAt, builder: (column) => ColumnOrderings(column));
+}
+
+class $$DriveUploadJobsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $DriveUploadJobsTable> {
+  $$DriveUploadJobsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get assignmentId => $composableBuilder(
+      column: $table.assignmentId, builder: (column) => column);
+
+  GeneratedColumn<String> get filePath =>
+      $composableBuilder(column: $table.filePath, builder: (column) => column);
+
+  GeneratedColumn<String> get fileType =>
+      $composableBuilder(column: $table.fileType, builder: (column) => column);
+
+  GeneratedColumn<String> get fileName =>
+      $composableBuilder(column: $table.fileName, builder: (column) => column);
+
+  GeneratedColumn<int> get fileSizeBytes => $composableBuilder(
+      column: $table.fileSizeBytes, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get capturedAt => $composableBuilder(
+      column: $table.capturedAt, builder: (column) => column);
+
+  GeneratedColumn<String> get status =>
+      $composableBuilder(column: $table.status, builder: (column) => column);
+
+  GeneratedColumn<String> get resumableUri => $composableBuilder(
+      column: $table.resumableUri, builder: (column) => column);
+
+  GeneratedColumn<String> get driveFileId => $composableBuilder(
+      column: $table.driveFileId, builder: (column) => column);
+
+  GeneratedColumn<int> get retryCount => $composableBuilder(
+      column: $table.retryCount, builder: (column) => column);
+
+  GeneratedColumn<String> get failureReason => $composableBuilder(
+      column: $table.failureReason, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get nextRetryAt => $composableBuilder(
+      column: $table.nextRetryAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+}
+
+class $$DriveUploadJobsTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $DriveUploadJobsTable,
+    DriveUploadJob,
+    $$DriveUploadJobsTableFilterComposer,
+    $$DriveUploadJobsTableOrderingComposer,
+    $$DriveUploadJobsTableAnnotationComposer,
+    $$DriveUploadJobsTableCreateCompanionBuilder,
+    $$DriveUploadJobsTableUpdateCompanionBuilder,
+    (
+      DriveUploadJob,
+      BaseReferences<_$AppDatabase, $DriveUploadJobsTable, DriveUploadJob>
+    ),
+    DriveUploadJob,
+    PrefetchHooks Function()> {
+  $$DriveUploadJobsTableTableManager(
+      _$AppDatabase db, $DriveUploadJobsTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$DriveUploadJobsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$DriveUploadJobsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$DriveUploadJobsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback: ({
+            Value<String> id = const Value.absent(),
+            Value<String> assignmentId = const Value.absent(),
+            Value<String> filePath = const Value.absent(),
+            Value<String> fileType = const Value.absent(),
+            Value<String> fileName = const Value.absent(),
+            Value<int> fileSizeBytes = const Value.absent(),
+            Value<DateTime> capturedAt = const Value.absent(),
+            Value<String> status = const Value.absent(),
+            Value<String?> resumableUri = const Value.absent(),
+            Value<String?> driveFileId = const Value.absent(),
+            Value<int> retryCount = const Value.absent(),
+            Value<String?> failureReason = const Value.absent(),
+            Value<DateTime?> nextRetryAt = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              DriveUploadJobsCompanion(
+            id: id,
+            assignmentId: assignmentId,
+            filePath: filePath,
+            fileType: fileType,
+            fileName: fileName,
+            fileSizeBytes: fileSizeBytes,
+            capturedAt: capturedAt,
+            status: status,
+            resumableUri: resumableUri,
+            driveFileId: driveFileId,
+            retryCount: retryCount,
+            failureReason: failureReason,
+            nextRetryAt: nextRetryAt,
+            createdAt: createdAt,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String id,
+            required String assignmentId,
+            required String filePath,
+            required String fileType,
+            required String fileName,
+            required int fileSizeBytes,
+            required DateTime capturedAt,
+            Value<String> status = const Value.absent(),
+            Value<String?> resumableUri = const Value.absent(),
+            Value<String?> driveFileId = const Value.absent(),
+            Value<int> retryCount = const Value.absent(),
+            Value<String?> failureReason = const Value.absent(),
+            Value<DateTime?> nextRetryAt = const Value.absent(),
+            required DateTime createdAt,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              DriveUploadJobsCompanion.insert(
+            id: id,
+            assignmentId: assignmentId,
+            filePath: filePath,
+            fileType: fileType,
+            fileName: fileName,
+            fileSizeBytes: fileSizeBytes,
+            capturedAt: capturedAt,
+            status: status,
+            resumableUri: resumableUri,
+            driveFileId: driveFileId,
+            retryCount: retryCount,
+            failureReason: failureReason,
+            nextRetryAt: nextRetryAt,
+            createdAt: createdAt,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$DriveUploadJobsTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $DriveUploadJobsTable,
+    DriveUploadJob,
+    $$DriveUploadJobsTableFilterComposer,
+    $$DriveUploadJobsTableOrderingComposer,
+    $$DriveUploadJobsTableAnnotationComposer,
+    $$DriveUploadJobsTableCreateCompanionBuilder,
+    $$DriveUploadJobsTableUpdateCompanionBuilder,
+    (
+      DriveUploadJob,
+      BaseReferences<_$AppDatabase, $DriveUploadJobsTable, DriveUploadJob>
+    ),
+    DriveUploadJob,
+    PrefetchHooks Function()>;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -8170,4 +9195,6 @@ class $AppDatabaseManager {
       $$SyncJobsTableTableManager(_db, _db.syncJobs);
   $$OfflineTilePacksTableTableManager get offlineTilePacks =>
       $$OfflineTilePacksTableTableManager(_db, _db.offlineTilePacks);
+  $$DriveUploadJobsTableTableManager get driveUploadJobs =>
+      $$DriveUploadJobsTableTableManager(_db, _db.driveUploadJobs);
 }

--- a/lib/core/db/tables/drive_upload_jobs.dart
+++ b/lib/core/db/tables/drive_upload_jobs.dart
@@ -1,0 +1,24 @@
+import 'package:drift/drift.dart';
+
+@TableIndex(name: 'drive_upload_jobs_status_idx', columns: {#status, #nextRetryAt})
+@TableIndex(name: 'drive_upload_jobs_assignment_idx', columns: {#assignmentId})
+class DriveUploadJobs extends Table {
+  TextColumn get id => text()();
+  TextColumn get assignmentId => text()();
+  TextColumn get filePath => text()();
+  TextColumn get fileType => text()(); // 'photo' | 'shapefile'
+  TextColumn get fileName => text()();
+  IntColumn get fileSizeBytes => integer()();
+  DateTimeColumn get capturedAt => dateTime()();
+  TextColumn get status =>
+      text().withDefault(const Constant('pending'))(); // pending|uploading|completed|failed|dead
+  TextColumn get resumableUri => text().nullable()();
+  TextColumn get driveFileId => text().nullable()();
+  IntColumn get retryCount => integer().withDefault(const Constant(0))();
+  TextColumn get failureReason => text().nullable()();
+  DateTimeColumn get nextRetryAt => dateTime().nullable()();
+  DateTimeColumn get createdAt => dateTime()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/lib/core/drive/drive_upload_api.dart
+++ b/lib/core/drive/drive_upload_api.dart
@@ -5,7 +5,9 @@ abstract interface class DriveUploadApi {
   Future<String> createOrGetFolder(String name, String parentId);
 
   /// Uploads [localPath] into [driveParentId] and returns the Drive file ID.
-  /// Pass [resumableUri] to resume an interrupted large-file upload.
+  ///
+  /// [resumableUri] is reserved for future resumable upload support.
+  /// It is currently unused by [GoogleDriveUploadApi]; uploads restart on failure.
   Future<String> uploadFile({
     required String localPath,
     required String driveParentId,

--- a/lib/core/drive/drive_upload_api.dart
+++ b/lib/core/drive/drive_upload_api.dart
@@ -1,0 +1,16 @@
+/// Upload surface for Google Drive. Separate from the read-only DriveApi
+/// to keep download and upload concerns independent.
+abstract interface class DriveUploadApi {
+  /// Returns the Drive folder ID. Queries existing folder first; creates if absent.
+  Future<String> createOrGetFolder(String name, String parentId);
+
+  /// Uploads [localPath] into [driveParentId] and returns the Drive file ID.
+  /// Pass [resumableUri] to resume an interrupted large-file upload.
+  Future<String> uploadFile({
+    required String localPath,
+    required String driveParentId,
+    required String fileName,
+    String? resumableUri,
+    void Function(int sent, int total)? onProgress,
+  });
+}

--- a/lib/core/drive/drive_upload_controller.dart
+++ b/lib/core/drive/drive_upload_controller.dart
@@ -10,6 +10,9 @@ class DriveUploadController {
   })  : _onDrain = onDrain,
         _preferences = preferences,
         _connectivityStream = connectivityStream ??
+            // connectivity_plus 5.x emits a single ConnectivityResult per event.
+            // Wrap in a list to match the Stream<List<ConnectivityResult>> type.
+            // Remove this .map() when upgrading to 6.x (which emits natively).
             Connectivity()
                 .onConnectivityChanged
                 .map((r) => <ConnectivityResult>[r]);
@@ -20,11 +23,18 @@ class DriveUploadController {
   StreamSubscription<List<ConnectivityResult>>? _sub;
 
   Future<void> start() async {
+    await stop(); // cancel any existing subscription before creating a new one
     _sub = _connectivityStream.listen((results) async {
       final isWifi = results.any((r) => r == ConnectivityResult.wifi);
       if (!isWifi) return;
       final autoEnabled = await _preferences.isAutoUploadEnabled();
-      if (autoEnabled) await _onDrain();
+      if (autoEnabled) {
+        try {
+          await _onDrain();
+        } on Object catch (_) {
+          // drain errors are handled by the worker itself; don't kill this subscription
+        }
+      }
     });
   }
 

--- a/lib/core/drive/drive_upload_controller.dart
+++ b/lib/core/drive/drive_upload_controller.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:firecheck/core/drive/drive_upload_preferences.dart';
+
+class DriveUploadController {
+  DriveUploadController({
+    required Future<void> Function() onDrain,
+    required DriveUploadPreferences preferences,
+    Stream<List<ConnectivityResult>>? connectivityStream,
+  })  : _onDrain = onDrain,
+        _preferences = preferences,
+        _connectivityStream = connectivityStream ??
+            Connectivity()
+                .onConnectivityChanged
+                .map((r) => <ConnectivityResult>[r]);
+
+  final Future<void> Function() _onDrain;
+  final DriveUploadPreferences _preferences;
+  final Stream<List<ConnectivityResult>> _connectivityStream;
+  StreamSubscription<List<ConnectivityResult>>? _sub;
+
+  Future<void> start() async {
+    _sub = _connectivityStream.listen((results) async {
+      final isWifi = results.any((r) => r == ConnectivityResult.wifi);
+      if (!isWifi) return;
+      final autoEnabled = await _preferences.isAutoUploadEnabled();
+      if (autoEnabled) await _onDrain();
+    });
+  }
+
+  Future<void> triggerNow() => _onDrain();
+
+  Future<void> stop() async {
+    await _sub?.cancel();
+    _sub = null;
+  }
+}

--- a/lib/core/drive/drive_upload_job_status.dart
+++ b/lib/core/drive/drive_upload_job_status.dart
@@ -6,7 +6,11 @@ class DriveUploadJobStatus {
   static const completed = 'completed';
   static const failed = 'failed';
   static const dead = 'dead';
+}
 
-  static const typePhoto = 'photo';
-  static const typeShapefile = 'shapefile';
+class DriveFileType {
+  DriveFileType._();
+
+  static const photo = 'photo';
+  static const shapefile = 'shapefile';
 }

--- a/lib/core/drive/drive_upload_job_status.dart
+++ b/lib/core/drive/drive_upload_job_status.dart
@@ -1,0 +1,12 @@
+class DriveUploadJobStatus {
+  DriveUploadJobStatus._();
+
+  static const pending = 'pending';
+  static const uploading = 'uploading';
+  static const completed = 'completed';
+  static const failed = 'failed';
+  static const dead = 'dead';
+
+  static const typePhoto = 'photo';
+  static const typeShapefile = 'shapefile';
+}

--- a/lib/core/drive/drive_upload_preferences.dart
+++ b/lib/core/drive/drive_upload_preferences.dart
@@ -1,0 +1,16 @@
+import 'package:firecheck/core/security/secure_storage.dart';
+
+class DriveUploadPreferences {
+  DriveUploadPreferences(this._storage);
+  final SecureStorage _storage;
+
+  static const _keyAutoUpload = 'drive_auto_upload_enabled';
+
+  Future<bool> isAutoUploadEnabled() async {
+    final val = await _storage.read(_keyAutoUpload);
+    return val == 'true';
+  }
+
+  Future<void> setAutoUploadEnabled({required bool enabled}) =>
+      _storage.write(_keyAutoUpload, enabled ? 'true' : 'false');
+}

--- a/lib/core/drive/drive_upload_providers.dart
+++ b/lib/core/drive/drive_upload_providers.dart
@@ -1,8 +1,11 @@
 // lib/core/drive/drive_upload_providers.dart
+import 'package:firecheck/core/drive/drive_upload_controller.dart';
 import 'package:firecheck/core/drive/drive_upload_preferences.dart';
 import 'package:firecheck/core/drive/drive_upload_repository.dart';
 import 'package:firecheck/core/drive/drive_upload_worker.dart';
+import 'package:firecheck/core/drive/enqueue_assignment_use_case.dart';
 import 'package:firecheck/core/drive/google_drive_upload_api.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
 import 'package:firecheck/features/auth/presentation/auth_providers.dart';
 import 'package:firecheck/features/home/presentation/home_providers.dart';
 import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
@@ -40,5 +43,22 @@ final driveUploadNotifierProvider =
   return DriveUploadNotifier(
     repo: ref.watch(driveUploadRepoProvider),
     worker: ref.watch(driveUploadWorkerProvider),
+  );
+});
+
+final driveUploadControllerProvider = Provider<DriveUploadController>((ref) {
+  return DriveUploadController(
+    onDrain: () => ref.read(driveUploadWorkerProvider).drain(),
+    preferences: ref.watch(driveUploadPreferencesProvider),
+  );
+});
+
+final enqueueAssignmentUseCaseProvider =
+    Provider<EnqueueAssignmentUseCase>((ref) {
+  final db = ref.watch(appDatabaseProvider);
+  return EnqueueAssignmentUseCase(
+    db: db,
+    repo: ref.watch(driveUploadRepoProvider),
+    exporter: ShapefileExporter(db: db),
   );
 });

--- a/lib/core/drive/drive_upload_providers.dart
+++ b/lib/core/drive/drive_upload_providers.dart
@@ -1,0 +1,44 @@
+// lib/core/drive/drive_upload_providers.dart
+import 'package:firecheck/core/drive/drive_upload_preferences.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/drive/drive_upload_worker.dart';
+import 'package:firecheck/core/drive/google_drive_upload_api.dart';
+import 'package:firecheck/features/auth/presentation/auth_providers.dart';
+import 'package:firecheck/features/home/presentation/home_providers.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+/// Overridden in main.dart with a real GoogleSignIn instance.
+final googleSignInProvider = Provider<GoogleSignIn>((ref) {
+  throw UnimplementedError('Override googleSignInProvider in main.dart');
+});
+
+final driveUploadRepoProvider = Provider<DriveUploadRepository>((ref) {
+  return DriveUploadRepository(ref.watch(appDatabaseProvider));
+});
+
+final driveUploadWorkerProvider = Provider<DriveUploadWorker>((ref) {
+  final rootFolderId = dotenv.env['DRIVE_UPLOAD_FOLDER_ID'] ?? '';
+  return DriveUploadWorker(
+    api: GoogleDriveUploadApi(
+      googleSignIn: ref.watch(googleSignInProvider),
+    ),
+    repo: ref.watch(driveUploadRepoProvider),
+    db: ref.watch(appDatabaseProvider),
+    rootFolderId: rootFolderId,
+  );
+});
+
+final driveUploadPreferencesProvider = Provider<DriveUploadPreferences>((ref) {
+  return DriveUploadPreferences(ref.watch(secureStorageProvider));
+});
+
+final driveUploadNotifierProvider =
+    StateNotifierProvider<DriveUploadNotifier, DriveUploadState>((ref) {
+  return DriveUploadNotifier(
+    repo: ref.watch(driveUploadRepoProvider),
+    worker: ref.watch(driveUploadWorkerProvider),
+  );
+});

--- a/lib/core/drive/drive_upload_repository.dart
+++ b/lib/core/drive/drive_upload_repository.dart
@@ -133,7 +133,7 @@ class DriveUploadRepository {
     final row = await (_db.select(_db.driveUploadJobs)
           ..where((t) =>
               t.assignmentId.equals(assignmentId) &
-              t.fileType.equals(DriveUploadJobStatus.typeShapefile) &
+              t.fileType.equals(DriveFileType.shapefile) &
               t.status.isNotIn([DriveUploadJobStatus.completed]))
           ..limit(1))
         .getSingleOrNull();

--- a/lib/core/drive/drive_upload_repository.dart
+++ b/lib/core/drive/drive_upload_repository.dart
@@ -47,7 +47,13 @@ class DriveUploadRepository {
 
   Stream<List<DriveUploadJob>> watchQueue() {
     return (_db.select(_db.driveUploadJobs)
-          ..where((t) => t.status.isNotIn([DriveUploadJobStatus.completed]))
+          ..where((t) => t.status.isIn([
+                DriveUploadJobStatus.pending,
+                DriveUploadJobStatus.uploading,
+                DriveUploadJobStatus.failed,
+                DriveUploadJobStatus.dead,
+                DriveUploadJobStatus.completed,
+              ]))
           ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]))
         .watch();
   }
@@ -130,9 +136,7 @@ class DriveUploadRepository {
 
   Future<bool> jobExistsForFilePath(String filePath) async {
     final row = await (_db.select(_db.driveUploadJobs)
-          ..where((t) =>
-              t.filePath.equals(filePath) &
-              t.status.isNotIn([DriveUploadJobStatus.completed]))
+          ..where((t) => t.filePath.equals(filePath))
           ..limit(1))
         .getSingleOrNull();
     return row != null;
@@ -142,8 +146,7 @@ class DriveUploadRepository {
     final row = await (_db.select(_db.driveUploadJobs)
           ..where((t) =>
               t.assignmentId.equals(assignmentId) &
-              t.fileType.equals(DriveFileType.shapefile) &
-              t.status.isNotIn([DriveUploadJobStatus.completed]))
+              t.fileType.equals(DriveFileType.shapefile))
           ..limit(1))
         .getSingleOrNull();
     return row != null;

--- a/lib/core/drive/drive_upload_repository.dart
+++ b/lib/core/drive/drive_upload_repository.dart
@@ -110,6 +110,15 @@ class DriveUploadRepository {
     ));
   }
 
+  Future<void> resetStuckUploadingToPending() async {
+    await (_db.update(_db.driveUploadJobs)
+          ..where((t) => t.status.equals(DriveUploadJobStatus.uploading)))
+        .write(const DriveUploadJobsCompanion(
+      status: Value(DriveUploadJobStatus.pending),
+      nextRetryAt: Value(null),
+    ));
+  }
+
   Future<void> resetFailedToPending() async {
     await (_db.update(_db.driveUploadJobs)
           ..where((t) => t.status.equals(DriveUploadJobStatus.failed)))

--- a/lib/core/drive/drive_upload_repository.dart
+++ b/lib/core/drive/drive_upload_repository.dart
@@ -1,0 +1,142 @@
+import 'package:drift/drift.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+
+class DriveUploadRepository {
+  DriveUploadRepository(this._db);
+  final AppDatabase _db;
+
+  Future<void> insertJob({
+    required String id,
+    required String assignmentId,
+    required String filePath,
+    required String fileType,
+    required String fileName,
+    required int fileSizeBytes,
+    required DateTime capturedAt,
+  }) async {
+    await _db.into(_db.driveUploadJobs).insert(
+          DriveUploadJobsCompanion.insert(
+            id: id,
+            assignmentId: assignmentId,
+            filePath: filePath,
+            fileType: fileType,
+            fileName: fileName,
+            fileSizeBytes: fileSizeBytes,
+            capturedAt: capturedAt,
+            createdAt: DateTime.now(),
+          ),
+        );
+  }
+
+  Future<List<DriveUploadJob>> getPendingJobs({DateTime? now}) async {
+    final cutoff = now ?? DateTime.now();
+    return (_db.select(_db.driveUploadJobs)
+          ..where(
+            (t) =>
+                t.status.isIn([
+                  DriveUploadJobStatus.pending,
+                  DriveUploadJobStatus.failed,
+                ]) &
+                (t.nextRetryAt.isNull() |
+                    t.nextRetryAt.isSmallerOrEqualValue(cutoff)),
+          )
+          ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]))
+        .get();
+  }
+
+  Stream<List<DriveUploadJob>> watchQueue() {
+    return (_db.select(_db.driveUploadJobs)
+          ..where((t) => t.status.isNotIn([DriveUploadJobStatus.completed]))
+          ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]))
+        .watch();
+  }
+
+  Stream<int> watchPendingCount() {
+    return watchQueue().map((jobs) => jobs.length);
+  }
+
+  Future<void> markUploading(String id) async {
+    await (_db.update(_db.driveUploadJobs)..where((t) => t.id.equals(id)))
+        .write(const DriveUploadJobsCompanion(
+      status: Value(DriveUploadJobStatus.uploading),
+    ));
+  }
+
+  Future<void> markCompleted(String id, {required String driveFileId}) async {
+    await (_db.update(_db.driveUploadJobs)..where((t) => t.id.equals(id)))
+        .write(DriveUploadJobsCompanion(
+      status: const Value(DriveUploadJobStatus.completed),
+      driveFileId: Value(driveFileId),
+      resumableUri: const Value(null),
+    ));
+  }
+
+  Future<void> markFailed(
+    String id, {
+    required String reason,
+    required int retryCount,
+    required DateTime nextRetryAt,
+  }) async {
+    await (_db.update(_db.driveUploadJobs)..where((t) => t.id.equals(id)))
+        .write(DriveUploadJobsCompanion(
+      status: const Value(DriveUploadJobStatus.failed),
+      failureReason: Value(reason),
+      retryCount: Value(retryCount),
+      nextRetryAt: Value(nextRetryAt),
+    ));
+  }
+
+  Future<void> markDead(String id, {required String reason}) async {
+    await (_db.update(_db.driveUploadJobs)..where((t) => t.id.equals(id)))
+        .write(DriveUploadJobsCompanion(
+      status: const Value(DriveUploadJobStatus.dead),
+      failureReason: Value(reason),
+    ));
+  }
+
+  Future<void> setResumableUri(String id, String uri) async {
+    await (_db.update(_db.driveUploadJobs)..where((t) => t.id.equals(id)))
+        .write(DriveUploadJobsCompanion(resumableUri: Value(uri)));
+  }
+
+  Future<void> resetForRetry(String id) async {
+    await (_db.update(_db.driveUploadJobs)..where((t) => t.id.equals(id)))
+        .write(const DriveUploadJobsCompanion(
+      status: Value(DriveUploadJobStatus.pending),
+      retryCount: Value(0),
+      failureReason: Value(null),
+      nextRetryAt: Value(null),
+    ));
+  }
+
+  Future<void> resetFailedToPending() async {
+    await (_db.update(_db.driveUploadJobs)
+          ..where((t) => t.status.equals(DriveUploadJobStatus.failed)))
+        .write(const DriveUploadJobsCompanion(
+      status: Value(DriveUploadJobStatus.pending),
+      nextRetryAt: Value(null),
+    ));
+  }
+
+  Future<bool> jobExistsForFilePath(String filePath) async {
+    final row = await (_db.select(_db.driveUploadJobs)
+          ..where((t) =>
+              t.filePath.equals(filePath) &
+              t.status.isNotIn([DriveUploadJobStatus.completed]))
+          ..limit(1))
+        .getSingleOrNull();
+    return row != null;
+  }
+
+  Future<bool> shapefileJobExistsForAssignment(String assignmentId) async {
+    final row = await (_db.select(_db.driveUploadJobs)
+          ..where((t) =>
+              t.assignmentId.equals(assignmentId) &
+              t.fileType.equals(DriveUploadJobStatus.typeShapefile) &
+              t.status.isNotIn([DriveUploadJobStatus.completed]))
+          ..limit(1))
+        .getSingleOrNull();
+    return row != null;
+  }
+}

--- a/lib/core/drive/drive_upload_worker.dart
+++ b/lib/core/drive/drive_upload_worker.dart
@@ -1,0 +1,108 @@
+import 'dart:io';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_api.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:intl/intl.dart';
+
+class DriveUploadWorker {
+  DriveUploadWorker({
+    required this.api,
+    required this.repo,
+    required this.db,
+    required this.rootFolderId,
+  });
+
+  final DriveUploadApi api;
+  final DriveUploadRepository repo;
+  final AppDatabase db;
+  final String rootFolderId;
+
+  static const _maxConcurrent = 3;
+  bool _running = false;
+
+  // Session-scoped folder ID cache; not persisted across app restarts.
+  final _folderCache = <String, String>{};
+
+  Future<void> drain() async {
+    if (_running) return;
+    _running = true;
+    try {
+      while (true) {
+        final jobs = await repo.getPendingJobs();
+        if (jobs.isEmpty) return;
+        await Future.wait(jobs.take(_maxConcurrent).map(_processOne));
+      }
+    } finally {
+      _running = false;
+    }
+  }
+
+  Future<void> _processOne(DriveUploadJob job) async {
+    final file = File(job.filePath);
+    if (!file.existsSync()) {
+      await repo.markDead(job.id, reason: 'file missing: ${job.filePath}');
+      return;
+    }
+
+    await repo.markUploading(job.id);
+
+    try {
+      final parentId = await _resolveParentFolder(job);
+      final driveFileId = await api.uploadFile(
+        localPath: job.filePath,
+        driveParentId: parentId,
+        fileName: job.fileName,
+        resumableUri: job.resumableUri,
+      );
+      await repo.markCompleted(job.id, driveFileId: driveFileId);
+    } on Exception catch (e) {
+      final attempts = job.retryCount + 1;
+      final next = _nextRetryAt(attempts);
+      if (next == null) {
+        await repo.markDead(job.id, reason: e.toString());
+      } else {
+        await repo.markFailed(
+          job.id,
+          reason: e.toString(),
+          retryCount: attempts,
+          nextRetryAt: next,
+        );
+      }
+    }
+  }
+
+  Future<String> _resolveParentFolder(DriveUploadJob job) async {
+    final assignment = await (db.select(db.assignments)
+          ..where((t) => t.id.equals(job.assignmentId)))
+        .getSingle();
+    final enumeratorId = assignment.enumeratorId;
+    final dateKey = DateFormat('yyyy-MM-dd').format(job.capturedAt);
+    final subfolderName =
+        job.fileType == DriveFileType.photo ? 'photos' : 'shapefiles';
+
+    final cacheKey = '$enumeratorId/$dateKey/$subfolderName';
+    if (_folderCache.containsKey(cacheKey)) {
+      return _folderCache[cacheKey]!;
+    }
+
+    final enumeratorFolderId =
+        await api.createOrGetFolder(enumeratorId, rootFolderId);
+    final dateFolderId =
+        await api.createOrGetFolder(dateKey, enumeratorFolderId);
+    final subFolderId =
+        await api.createOrGetFolder(subfolderName, dateFolderId);
+
+    _folderCache[cacheKey] = subFolderId;
+    return subFolderId;
+  }
+
+  DateTime? _nextRetryAt(int attempts) {
+    final base = DateTime.now();
+    return switch (attempts) {
+      1 => base.add(const Duration(seconds: 30)),
+      2 => base.add(const Duration(minutes: 2)),
+      _ => null,
+    };
+  }
+}

--- a/lib/core/drive/drive_upload_worker.dart
+++ b/lib/core/drive/drive_upload_worker.dart
@@ -85,8 +85,20 @@ class DriveUploadWorker {
     final subfolderName =
         job.fileType == DriveFileType.photo ? 'photos' : 'shapefiles';
     final cacheKey = '$enumeratorId/$dateKey/$subfolderName';
-    return _folderCache[cacheKey] ??=
-        _createFolderHierarchy(enumeratorId, dateKey, subfolderName);
+    if (_folderCache.containsKey(cacheKey)) return _folderCache[cacheKey]!;
+    // Store only successful results; remove on failure so retries hit Drive again.
+    _folderCache[cacheKey] = _createFolderHierarchy(
+      enumeratorId,
+      dateKey,
+      subfolderName,
+    ).then(
+      (id) => id,
+      onError: (Object e, StackTrace s) {
+        _folderCache.remove(cacheKey);
+        return Future<String>.error(e, s);
+      },
+    );
+    return _folderCache[cacheKey]!;
   }
 
   Future<String> _createFolderHierarchy(

--- a/lib/core/drive/drive_upload_worker.dart
+++ b/lib/core/drive/drive_upload_worker.dart
@@ -19,15 +19,19 @@ class DriveUploadWorker {
   final String rootFolderId;
 
   static const _maxConcurrent = 3;
+  // NOTE: This guard is not isolate-safe. Background WorkManager isolates
+  // have their own instance of this worker. resetStuckUploadingToPending()
+  // in drain() provides the actual safety net against duplicate processing.
   bool _running = false;
 
   // Session-scoped folder ID cache; not persisted across app restarts.
-  final _folderCache = <String, String>{};
+  final _folderCache = <String, Future<String>>{};
 
   Future<void> drain() async {
     if (_running) return;
     _running = true;
     try {
+      await repo.resetStuckUploadingToPending();
       while (true) {
         final jobs = await repo.getPendingJobs();
         if (jobs.isEmpty) return;
@@ -56,7 +60,7 @@ class DriveUploadWorker {
         resumableUri: job.resumableUri,
       );
       await repo.markCompleted(job.id, driveFileId: driveFileId);
-    } on Exception catch (e) {
+    } on Object catch (e) {
       final attempts = job.retryCount + 1;
       final next = _nextRetryAt(attempts);
       if (next == null) {
@@ -80,21 +84,21 @@ class DriveUploadWorker {
     final dateKey = DateFormat('yyyy-MM-dd').format(job.capturedAt);
     final subfolderName =
         job.fileType == DriveFileType.photo ? 'photos' : 'shapefiles';
-
     final cacheKey = '$enumeratorId/$dateKey/$subfolderName';
-    if (_folderCache.containsKey(cacheKey)) {
-      return _folderCache[cacheKey]!;
-    }
+    return _folderCache[cacheKey] ??=
+        _createFolderHierarchy(enumeratorId, dateKey, subfolderName);
+  }
 
+  Future<String> _createFolderHierarchy(
+    String enumeratorId,
+    String dateKey,
+    String subfolderName,
+  ) async {
     final enumeratorFolderId =
         await api.createOrGetFolder(enumeratorId, rootFolderId);
     final dateFolderId =
         await api.createOrGetFolder(dateKey, enumeratorFolderId);
-    final subFolderId =
-        await api.createOrGetFolder(subfolderName, dateFolderId);
-
-    _folderCache[cacheKey] = subFolderId;
-    return subFolderId;
+    return api.createOrGetFolder(subfolderName, dateFolderId);
   }
 
   DateTime? _nextRetryAt(int attempts) {
@@ -102,6 +106,7 @@ class DriveUploadWorker {
     return switch (attempts) {
       1 => base.add(const Duration(seconds: 30)),
       2 => base.add(const Duration(minutes: 2)),
+      3 => base.add(const Duration(minutes: 10)),
       _ => null,
     };
   }

--- a/lib/core/drive/drive_upload_workmanager.dart
+++ b/lib/core/drive/drive_upload_workmanager.dart
@@ -5,6 +5,7 @@ import 'package:firecheck/core/db/database.dart';
 import 'package:firecheck/core/drive/drive_upload_repository.dart';
 import 'package:firecheck/core/drive/drive_upload_worker.dart';
 import 'package:firecheck/core/drive/google_drive_upload_api.dart';
+import 'package:firecheck/features/auth/data/google_auth_repository.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:workmanager/workmanager.dart';
@@ -26,7 +27,9 @@ void driveUploadCallbackDispatcher() {
       // Opens the real on-disk Drift database in this background isolate.
       final db = AppDatabase();
       final signIn = GoogleSignIn(
-        scopes: ['https://www.googleapis.com/auth/drive.file'],
+        scopes: [GoogleAuthRepository.driveFileScope],
+        // Background isolate constructs a fresh GoogleSignIn — clientId is read
+        // automatically from GoogleService-Info.plist / google-services.json.
       );
       final uploadApi = GoogleDriveUploadApi(googleSignIn: signIn);
       final repo = DriveUploadRepository(db);

--- a/lib/core/drive/drive_upload_workmanager.dart
+++ b/lib/core/drive/drive_upload_workmanager.dart
@@ -31,6 +31,12 @@ void driveUploadCallbackDispatcher() {
         // Background isolate constructs a fresh GoogleSignIn — clientId is read
         // automatically from GoogleService-Info.plist / google-services.json.
       );
+
+      // Bail out if there is no active session — the foreground app will handle
+      // the upload once the user signs in again.
+      final account = await signIn.signInSilently();
+      if (account == null) return true;
+
       final uploadApi = GoogleDriveUploadApi(googleSignIn: signIn);
       final repo = DriveUploadRepository(db);
       final worker = DriveUploadWorker(

--- a/lib/core/drive/drive_upload_workmanager.dart
+++ b/lib/core/drive/drive_upload_workmanager.dart
@@ -4,10 +4,9 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:firecheck/core/db/database.dart';
 import 'package:firecheck/core/drive/drive_upload_repository.dart';
 import 'package:firecheck/core/drive/drive_upload_worker.dart';
-import 'package:firecheck/core/drive/fake_drive_upload_api.dart';
-// TODO(task-10): replace FakeDriveUploadApi with GoogleDriveUploadApi once
-// lib/core/drive/google_drive_upload_api.dart is implemented.
+import 'package:firecheck/core/drive/google_drive_upload_api.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 import 'package:workmanager/workmanager.dart';
 
 const _periodicTaskName = 'firecheck.drive_upload.periodic';
@@ -26,9 +25,10 @@ void driveUploadCallbackDispatcher() {
 
       // Opens the real on-disk Drift database in this background isolate.
       final db = AppDatabase();
-      // TODO(task-10): replace with GoogleDriveUploadApi(googleSignIn: signIn)
-      // once the real upload API is implemented.
-      final uploadApi = FakeDriveUploadApi();
+      final signIn = GoogleSignIn(
+        scopes: ['https://www.googleapis.com/auth/drive.file'],
+      );
+      final uploadApi = GoogleDriveUploadApi(googleSignIn: signIn);
       final repo = DriveUploadRepository(db);
       final worker = DriveUploadWorker(
         api: uploadApi,

--- a/lib/core/drive/drive_upload_workmanager.dart
+++ b/lib/core/drive/drive_upload_workmanager.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/drive/drive_upload_worker.dart';
+import 'package:firecheck/core/drive/fake_drive_upload_api.dart';
+// TODO(task-10): replace FakeDriveUploadApi with GoogleDriveUploadApi once
+// lib/core/drive/google_drive_upload_api.dart is implemented.
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:workmanager/workmanager.dart';
+
+const _periodicTaskName = 'firecheck.drive_upload.periodic';
+
+@pragma('vm:entry-point')
+void driveUploadCallbackDispatcher() {
+  Workmanager().executeTask((task, inputData) async {
+    try {
+      // Only proceed if Wi-Fi is available.
+      final connectivity = await Connectivity().checkConnectivity();
+      if (connectivity != ConnectivityResult.wifi) return true;
+
+      await dotenv.load();
+      final rootFolderId = dotenv.env['DRIVE_UPLOAD_FOLDER_ID'] ?? '';
+      if (rootFolderId.isEmpty) return false;
+
+      // Opens the real on-disk Drift database in this background isolate.
+      final db = AppDatabase();
+      // TODO(task-10): replace with GoogleDriveUploadApi(googleSignIn: signIn)
+      // once the real upload API is implemented.
+      final uploadApi = FakeDriveUploadApi();
+      final repo = DriveUploadRepository(db);
+      final worker = DriveUploadWorker(
+        api: uploadApi,
+        repo: repo,
+        db: db,
+        rootFolderId: rootFolderId,
+      );
+      await worker.drain();
+      await db.close();
+      return true;
+    } on Object {
+      return false;
+    }
+  });
+}
+
+Future<void> registerPeriodicDriveUpload() async {
+  await Workmanager().initialize(driveUploadCallbackDispatcher);
+  await Workmanager().registerPeriodicTask(
+    _periodicTaskName,
+    'firecheck.drive_upload',
+    frequency: const Duration(minutes: 15),
+    constraints: Constraints(networkType: NetworkType.connected),
+  );
+}
+
+Future<void> cancelPeriodicDriveUpload() async {
+  await Workmanager().cancelByUniqueName(_periodicTaskName);
+}

--- a/lib/core/drive/enqueue_assignment_use_case.dart
+++ b/lib/core/drive/enqueue_assignment_use_case.dart
@@ -1,8 +1,11 @@
 import 'dart:io';
+import 'package:drift/drift.dart';
 import 'package:firecheck/core/db/database.dart';
 import 'package:firecheck/core/drive/drive_upload_job_status.dart';
 import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
 import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
+import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
 
 class EnqueueAssignmentUseCase {
@@ -29,15 +32,20 @@ class EnqueueAssignmentUseCase {
     if (!shapefileExists) {
       final (failure, zipPath) =
           await _exporter.exportToFile(assignmentId: assignmentId);
-      if (failure == null && zipPath != null) {
+      if (failure != null) {
+        // NoCompletedFeatures is fine — nothing to export
+        if (failure is! NoCompletedFeatures) {
+          throw Exception('Shapefile export failed: $failure');
+        }
+      } else if (zipPath != null) {
         final file = File(zipPath);
-        final size = file.existsSync() ? await file.length() : 0;
+        final size = await file.exists() ? await file.length() : 0;
         await _repo.insertJob(
           id: _uuid.v4(),
           assignmentId: assignmentId,
           filePath: zipPath,
           fileType: DriveFileType.shapefile,
-          fileName: zipPath.split('/').last,
+          fileName: p.basename(zipPath),
           fileSizeBytes: size,
           capturedAt: DateTime.now(),
         );
@@ -51,13 +59,13 @@ class EnqueueAssignmentUseCase {
       final exists = await _repo.jobExistsForFilePath(photo.localPath);
       if (exists) continue;
       final file = File(photo.localPath);
-      final size = file.existsSync() ? await file.length() : 0;
+      final size = await file.exists() ? await file.length() : 0;
       await _repo.insertJob(
         id: _uuid.v4(),
         assignmentId: assignmentId,
         filePath: photo.localPath,
         fileType: DriveFileType.photo,
-        fileName: photo.localPath.split('/').last,
+        fileName: p.basename(photo.localPath),
         fileSizeBytes: size,
         capturedAt: photo.capturedAt,
       );
@@ -68,9 +76,13 @@ class EnqueueAssignmentUseCase {
   }
 
   Future<List<Photo>> _photosForAssignment(String assignmentId) async {
-    final featureIds = await (_db.selectOnly(_db.features)
-          ..addColumns([_db.features.id])
-          ..where(_db.features.assignmentId.equals(assignmentId)))
+    final featureQuery = _db.selectOnly(_db.features)
+      ..addColumns([_db.features.id])
+      ..where(
+        _db.features.assignmentId.equals(assignmentId) &
+            _db.features.status.equals('complete'),
+      );
+    final featureIds = await featureQuery
         .map((row) => row.read(_db.features.id)!)
         .get();
 

--- a/lib/core/drive/enqueue_assignment_use_case.dart
+++ b/lib/core/drive/enqueue_assignment_use_case.dart
@@ -1,0 +1,91 @@
+import 'dart:io';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
+import 'package:uuid/uuid.dart';
+
+class EnqueueAssignmentUseCase {
+  EnqueueAssignmentUseCase({
+    required AppDatabase db,
+    required DriveUploadRepository repo,
+    required ShapefileExporter exporter,
+  })  : _db = db,
+        _repo = repo,
+        _exporter = exporter;
+
+  final AppDatabase _db;
+  final DriveUploadRepository _repo;
+  final ShapefileExporter _exporter;
+  static const _uuid = Uuid();
+
+  /// Returns the number of new jobs created (0 if already fully enqueued).
+  Future<int> execute({required String assignmentId}) async {
+    var created = 0;
+
+    // ── Shapefile ────────────────────────────────────────────────────────────
+    final shapefileExists =
+        await _repo.shapefileJobExistsForAssignment(assignmentId);
+    if (!shapefileExists) {
+      final (failure, zipPath) =
+          await _exporter.exportToFile(assignmentId: assignmentId);
+      if (failure == null && zipPath != null) {
+        final file = File(zipPath);
+        final size = file.existsSync() ? await file.length() : 0;
+        await _repo.insertJob(
+          id: _uuid.v4(),
+          assignmentId: assignmentId,
+          filePath: zipPath,
+          fileType: DriveFileType.shapefile,
+          fileName: zipPath.split('/').last,
+          fileSizeBytes: size,
+          capturedAt: DateTime.now(),
+        );
+        created++;
+      }
+    }
+
+    // ── Photos ───────────────────────────────────────────────────────────────
+    final photos = await _photosForAssignment(assignmentId);
+    for (final photo in photos) {
+      final exists = await _repo.jobExistsForFilePath(photo.localPath);
+      if (exists) continue;
+      final file = File(photo.localPath);
+      final size = file.existsSync() ? await file.length() : 0;
+      await _repo.insertJob(
+        id: _uuid.v4(),
+        assignmentId: assignmentId,
+        filePath: photo.localPath,
+        fileType: DriveFileType.photo,
+        fileName: photo.localPath.split('/').last,
+        fileSizeBytes: size,
+        capturedAt: photo.capturedAt,
+      );
+      created++;
+    }
+
+    return created;
+  }
+
+  Future<List<Photo>> _photosForAssignment(String assignmentId) async {
+    final featureIds = await (_db.selectOnly(_db.features)
+          ..addColumns([_db.features.id])
+          ..where(_db.features.assignmentId.equals(assignmentId)))
+        .map((row) => row.read(_db.features.id)!)
+        .get();
+
+    if (featureIds.isEmpty) return [];
+
+    final submissionIds = await (_db.selectOnly(_db.submissions)
+          ..addColumns([_db.submissions.id])
+          ..where(_db.submissions.featureId.isIn(featureIds)))
+        .map((row) => row.read(_db.submissions.id)!)
+        .get();
+
+    if (submissionIds.isEmpty) return [];
+
+    return (_db.select(_db.photos)
+          ..where((t) => t.submissionId.isIn(submissionIds)))
+        .get();
+  }
+}

--- a/lib/core/drive/enqueue_assignment_use_case.dart
+++ b/lib/core/drive/enqueue_assignment_use_case.dart
@@ -33,9 +33,11 @@ class EnqueueAssignmentUseCase {
       final (failure, zipPath) =
           await _exporter.exportToFile(assignmentId: assignmentId);
       if (failure != null) {
-        // NoCompletedFeatures is fine — nothing to export
-        if (failure is! NoCompletedFeatures) {
-          throw Exception('Shapefile export failed: $failure');
+        if (failure is NoCompletedFeatures) {
+          // No field data yet — nothing to export, continue with photos.
+        } else {
+          // Export failed; skip shapefile and continue with photos.
+          // The failure will surface in the next export attempt.
         }
       } else if (zipPath != null) {
         final file = File(zipPath);

--- a/lib/core/drive/fake_drive_upload_api.dart
+++ b/lib/core/drive/fake_drive_upload_api.dart
@@ -1,0 +1,37 @@
+import 'package:firecheck/core/drive/drive_upload_api.dart';
+
+class FakeDriveUploadApi implements DriveUploadApi {
+  FakeDriveUploadApi({
+    this.throwOnUpload = false,
+    this.throwOnFolder = false,
+  });
+
+  final bool throwOnUpload;
+  final bool throwOnFolder;
+
+  final List<String> uploadedPaths = [];
+  final Map<String, String> _folderIds = {};
+  int _fileCounter = 0;
+
+  @override
+  Future<String> createOrGetFolder(String name, String parentId) async {
+    if (throwOnFolder) throw Exception('folder creation failed');
+    final key = '$parentId/$name';
+    return _folderIds[key] ??= 'folder-${_folderIds.length + 1}';
+  }
+
+  @override
+  Future<String> uploadFile({
+    required String localPath,
+    required String driveParentId,
+    required String fileName,
+    String? resumableUri,
+    void Function(int sent, int total)? onProgress,
+  }) async {
+    if (throwOnUpload) throw Exception('upload failed');
+    uploadedPaths.add(localPath);
+    _fileCounter++;
+    onProgress?.call(100, 100);
+    return 'drive-file-$_fileCounter';
+  }
+}

--- a/lib/core/drive/google_drive_upload_api.dart
+++ b/lib/core/drive/google_drive_upload_api.dart
@@ -30,9 +30,9 @@ class GoogleDriveUploadApi implements DriveUploadApi {
       spaces: 'drive',
       $fields: 'files(id)',
     );
-    if (existing.files?.isNotEmpty == true) {
-      return existing.files!.first.id!;
-    }
+    final existingId = existing.files?.firstOrNull?.id;
+    if (existingId != null) return existingId;
+
     final folder = await api.files.create(
       gdrive.File()
         ..name = name
@@ -40,7 +40,11 @@ class GoogleDriveUploadApi implements DriveUploadApi {
         ..parents = [parentId],
       $fields: 'id',
     );
-    return folder.id!;
+    final folderId = folder.id;
+    if (folderId == null) {
+      throw AuthFailure('Drive did not return id for created folder: $name');
+    }
+    return folderId;
   }
 
   @override
@@ -54,9 +58,12 @@ class GoogleDriveUploadApi implements DriveUploadApi {
     final api = await _api();
     final file = File(localPath);
     final fileSize = await file.length();
-    final mimeType = fileName.toLowerCase().endsWith('.jpg')
+    final lower = fileName.toLowerCase();
+    final mimeType = (lower.endsWith('.jpg') || lower.endsWith('.jpeg'))
         ? 'image/jpeg'
-        : 'application/zip';
+        : lower.endsWith('.png')
+            ? 'image/png'
+            : 'application/zip';
 
     final media = gdrive.Media(
       file.openRead(),
@@ -72,7 +79,13 @@ class GoogleDriveUploadApi implements DriveUploadApi {
       uploadMedia: media,
       $fields: 'id',
     );
+    final fileId = created.id;
+    if (fileId == null) {
+      throw AuthFailure('Drive did not return id for uploaded file: $fileName');
+    }
+    // googleapis does not expose a progress stream for media uploads;
+    // onProgress fires once on completion.
     onProgress?.call(fileSize, fileSize);
-    return created.id!;
+    return fileId;
   }
 }

--- a/lib/core/drive/google_drive_upload_api.dart
+++ b/lib/core/drive/google_drive_upload_api.dart
@@ -22,10 +22,13 @@ class GoogleDriveUploadApi implements DriveUploadApi {
   @override
   Future<String> createOrGetFolder(String name, String parentId) async {
     final api = await _api();
+    final escapedName = name.replaceAll(r'\', r'\\').replaceAll("'", r"\'");
+    final escapedParent =
+        parentId.replaceAll(r'\', r'\\').replaceAll("'", r"\'");
     final existing = await api.files.list(
-      q: "name = '$name' "
+      q: "name = '$escapedName' "
           "and mimeType = 'application/vnd.google-apps.folder' "
-          "and '$parentId' in parents "
+          "and '$escapedParent' in parents "
           "and trashed = false",
       spaces: 'drive',
       $fields: 'files(id)',
@@ -52,6 +55,9 @@ class GoogleDriveUploadApi implements DriveUploadApi {
     required String localPath,
     required String driveParentId,
     required String fileName,
+    // resumableUri is accepted for interface compatibility but is currently
+    // ignored — the googleapis client does not expose a resumable-URI handle
+    // in its response, so uploads always restart from the beginning on failure.
     String? resumableUri,
     void Function(int sent, int total)? onProgress,
   }) async {

--- a/lib/core/drive/google_drive_upload_api.dart
+++ b/lib/core/drive/google_drive_upload_api.dart
@@ -1,0 +1,78 @@
+// lib/core/drive/google_drive_upload_api.dart
+import 'dart:io';
+
+import 'package:extension_google_sign_in_as_googleapis_auth/extension_google_sign_in_as_googleapis_auth.dart';
+import 'package:firecheck/core/drive/drive_upload_api.dart';
+import 'package:firecheck/core/errors/failure.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:googleapis/drive/v3.dart' as gdrive;
+
+class GoogleDriveUploadApi implements DriveUploadApi {
+  GoogleDriveUploadApi({required GoogleSignIn googleSignIn})
+      : _googleSignIn = googleSignIn;
+
+  final GoogleSignIn _googleSignIn;
+
+  Future<gdrive.DriveApi> _api() async {
+    final client = await _googleSignIn.authenticatedClient();
+    if (client == null) throw const AuthFailure('Not signed in to Google');
+    return gdrive.DriveApi(client);
+  }
+
+  @override
+  Future<String> createOrGetFolder(String name, String parentId) async {
+    final api = await _api();
+    final existing = await api.files.list(
+      q: "name = '$name' "
+          "and mimeType = 'application/vnd.google-apps.folder' "
+          "and '$parentId' in parents "
+          "and trashed = false",
+      spaces: 'drive',
+      $fields: 'files(id)',
+    );
+    if (existing.files?.isNotEmpty == true) {
+      return existing.files!.first.id!;
+    }
+    final folder = await api.files.create(
+      gdrive.File()
+        ..name = name
+        ..mimeType = 'application/vnd.google-apps.folder'
+        ..parents = [parentId],
+      $fields: 'id',
+    );
+    return folder.id!;
+  }
+
+  @override
+  Future<String> uploadFile({
+    required String localPath,
+    required String driveParentId,
+    required String fileName,
+    String? resumableUri,
+    void Function(int sent, int total)? onProgress,
+  }) async {
+    final api = await _api();
+    final file = File(localPath);
+    final fileSize = await file.length();
+    final mimeType = fileName.toLowerCase().endsWith('.jpg')
+        ? 'image/jpeg'
+        : 'application/zip';
+
+    final media = gdrive.Media(
+      file.openRead(),
+      fileSize,
+      contentType: mimeType,
+    );
+    final metadata = gdrive.File()
+      ..name = fileName
+      ..parents = [driveParentId];
+
+    final created = await api.files.create(
+      metadata,
+      uploadMedia: media,
+      $fields: 'id',
+    );
+    onProgress?.call(fileSize, fileSize);
+    return created.id!;
+  }
+}

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,4 +1,5 @@
 import 'package:firecheck/features/assignment/presentation/assignment_closed_blocker.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_screen.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_lock_providers.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_lock_state.dart';
 import 'package:firecheck/features/assignment/presentation/get_maps_screen.dart';
@@ -110,6 +111,10 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/blocker',
         builder: (context, state) => const AssignmentClosedBlocker(),
+      ),
+      GoRoute(
+        path: '/uploads',
+        builder: (context, state) => const UploadQueueScreen(),
       ),
     ],
   );

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,5 +1,4 @@
 import 'package:firecheck/features/assignment/presentation/assignment_closed_blocker.dart';
-import 'package:firecheck/features/upload/presentation/upload_queue_screen.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_lock_providers.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_lock_state.dart';
 import 'package:firecheck/features/assignment/presentation/get_maps_screen.dart';
@@ -13,6 +12,7 @@ import 'package:firecheck/features/map/presentation/map_screen.dart';
 import 'package:firecheck/features/review/presentation/review_screen.dart';
 import 'package:firecheck/features/survey/building_form/presentation/submission_detail_screen.dart';
 import 'package:firecheck/features/survey/olp_survey/presentation/result/olp_result_screen.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';

--- a/lib/core/sync/shapefile/export/shapefile_exporter.dart
+++ b/lib/core/sync/shapefile/export/shapefile_exporter.dart
@@ -334,12 +334,39 @@ class ShapefileExporter {
   final Directory? tempDirOverride;
 
   Future<ExportFailure?> export({required String assignmentId}) async {
+    final destDir = tempDirOverride ?? await getTemporaryDirectory();
+    final (failure, _) = await _buildAndWriteZip(
+      assignmentId: assignmentId,
+      destDir: destDir,
+      callShareFile: true,
+    );
+    return failure;
+  }
+
+  /// Exports to a stable path for upload. Returns the zip path on success.
+  /// Callers must not delete the file until upload confirms.
+  Future<(ExportFailure?, String?)> exportToFile({
+    required String assignmentId,
+  }) async {
+    final destDir = tempDirOverride ?? await getApplicationDocumentsDirectory();
+    return _buildAndWriteZip(
+      assignmentId: assignmentId,
+      destDir: destDir,
+      callShareFile: false,
+    );
+  }
+
+  Future<(ExportFailure?, String?)> _buildAndWriteZip({
+    required String assignmentId,
+    required Directory destDir,
+    required bool callShareFile,
+  }) async {
     // Query all completed features with their submissions and attributes.
     final buildingRows = await _queryBuildings(assignmentId);
     final roadRows = await _queryRoads(assignmentId);
 
     if (buildingRows.isEmpty && roadRows.isEmpty) {
-      return const NoCompletedFeatures();
+      return (const NoCompletedFeatures(), null);
     }
 
     // Build layer inputs
@@ -392,13 +419,13 @@ class ShapefileExporter {
         inputs.map((input) => compute(_writeLayer, input)),
       );
     } catch (e) {
-      return WriteError(e.toString());
+      return (WriteError(e.toString()), null);
     }
 
     // Guard against exporter bugs producing empty file components.
     for (final out in outputs) {
       if (out.shp.isEmpty || out.shx.isEmpty || out.dbf.isEmpty) {
-        return WriteError('Layer ${out.layerName} produced empty components');
+        return (WriteError('Layer ${out.layerName} produced empty components'), null);
       }
     }
 
@@ -426,30 +453,29 @@ class ShapefileExporter {
         );
     }
 
-    // Write ZIP to temp directory
+    // Write ZIP to destination directory
     final zipBytes = ZipEncoder().encode(archive);
-    if (zipBytes == null) return const WriteError('ZIP encoding produced no output');
-    final tempDir = tempDirOverride ?? await getTemporaryDirectory();
+    if (zipBytes == null) return (const WriteError('ZIP encoding produced no output'), null);
     final timestamp = DateFormat('yyyyMMdd_HHmmss').format(DateTime.now());
     final zipName = 'firecheck_${assignmentId}_$timestamp.zip';
-    final zipPath = p.join(tempDir.path, zipName);
+    final zipPath = p.join(destDir.path, zipName);
 
     try {
       await File(zipPath).writeAsBytes(zipBytes);
     } catch (e) {
-      return WriteError(e.toString());
+      return (WriteError(e.toString()), null);
     }
 
     // Share / hand off
-    if (shareFile != null) {
+    if (callShareFile && shareFile != null) {
       try {
         await shareFile!(zipPath);
       } catch (e) {
-        return ShareError(e.toString());
+        return (ShareError(e.toString()), null);
       }
     }
 
-    return null;
+    return (null, zipPath);
   }
 
   // -------------------------------------------------------------------------

--- a/lib/core/sync/shapefile/export/shapefile_exporter.dart
+++ b/lib/core/sync/shapefile/export/shapefile_exporter.dart
@@ -335,12 +335,19 @@ class ShapefileExporter {
 
   Future<ExportFailure?> export({required String assignmentId}) async {
     final destDir = tempDirOverride ?? await getTemporaryDirectory();
-    final (failure, _) = await _buildAndWriteZip(
+    final (failure, zipPath) = await _buildAndWriteZip(
       assignmentId: assignmentId,
       destDir: destDir,
-      callShareFile: true,
     );
-    return failure;
+    if (failure != null || zipPath == null) return failure;
+    if (shareFile != null) {
+      try {
+        await shareFile!(zipPath);
+      } catch (e) {
+        return ShareError(e.toString());
+      }
+    }
+    return null;
   }
 
   /// Exports to a stable path for upload. Returns the zip path on success.
@@ -352,14 +359,12 @@ class ShapefileExporter {
     return _buildAndWriteZip(
       assignmentId: assignmentId,
       destDir: destDir,
-      callShareFile: false,
     );
   }
 
   Future<(ExportFailure?, String?)> _buildAndWriteZip({
     required String assignmentId,
     required Directory destDir,
-    required bool callShareFile,
   }) async {
     // Query all completed features with their submissions and attributes.
     final buildingRows = await _queryBuildings(assignmentId);
@@ -464,15 +469,6 @@ class ShapefileExporter {
       await File(zipPath).writeAsBytes(zipBytes);
     } catch (e) {
       return (WriteError(e.toString()), null);
-    }
-
-    // Share / hand off
-    if (callShareFile && shareFile != null) {
-      try {
-        await shareFile!(zipPath);
-      } catch (e) {
-        return (ShareError(e.toString()), null);
-      }
     }
 
     return (null, zipPath);

--- a/lib/features/auth/data/fake_google_auth_repository.dart
+++ b/lib/features/auth/data/fake_google_auth_repository.dart
@@ -18,4 +18,7 @@ class FakeGoogleAuthRepository implements GoogleAuthRepository {
 
   @override
   Future<String> getEnumeratorId() async => 'test-enumerator';
+
+  @override
+  Future<bool> requestDriveUploadScope() async => true;
 }

--- a/lib/features/auth/data/google_auth_repository.dart
+++ b/lib/features/auth/data/google_auth_repository.dart
@@ -1,9 +1,15 @@
 // lib/features/auth/data/google_auth_repository.dart
 abstract interface class GoogleAuthRepository {
+  static const driveFileScope =
+      'https://www.googleapis.com/auth/drive.file';
+
   Future<bool> isSignedIn();
   Future<void> signIn();
   Future<void> signOut();
 
   /// Returns the local-part of the signed-in Gmail address (e.g. 'jlescarlan11').
   Future<String> getEnumeratorId();
+
+  /// Requests the drive.file OAuth scope. Returns true if granted.
+  Future<bool> requestDriveUploadScope();
 }

--- a/lib/features/auth/data/google_sign_in_auth_repository.dart
+++ b/lib/features/auth/data/google_sign_in_auth_repository.dart
@@ -49,4 +49,14 @@ class GoogleSignInAuthRepository implements GoogleAuthRepository {
     if (account == null) throw const AuthFailure('Not signed in to Google');
     return account.email.split('@').first;
   }
+
+  @override
+  Future<bool> requestDriveUploadScope() async {
+    try {
+      return await _googleSignIn
+          .requestScopes([GoogleAuthRepository.driveFileScope]);
+    } on Object {
+      return false;
+    }
+  }
 }

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -1,5 +1,4 @@
 import 'package:firecheck/core/security/biometric_gate_provider.dart';
-import 'package:firecheck/features/upload/presentation/upload_banner.dart';
 import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
 import 'package:firecheck/core/sync/shapefile/export/export_validation_result.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_lock_providers.dart';
@@ -8,6 +7,7 @@ import 'package:firecheck/features/assignment/presentation/submitted_banner.dart
 import 'package:firecheck/features/home/data/shapefile_export_notifier.dart';
 import 'package:firecheck/features/home/domain/export_state.dart';
 import 'package:firecheck/features/home/presentation/home_providers.dart';
+import 'package:firecheck/features/upload/presentation/upload_banner.dart';
 import 'package:firecheck/generated/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:firecheck/core/security/biometric_gate_provider.dart';
+import 'package:firecheck/features/upload/presentation/upload_banner.dart';
 import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
 import 'package:firecheck/core/sync/shapefile/export/export_validation_result.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_lock_providers.dart';
@@ -47,6 +48,8 @@ class HomeScreen extends ConsumerWidget {
           padding: const EdgeInsets.all(16),
           child: Column(
             children: [
+              const UploadBanner(),
+              const SizedBox(height: 8),
               if (lock is Submitted)
                 SubmittedBanner(submittedAt: lock.submittedAt)
               else

--- a/lib/features/upload/presentation/upload_banner.dart
+++ b/lib/features/upload/presentation/upload_banner.dart
@@ -1,0 +1,50 @@
+// lib/features/upload/presentation/upload_banner.dart
+import 'package:firecheck/core/drive/drive_upload_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+class UploadBanner extends ConsumerWidget {
+  const UploadBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(driveUploadNotifierProvider);
+    if (state.pendingCount == 0) return const SizedBox.shrink();
+
+    final totalMb =
+        (state.totalPendingBytes / 1024 / 1024).toStringAsFixed(1);
+
+    return Card(
+      color: Theme.of(context).colorScheme.primary,
+      margin: EdgeInsets.zero,
+      child: ListTile(
+        leading: Icon(
+          Icons.cloud_upload,
+          color: Theme.of(context).colorScheme.onPrimary,
+        ),
+        title: Text(
+          '${state.pendingCount} file${state.pendingCount == 1 ? '' : 's'} ready to upload',
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.onPrimary,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        subtitle: Text(
+          '$totalMb MB',
+          style: TextStyle(
+            color: Theme.of(context)
+                .colorScheme
+                .onPrimary
+                .withValues(alpha: 0.8),
+          ),
+        ),
+        trailing: Icon(
+          Icons.chevron_right,
+          color: Theme.of(context).colorScheme.onPrimary,
+        ),
+        onTap: () => context.push('/uploads'),
+      ),
+    );
+  }
+}

--- a/lib/features/upload/presentation/upload_queue_notifier.dart
+++ b/lib/features/upload/presentation/upload_queue_notifier.dart
@@ -1,0 +1,61 @@
+// lib/features/upload/presentation/upload_queue_notifier.dart
+import 'dart:async';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/drive/drive_upload_worker.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class DriveUploadState {
+  const DriveUploadState({
+    required this.jobs,
+  });
+
+  final List<DriveUploadJob> jobs;
+
+  int get pendingCount =>
+      jobs.where((j) => j.status != DriveUploadJobStatus.completed).length;
+
+  int get totalPendingBytes => jobs
+      .where((j) => j.status != DriveUploadJobStatus.completed)
+      .fold(0, (sum, j) => sum + j.fileSizeBytes);
+
+  int get completedCount =>
+      jobs.where((j) => j.status == DriveUploadJobStatus.completed).length;
+
+  bool get isUploading =>
+      jobs.any((j) => j.status == DriveUploadJobStatus.uploading);
+}
+
+class DriveUploadNotifier extends StateNotifier<DriveUploadState> {
+  DriveUploadNotifier({
+    required DriveUploadRepository repo,
+    required DriveUploadWorker worker,
+  })  : _repo = repo,
+        _worker = worker,
+        super(const DriveUploadState(jobs: [])) {
+    _sub = repo.watchQueue().listen((jobs) {
+      state = DriveUploadState(jobs: jobs);
+    });
+  }
+
+  final DriveUploadRepository _repo;
+  final DriveUploadWorker _worker;
+  StreamSubscription<List<DriveUploadJob>>? _sub;
+
+  Future<void> uploadAll() async {
+    await _repo.resetFailedToPending();
+    await _worker.drain();
+  }
+
+  Future<void> retryJob(String jobId) async {
+    await _repo.resetForRetry(jobId);
+    await _worker.drain();
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/features/upload/presentation/upload_queue_notifier.dart
+++ b/lib/features/upload/presentation/upload_queue_notifier.dart
@@ -13,15 +13,22 @@ class DriveUploadState {
 
   final List<DriveUploadJob> jobs;
 
-  int get pendingCount =>
-      jobs.where((j) => j.status != DriveUploadJobStatus.completed).length;
+  int get pendingCount => jobs
+      .where((j) =>
+          j.status == DriveUploadJobStatus.pending ||
+          j.status == DriveUploadJobStatus.failed ||
+          j.status == DriveUploadJobStatus.dead)
+      .length;
 
   int get totalPendingBytes => jobs
-      .where((j) => j.status != DriveUploadJobStatus.completed)
+      .where((j) =>
+          j.status == DriveUploadJobStatus.pending ||
+          j.status == DriveUploadJobStatus.failed ||
+          j.status == DriveUploadJobStatus.dead)
       .fold(0, (sum, j) => sum + j.fileSizeBytes);
 
-  int get completedCount =>
-      jobs.where((j) => j.status == DriveUploadJobStatus.completed).length;
+  int get uploadingCount =>
+      jobs.where((j) => j.status == DriveUploadJobStatus.uploading).length;
 
   bool get isUploading =>
       jobs.any((j) => j.status == DriveUploadJobStatus.uploading);

--- a/lib/features/upload/presentation/upload_queue_notifier.dart
+++ b/lib/features/upload/presentation/upload_queue_notifier.dart
@@ -57,11 +57,15 @@ class DriveUploadNotifier extends StateNotifier<DriveUploadState> {
   StreamSubscription<List<DriveUploadJob>>? _sub;
 
   Future<void> uploadAll() async {
+    assert(_repo != null && _worker != null,
+        'uploadAll() called on a seeded test notifier');
     await _repo!.resetFailedToPending();
     await _worker!.drain();
   }
 
   Future<void> retryJob(String jobId) async {
+    assert(_repo != null && _worker != null,
+        'retryJob() called on a seeded test notifier');
     await _repo!.resetForRetry(jobId);
     await _worker!.drain();
   }

--- a/lib/features/upload/presentation/upload_queue_notifier.dart
+++ b/lib/features/upload/presentation/upload_queue_notifier.dart
@@ -4,6 +4,7 @@ import 'package:firecheck/core/db/database.dart';
 import 'package:firecheck/core/drive/drive_upload_job_status.dart';
 import 'package:firecheck/core/drive/drive_upload_repository.dart';
 import 'package:firecheck/core/drive/drive_upload_worker.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class DriveUploadState {
@@ -38,16 +39,21 @@ class DriveUploadNotifier extends StateNotifier<DriveUploadState> {
   DriveUploadNotifier({
     required DriveUploadRepository repo,
     required DriveUploadWorker worker,
-  })  : _repo = repo,
-        _worker = worker,
-        super(const DriveUploadState(jobs: [])) {
+  })  : super(const DriveUploadState(jobs: [])) {
+    _repo = repo;
+    _worker = worker;
     _sub = repo.watchQueue().listen((jobs) {
       state = DriveUploadState(jobs: jobs);
     });
   }
 
-  final DriveUploadRepository _repo;
-  final DriveUploadWorker _worker;
+  /// Use in widget tests to seed a static state without subscribing to Drift.
+  @visibleForTesting
+  DriveUploadNotifier.seeded(DriveUploadState initialState)
+      : super(initialState);
+
+  late final DriveUploadRepository _repo;
+  late final DriveUploadWorker _worker;
   StreamSubscription<List<DriveUploadJob>>? _sub;
 
   Future<void> uploadAll() async {

--- a/lib/features/upload/presentation/upload_queue_notifier.dart
+++ b/lib/features/upload/presentation/upload_queue_notifier.dart
@@ -52,18 +52,18 @@ class DriveUploadNotifier extends StateNotifier<DriveUploadState> {
   DriveUploadNotifier.seeded(DriveUploadState initialState)
       : super(initialState);
 
-  late final DriveUploadRepository _repo;
-  late final DriveUploadWorker _worker;
+  DriveUploadRepository? _repo;
+  DriveUploadWorker? _worker;
   StreamSubscription<List<DriveUploadJob>>? _sub;
 
   Future<void> uploadAll() async {
-    await _repo.resetFailedToPending();
-    await _worker.drain();
+    await _repo!.resetFailedToPending();
+    await _worker!.drain();
   }
 
   Future<void> retryJob(String jobId) async {
-    await _repo.resetForRetry(jobId);
-    await _worker.drain();
+    await _repo!.resetForRetry(jobId);
+    await _worker!.drain();
   }
 
   @override

--- a/lib/features/upload/presentation/upload_queue_screen.dart
+++ b/lib/features/upload/presentation/upload_queue_screen.dart
@@ -1,0 +1,177 @@
+// lib/features/upload/presentation/upload_queue_screen.dart
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_preferences.dart';
+import 'package:firecheck/core/drive/drive_upload_providers.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class UploadQueueScreen extends ConsumerStatefulWidget {
+  const UploadQueueScreen({super.key});
+
+  @override
+  ConsumerState<UploadQueueScreen> createState() => _UploadQueueScreenState();
+}
+
+class _UploadQueueScreenState extends ConsumerState<UploadQueueScreen> {
+  bool _autoUpload = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadAutoUpload();
+  }
+
+  Future<void> _loadAutoUpload() async {
+    final prefs = ref.read(driveUploadPreferencesProvider);
+    final enabled = await prefs.isAutoUploadEnabled();
+    if (mounted) {
+      setState(() => _autoUpload = enabled);
+    }
+  }
+
+  Future<void> _toggleAutoUpload(bool value) async {
+    final prefs = ref.read(driveUploadPreferencesProvider);
+    await prefs.setAutoUploadEnabled(enabled: value);
+    if (mounted) {
+      setState(() => _autoUpload = value);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(driveUploadNotifierProvider);
+    final notifier = ref.read(driveUploadNotifierProvider.notifier);
+
+    final totalMb =
+        (state.totalPendingBytes / 1024 / 1024).toStringAsFixed(1);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Uploads')),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Summary bar
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              children: [
+                Text(
+                  '${state.pendingCount} file(s) · $totalMb MB',
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+                const Spacer(),
+                const Text('Auto-upload'),
+                const SizedBox(width: 8),
+                Switch(
+                  value: _autoUpload,
+                  onChanged: _toggleAutoUpload,
+                ),
+              ],
+            ),
+          ),
+
+          // Progress bar (only when uploading)
+          if (state.isUploading)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Uploading… ${state.uploadingCount} files'),
+                  const SizedBox(height: 4),
+                  const LinearProgressIndicator(value: null),
+                ],
+              ),
+            ),
+
+          // File list
+          Expanded(
+            child: state.jobs.isEmpty
+                ? const Center(child: Text('No pending uploads'))
+                : ListView.separated(
+                    itemCount: state.jobs.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, index) {
+                      final job = state.jobs[index];
+                      return _JobTile(
+                        job: job,
+                        onRetry: () => notifier.retryJob(job.id),
+                      );
+                    },
+                  ),
+          ),
+
+          // Upload All button
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: ElevatedButton(
+              onPressed:
+                  (state.isUploading || state.pendingCount == 0)
+                      ? null
+                      : () => notifier.uploadAll(),
+              style: ElevatedButton.styleFrom(
+                minimumSize: const Size.fromHeight(48),
+              ),
+              child: const Text('Upload All'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _JobTile extends StatelessWidget {
+  const _JobTile({required this.job, required this.onRetry});
+
+  final DriveUploadJob job;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final isFailed = job.status == DriveUploadJobStatus.failed ||
+        job.status == DriveUploadJobStatus.dead;
+
+    final kb = (job.fileSizeBytes / 1024).toStringAsFixed(0);
+
+    String chipText;
+    switch (job.status) {
+      case DriveUploadJobStatus.pending:
+        chipText = 'PENDING';
+        break;
+      case DriveUploadJobStatus.uploading:
+        chipText = 'UPLOADING';
+        break;
+      case DriveUploadJobStatus.completed:
+        chipText = '✓ DONE';
+        break;
+      case DriveUploadJobStatus.failed:
+        chipText = 'FAILED';
+        break;
+      case DriveUploadJobStatus.dead:
+        chipText = 'FAILED';
+        break;
+      default:
+        chipText = job.status.toUpperCase();
+    }
+
+    return ListTile(
+      leading: Icon(
+        job.fileType == DriveFileType.photo
+            ? Icons.image
+            : Icons.folder_zip,
+      ),
+      title: Text(job.fileName),
+      subtitle: isFailed
+          ? Text(
+              job.failureReason ?? 'Upload failed · Tap to retry',
+              style: const TextStyle(color: Colors.red),
+            )
+          : Text('${job.assignmentId} · $kb KB'),
+      trailing: Text(chipText),
+      onTap: isFailed ? onRetry : null,
+    );
+  }
+}

--- a/lib/features/upload/presentation/upload_queue_screen.dart
+++ b/lib/features/upload/presentation/upload_queue_screen.dart
@@ -1,9 +1,7 @@
 // lib/features/upload/presentation/upload_queue_screen.dart
 import 'package:firecheck/core/db/database.dart';
 import 'package:firecheck/core/drive/drive_upload_job_status.dart';
-import 'package:firecheck/core/drive/drive_upload_preferences.dart';
 import 'package:firecheck/core/drive/drive_upload_providers.dart';
-import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -81,7 +79,7 @@ class _UploadQueueScreenState extends ConsumerState<UploadQueueScreen> {
                 children: [
                   Text('Uploading… ${state.uploadingCount} files'),
                   const SizedBox(height: 4),
-                  const LinearProgressIndicator(value: null),
+                  const LinearProgressIndicator(),
                 ],
               ),
             ),
@@ -110,7 +108,7 @@ class _UploadQueueScreenState extends ConsumerState<UploadQueueScreen> {
               onPressed:
                   (state.isUploading || state.pendingCount == 0)
                       ? null
-                      : () => notifier.uploadAll(),
+                      : notifier.uploadAll,
               style: ElevatedButton.styleFrom(
                 minimumSize: const Size.fromHeight(48),
               ),
@@ -136,26 +134,14 @@ class _JobTile extends StatelessWidget {
 
     final kb = (job.fileSizeBytes / 1024).toStringAsFixed(0);
 
-    String chipText;
-    switch (job.status) {
-      case DriveUploadJobStatus.pending:
-        chipText = 'PENDING';
-        break;
-      case DriveUploadJobStatus.uploading:
-        chipText = 'UPLOADING';
-        break;
-      case DriveUploadJobStatus.completed:
-        chipText = '✓ DONE';
-        break;
-      case DriveUploadJobStatus.failed:
-        chipText = 'FAILED';
-        break;
-      case DriveUploadJobStatus.dead:
-        chipText = 'FAILED';
-        break;
-      default:
-        chipText = job.status.toUpperCase();
-    }
+    final chipText = switch (job.status) {
+      DriveUploadJobStatus.pending   => 'PENDING',
+      DriveUploadJobStatus.uploading => 'UPLOADING',
+      DriveUploadJobStatus.completed => '✓ DONE',
+      DriveUploadJobStatus.failed    => 'FAILED',
+      DriveUploadJobStatus.dead      => 'FAILED',
+      _                              => job.status.toUpperCase(),
+    };
 
     return ListTile(
       leading: Icon(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:firecheck/app.dart';
 import 'package:firecheck/core/device/storage_checker.dart';
+import 'package:firecheck/core/drive/drive_upload_providers.dart';
+import 'package:firecheck/core/drive/drive_upload_workmanager.dart';
 import 'package:firecheck/core/drive/google_drive_api.dart';
 import 'package:firecheck/core/mapbox/offline_pack_adapter.dart';
 import 'package:firecheck/core/sync/presentation/sync_providers.dart';
@@ -8,6 +10,8 @@ import 'package:firecheck/core/sync/shapefile/reprojector.dart';
 import 'package:firecheck/core/sync/shapefile/shapefile_importer.dart';
 import 'package:firecheck/core/sync/worker/workmanager_dispatcher.dart';
 import 'package:firecheck/core/validation/supabase_validation_failure_reporter.dart';
+import 'package:firecheck/features/assignment/presentation/assignment_lock_providers.dart';
+import 'package:firecheck/features/assignment/presentation/assignment_lock_state.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_providers.dart';
 import 'package:firecheck/features/auth/data/google_sign_in_auth_repository.dart';
 import 'package:firecheck/features/auth/presentation/google_auth_providers.dart';
@@ -23,7 +27,10 @@ import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 final _googleSignIn = GoogleSignIn(
-  scopes: ['https://www.googleapis.com/auth/drive.readonly'],
+  scopes: [
+    'https://www.googleapis.com/auth/drive.readonly',
+    'https://www.googleapis.com/auth/drive.file',
+  ],
 );
 
 Future<void> main() async {
@@ -49,6 +56,7 @@ Future<void> main() async {
 
   await Supabase.initialize(url: supaUrl, anonKey: supaKey);
   await registerPeriodicSync();
+  await registerPeriodicDriveUpload();
   MapboxOptions.setAccessToken(mapboxToken);
 
   // Phase 1 T19: wire the real Mapbox renderer + offline-pack adapter so
@@ -69,6 +77,7 @@ Future<void> main() async {
   runApp(
     ProviderScope(
       overrides: [
+        googleSignInProvider.overrideWithValue(_googleSignIn),
         mapRendererProvider.overrideWithValue(MapboxMapRenderer()),
         if (tileStore != null)
           offlinePackAdapterProvider.overrideWithValue(
@@ -99,9 +108,49 @@ Future<void> main() async {
           ),
         ),
       ],
-      child: const _SyncBootstrap(child: FireCheckApp()),
+      child: const _DriveUploadBootstrap(
+        child: _SyncBootstrap(child: FireCheckApp()),
+      ),
     ),
   );
+}
+
+class _DriveUploadBootstrap extends ConsumerStatefulWidget {
+  const _DriveUploadBootstrap({required this.child});
+  final Widget child;
+
+  @override
+  ConsumerState<_DriveUploadBootstrap> createState() =>
+      _DriveUploadBootstrapState();
+}
+
+class _DriveUploadBootstrapState extends ConsumerState<_DriveUploadBootstrap> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(_boot);
+  }
+
+  Future<void> _boot() async {
+    final controller = ref.read(driveUploadControllerProvider);
+    await controller.start();
+    _watchForCompletion();
+  }
+
+  void _watchForCompletion() {
+    ref.read(assignmentLockStateProvider.stream).listen((state) async {
+      if (state is! Submitted) return;
+      final repo = ref.read(assignmentRepositoryProvider);
+      final assignment = await repo.getCurrentAssignment();
+      if (assignment == null) return;
+      await ref.read(enqueueAssignmentUseCaseProvider).execute(
+            assignmentId: assignment.id,
+          );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
 }
 
 class _SyncBootstrap extends ConsumerStatefulWidget {

--- a/test/core/db/database_test.dart
+++ b/test/core/db/database_test.dart
@@ -44,9 +44,9 @@ void main() {
       expect(db.schemaVersion, greaterThanOrEqualTo(3));
     });
 
-    test('the DB registers exactly the 12 expected tables', () {
+    test('the DB registers exactly the 13 expected tables', () {
       final names = db.allTables.map((t) => t.actualTableName).toSet();
-      expect(names, hasLength(12));
+      expect(names, hasLength(13));
       expect(
         names,
         equals({
@@ -62,6 +62,7 @@ void main() {
           'sync_jobs',
           'offline_tile_packs',
           'feature_geometry_revisions',
+          'drive_upload_jobs',
         }),
       );
     });

--- a/test/core/db/drive_upload_jobs_table_test.dart
+++ b/test/core/db/drive_upload_jobs_table_test.dart
@@ -1,0 +1,29 @@
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('drive_upload_jobs table is accessible and accepts inserts', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    expect(db.driveUploadJobs, isNotNull);
+
+    final id = await db.into(db.driveUploadJobs).insertReturning(
+          DriveUploadJobsCompanion.insert(
+            id: '1',
+            assignmentId: 'a-001',
+            filePath: '/photos/p1.jpg',
+            fileType: 'photo',
+            fileName: 'p1.jpg',
+            fileSizeBytes: 1024,
+            capturedAt: DateTime(2026, 5, 2),
+            createdAt: DateTime(2026, 5, 2),
+          ),
+        );
+
+    expect(id.status, 'pending');
+    expect(id.retryCount, 0);
+    expect(id.resumableUri, isNull);
+  });
+}

--- a/test/core/db/migration_v7_to_v8_test.dart
+++ b/test/core/db/migration_v7_to_v8_test.dart
@@ -3,6 +3,7 @@ import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:drift/native.dart';
 import 'package:firecheck/core/db/database.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
 
 void main() {
   test('schemaVersion is at least 8', () {
@@ -112,5 +113,87 @@ void main() {
     expect(row.retryCount, 2);
     expect(row.failureReason, 'network timeout');
     expect(row.nextRetryAt, isNotNull);
+  });
+
+  // ── Real v7 → v8 migration test ────────────────────────────────────────────
+  //
+  // Opens an in-memory database pre-seeded with the v7 schema (no
+  // drive_upload_jobs table), then lets AppDatabase run its onUpgrade
+  // migration. Verifies that the table and its indexes are created correctly.
+  test('migrates from v7 to v8: creates drive_upload_jobs table and indexes',
+      () async {
+    // Build a v7 schema in raw SQLite before Drift touches the database.
+    // NativeDatabase.memory(setup:) fires on the raw sqlite3.Database before
+    // any Drift migration runs, so we can set user_version = 7 and create the
+    // v7 tables here.
+    final db = AppDatabase.forTesting(
+      NativeDatabase.memory(
+        setup: (rawDb) {
+          // Mark this as a v7 database so Drift's onUpgrade fires with from=7.
+          rawDb.execute('PRAGMA user_version = 7');
+
+          // Create a representative subset of v7 tables. We only need enough
+          // so that the migration's CREATE TABLE for drive_upload_jobs
+          // succeeds; we don't need every column of every table.
+          rawDb.execute('''
+            CREATE TABLE IF NOT EXISTS enumerators (
+              id TEXT NOT NULL PRIMARY KEY,
+              name TEXT NOT NULL
+            )
+          ''');
+          rawDb.execute('''
+            CREATE TABLE IF NOT EXISTS assignments (
+              id TEXT NOT NULL PRIMARY KEY,
+              enumerator_id TEXT NOT NULL,
+              campaign_id TEXT NOT NULL,
+              boundary_polygon_geojson TEXT NOT NULL,
+              created_at INTEGER NOT NULL,
+              submitted_at INTEGER,
+              closed_remotely INTEGER NOT NULL DEFAULT 0,
+              drive_modified_time TEXT,
+              drive_folder_id TEXT
+            )
+          ''');
+        },
+      ),
+    );
+    addTearDown(db.close);
+
+    // Touch the DB to trigger Drift's migration.
+    final tables = await db
+        .customSelect(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='drive_upload_jobs'",
+        )
+        .get();
+    expect(tables, hasLength(1),
+        reason: 'drive_upload_jobs table must exist after v7→v8 migration');
+
+    final indexes = await db
+        .customSelect(
+          "SELECT name FROM sqlite_master WHERE type='index' "
+          "AND (name='drive_upload_jobs_status_idx' "
+          "OR name='drive_upload_jobs_assignment_idx')",
+        )
+        .get();
+    final indexNames =
+        indexes.map((r) => r.data['name'] as String).toSet();
+    expect(indexNames, contains('drive_upload_jobs_status_idx'));
+    expect(indexNames, contains('drive_upload_jobs_assignment_idx'));
+
+    // Verify the migrated table accepts a row insertion (smoke test).
+    await db.customStatement('''
+      INSERT INTO drive_upload_jobs
+        (id, assignment_id, file_path, file_type, file_name,
+         file_size_bytes, captured_at, created_at)
+      VALUES
+        ('test-id', 'a-001', '/photos/test.jpg', 'photo', 'test.jpg',
+         1024, 0, 0)
+    ''');
+    final row = await db
+        .customSelect(
+          "SELECT id FROM drive_upload_jobs WHERE id='test-id'",
+        )
+        .getSingle();
+    expect(row.data['id'], 'test-id');
   });
 }

--- a/test/core/db/migration_v7_to_v8_test.dart
+++ b/test/core/db/migration_v7_to_v8_test.dart
@@ -1,0 +1,116 @@
+// test/core/db/migration_v7_to_v8_test.dart
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('schemaVersion is at least 8', () {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    expect(db.schemaVersion, greaterThanOrEqualTo(8));
+  });
+
+  test('drive_upload_jobs table exists in sqlite_master', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final rows = await db
+        .customSelect(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='drive_upload_jobs'",
+        )
+        .get();
+    expect(rows, hasLength(1));
+  });
+
+  test('drive_upload_jobs indexes exist', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final rows = await db
+        .customSelect(
+          "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'",
+        )
+        .get();
+    final names = rows.map((r) => r.data['name'] as String).toSet();
+    expect(names, contains('drive_upload_jobs_status_idx'));
+    expect(names, contains('drive_upload_jobs_assignment_idx'));
+  });
+
+  test('status defaults to pending and retryCount defaults to 0', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    await db.into(db.driveUploadJobs).insert(
+          DriveUploadJobsCompanion.insert(
+            id: 'j1',
+            assignmentId: 'a-001',
+            filePath: '/photos/p1.jpg',
+            fileType: 'photo',
+            fileName: 'p1.jpg',
+            fileSizeBytes: 2048,
+            capturedAt: DateTime(2026, 5, 2),
+            createdAt: DateTime(2026, 5, 2),
+          ),
+        );
+    final row = await (db.select(db.driveUploadJobs)
+          ..where((t) => t.id.equals('j1')))
+        .getSingle();
+    expect(row.status, 'pending');
+    expect(row.retryCount, 0);
+  });
+
+  test('nullable columns accept null on insert', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    await db.into(db.driveUploadJobs).insert(
+          DriveUploadJobsCompanion.insert(
+            id: 'j2',
+            assignmentId: 'a-001',
+            filePath: '/shapefiles/s1.zip',
+            fileType: 'shapefile',
+            fileName: 's1.zip',
+            fileSizeBytes: 8192,
+            capturedAt: DateTime(2026, 5, 2),
+            createdAt: DateTime(2026, 5, 2),
+          ),
+        );
+    final row = await (db.select(db.driveUploadJobs)
+          ..where((t) => t.id.equals('j2')))
+        .getSingle();
+    expect(row.resumableUri, isNull);
+    expect(row.driveFileId, isNull);
+    expect(row.failureReason, isNull);
+    expect(row.nextRetryAt, isNull);
+  });
+
+  test('nullable columns can be set to non-null values', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final now = DateTime(2026, 5, 2, 10, 0);
+    await db.into(db.driveUploadJobs).insert(
+          DriveUploadJobsCompanion.insert(
+            id: 'j3',
+            assignmentId: 'a-002',
+            filePath: '/photos/p3.jpg',
+            fileType: 'photo',
+            fileName: 'p3.jpg',
+            fileSizeBytes: 4096,
+            capturedAt: now,
+            createdAt: now,
+            status: const Value('uploading'),
+            resumableUri: const Value('https://upload.example.com/abc123'),
+            driveFileId: const Value('1BxFgHkLmN'),
+            retryCount: const Value(2),
+            failureReason: const Value('network timeout'),
+            nextRetryAt: Value(now.add(const Duration(minutes: 5))),
+          ),
+        );
+    final row = await (db.select(db.driveUploadJobs)
+          ..where((t) => t.id.equals('j3')))
+        .getSingle();
+    expect(row.status, 'uploading');
+    expect(row.resumableUri, 'https://upload.example.com/abc123');
+    expect(row.driveFileId, '1BxFgHkLmN');
+    expect(row.retryCount, 2);
+    expect(row.failureReason, 'network timeout');
+    expect(row.nextRetryAt, isNotNull);
+  });
+}

--- a/test/core/drive/drive_upload_controller_test.dart
+++ b/test/core/drive/drive_upload_controller_test.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:firecheck/core/drive/drive_upload_controller.dart';
+import 'package:firecheck/core/drive/drive_upload_preferences.dart';
+import 'package:firecheck/core/security/secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('triggerNow calls onDrain', () async {
+    var drainCalled = 0;
+    final prefs = DriveUploadPreferences(InMemorySecureStorage());
+    final ctrl = DriveUploadController(
+      onDrain: () async => drainCalled++,
+      preferences: prefs,
+    );
+
+    await ctrl.triggerNow();
+    expect(drainCalled, 1);
+  });
+
+  test('Wi-Fi connectivity event triggers drain when auto-upload is on',
+      () async {
+    final controller = StreamController<List<ConnectivityResult>>();
+    var drainCalled = 0;
+    final storage = InMemorySecureStorage();
+    final prefs = DriveUploadPreferences(storage);
+    await prefs.setAutoUploadEnabled(enabled: true);
+
+    final ctrl = DriveUploadController(
+      onDrain: () async => drainCalled++,
+      preferences: prefs,
+      connectivityStream: controller.stream,
+    );
+    await ctrl.start();
+
+    controller.add([ConnectivityResult.wifi]);
+    await Future.delayed(Duration.zero);
+
+    expect(drainCalled, greaterThanOrEqualTo(1));
+    await ctrl.stop();
+    await controller.close();
+  });
+
+  test('mobile connectivity does not trigger drain', () async {
+    final controller = StreamController<List<ConnectivityResult>>();
+    var drainCalled = 0;
+    final prefs = DriveUploadPreferences(InMemorySecureStorage());
+    await prefs.setAutoUploadEnabled(enabled: true);
+
+    final ctrl = DriveUploadController(
+      onDrain: () async => drainCalled++,
+      preferences: prefs,
+      connectivityStream: controller.stream,
+    );
+    await ctrl.start();
+
+    controller.add([ConnectivityResult.mobile]);
+    await Future.delayed(Duration.zero);
+
+    expect(drainCalled, 0);
+    await ctrl.stop();
+    await controller.close();
+  });
+
+  test('Wi-Fi event does not trigger drain when auto-upload is off', () async {
+    final streamCtrl = StreamController<List<ConnectivityResult>>();
+    var drainCalled = 0;
+    final prefs = DriveUploadPreferences(InMemorySecureStorage());
+    // auto-upload default is false
+
+    final ctrl = DriveUploadController(
+      onDrain: () async => drainCalled++,
+      preferences: prefs,
+      connectivityStream: streamCtrl.stream,
+    );
+    await ctrl.start();
+
+    streamCtrl.add([ConnectivityResult.wifi]);
+    await Future.delayed(Duration.zero);
+
+    expect(drainCalled, 0);
+    await ctrl.stop();
+    await streamCtrl.close();
+  });
+}

--- a/test/core/drive/drive_upload_controller_test.dart
+++ b/test/core/drive/drive_upload_controller_test.dart
@@ -82,4 +82,25 @@ void main() {
     await ctrl.stop();
     await streamCtrl.close();
   });
+
+  test('no drain occurs after stop()', () async {
+    final streamCtrl = StreamController<List<ConnectivityResult>>();
+    var drainCalled = 0;
+    final prefs = DriveUploadPreferences(InMemorySecureStorage());
+    await prefs.setAutoUploadEnabled(enabled: true);
+
+    final ctrl = DriveUploadController(
+      onDrain: () async => drainCalled++,
+      preferences: prefs,
+      connectivityStream: streamCtrl.stream,
+    );
+    await ctrl.start();
+    await ctrl.stop();
+
+    streamCtrl.add([ConnectivityResult.wifi]);
+    await Future.delayed(Duration.zero);
+
+    expect(drainCalled, 0);
+    await streamCtrl.close();
+  });
 }

--- a/test/core/drive/drive_upload_preferences_test.dart
+++ b/test/core/drive/drive_upload_preferences_test.dart
@@ -1,0 +1,18 @@
+import 'package:firecheck/core/drive/drive_upload_preferences.dart';
+import 'package:firecheck/core/security/secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('autoUploadEnabled defaults to false', () async {
+    final prefs = DriveUploadPreferences(InMemorySecureStorage());
+    expect(await prefs.isAutoUploadEnabled(), isFalse);
+  });
+
+  test('setAutoUpload persists and reads back', () async {
+    final prefs = DriveUploadPreferences(InMemorySecureStorage());
+    await prefs.setAutoUploadEnabled(enabled: true);
+    expect(await prefs.isAutoUploadEnabled(), isTrue);
+    await prefs.setAutoUploadEnabled(enabled: false);
+    expect(await prefs.isAutoUploadEnabled(), isFalse);
+  });
+}

--- a/test/core/drive/drive_upload_repository_test.dart
+++ b/test/core/drive/drive_upload_repository_test.dart
@@ -17,7 +17,7 @@ void main() {
         id: 'j1',
         assignmentId: 'a1',
         filePath: '/photos/p1.jpg',
-        fileType: DriveUploadJobStatus.typePhoto,
+        fileType: DriveFileType.photo,
         fileName: 'p1.jpg',
         fileSizeBytes: 1024,
         capturedAt: DateTime(2026, 5, 2),
@@ -34,10 +34,10 @@ void main() {
       final repo = DriveUploadRepository(db);
 
       await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
-          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileType: DriveFileType.photo, fileName: 'p1.jpg',
           fileSizeBytes: 100, capturedAt: DateTime(2026));
       await repo.insertJob(id: 'j2', assignmentId: 'a1', filePath: '/p2.jpg',
-          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p2.jpg',
+          fileType: DriveFileType.photo, fileName: 'p2.jpg',
           fileSizeBytes: 100, capturedAt: DateTime(2026));
 
       await repo.markCompleted('j1', driveFileId: 'drive-1');
@@ -55,7 +55,7 @@ void main() {
       final repo = DriveUploadRepository(db);
 
       await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
-          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileType: DriveFileType.photo, fileName: 'p1.jpg',
           fileSizeBytes: 100, capturedAt: DateTime(2026));
       await repo.markFailed('j1',
           reason: 'err', retryCount: 1,
@@ -71,7 +71,7 @@ void main() {
       final repo = DriveUploadRepository(db);
 
       await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
-          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileType: DriveFileType.photo, fileName: 'p1.jpg',
           fileSizeBytes: 100, capturedAt: DateTime(2026));
       await repo.markDead('j1', reason: 'file missing');
 
@@ -86,7 +86,7 @@ void main() {
       final repo = DriveUploadRepository(db);
 
       await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
-          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileType: DriveFileType.photo, fileName: 'p1.jpg',
           fileSizeBytes: 100, capturedAt: DateTime(2026));
       await repo.markDead('j1', reason: 'err');
       await repo.resetForRetry('j1');
@@ -95,6 +95,7 @@ void main() {
       expect(all.first.status, DriveUploadJobStatus.pending);
       expect(all.first.retryCount, 0);
       expect(all.first.failureReason, isNull);
+      expect(all.first.nextRetryAt, isNull);
     });
 
     test('resetFailedToPending resets failed jobs only, not dead', () async {
@@ -103,10 +104,10 @@ void main() {
       final repo = DriveUploadRepository(db);
 
       await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
-          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileType: DriveFileType.photo, fileName: 'p1.jpg',
           fileSizeBytes: 100, capturedAt: DateTime(2026));
       await repo.insertJob(id: 'j2', assignmentId: 'a1', filePath: '/p2.jpg',
-          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p2.jpg',
+          fileType: DriveFileType.photo, fileName: 'p2.jpg',
           fileSizeBytes: 100, capturedAt: DateTime(2026));
 
       await repo.markFailed('j1', reason: 'net', retryCount: 1,
@@ -128,7 +129,7 @@ void main() {
       final repo = DriveUploadRepository(db);
 
       await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
-          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileType: DriveFileType.photo, fileName: 'p1.jpg',
           fileSizeBytes: 100, capturedAt: DateTime(2026));
 
       expect(await repo.jobExistsForFilePath('/p1.jpg'), isTrue);
@@ -141,11 +142,26 @@ void main() {
       final repo = DriveUploadRepository(db);
 
       await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/a1.zip',
-          fileType: DriveUploadJobStatus.typeShapefile, fileName: 'a1.zip',
+          fileType: DriveFileType.shapefile, fileName: 'a1.zip',
           fileSizeBytes: 1000, capturedAt: DateTime(2026));
       await repo.markCompleted('j1', driveFileId: 'drive-1');
 
       expect(await repo.shapefileJobExistsForAssignment('a1'), isFalse);
+    });
+
+    test('markCompleted clears resumableUri', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+          fileType: DriveFileType.photo, fileName: 'p1.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+      await repo.setResumableUri('j1', 'https://resumable-uri');
+      await repo.markCompleted('j1', driveFileId: 'drive-1');
+
+      final all = await db.select(db.driveUploadJobs).get();
+      expect(all.first.resumableUri, isNull);
     });
   });
 }

--- a/test/core/drive/drive_upload_repository_test.dart
+++ b/test/core/drive/drive_upload_repository_test.dart
@@ -1,0 +1,151 @@
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+AppDatabase _db() => AppDatabase.forTesting(NativeDatabase.memory());
+
+void main() {
+  group('DriveUploadRepository', () {
+    test('insertJob creates a pending job', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(
+        id: 'j1',
+        assignmentId: 'a1',
+        filePath: '/photos/p1.jpg',
+        fileType: DriveUploadJobStatus.typePhoto,
+        fileName: 'p1.jpg',
+        fileSizeBytes: 1024,
+        capturedAt: DateTime(2026, 5, 2),
+      );
+
+      final jobs = await repo.getPendingJobs();
+      expect(jobs.length, 1);
+      expect(jobs.first.status, DriveUploadJobStatus.pending);
+    });
+
+    test('getPendingJobs excludes completed and future-retry jobs', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+      await repo.insertJob(id: 'j2', assignmentId: 'a1', filePath: '/p2.jpg',
+          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p2.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+
+      await repo.markCompleted('j1', driveFileId: 'drive-1');
+      await repo.markFailed('j2',
+          reason: 'network', retryCount: 1,
+          nextRetryAt: DateTime.now().add(const Duration(hours: 1)));
+
+      final jobs = await repo.getPendingJobs();
+      expect(jobs, isEmpty);
+    });
+
+    test('getPendingJobs includes failed jobs whose retry time has passed', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+      await repo.markFailed('j1',
+          reason: 'err', retryCount: 1,
+          nextRetryAt: DateTime.now().subtract(const Duration(seconds: 1)));
+
+      final jobs = await repo.getPendingJobs();
+      expect(jobs.length, 1);
+    });
+
+    test('markDead sets status=dead and failureReason', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+      await repo.markDead('j1', reason: 'file missing');
+
+      final all = await db.select(db.driveUploadJobs).get();
+      expect(all.first.status, DriveUploadJobStatus.dead);
+      expect(all.first.failureReason, 'file missing');
+    });
+
+    test('resetForRetry resets retryCount and status to pending', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+      await repo.markDead('j1', reason: 'err');
+      await repo.resetForRetry('j1');
+
+      final all = await db.select(db.driveUploadJobs).get();
+      expect(all.first.status, DriveUploadJobStatus.pending);
+      expect(all.first.retryCount, 0);
+      expect(all.first.failureReason, isNull);
+    });
+
+    test('resetFailedToPending resets failed jobs only, not dead', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+      await repo.insertJob(id: 'j2', assignmentId: 'a1', filePath: '/p2.jpg',
+          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p2.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+
+      await repo.markFailed('j1', reason: 'net', retryCount: 1,
+          nextRetryAt: DateTime.now().add(const Duration(hours: 1)));
+      await repo.markDead('j2', reason: 'perma');
+
+      await repo.resetFailedToPending();
+
+      final all = await db.select(db.driveUploadJobs).get();
+      final j1 = all.firstWhere((j) => j.id == 'j1');
+      final j2 = all.firstWhere((j) => j.id == 'j2');
+      expect(j1.status, DriveUploadJobStatus.pending);
+      expect(j2.status, DriveUploadJobStatus.dead); // unchanged
+    });
+
+    test('jobExistsForFilePath returns true when non-completed job exists', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+          fileType: DriveUploadJobStatus.typePhoto, fileName: 'p1.jpg',
+          fileSizeBytes: 100, capturedAt: DateTime(2026));
+
+      expect(await repo.jobExistsForFilePath('/p1.jpg'), isTrue);
+      expect(await repo.jobExistsForFilePath('/other.jpg'), isFalse);
+    });
+
+    test('shapefileJobExistsForAssignment returns false when only completed', () async {
+      final db = _db();
+      addTearDown(db.close);
+      final repo = DriveUploadRepository(db);
+
+      await repo.insertJob(id: 'j1', assignmentId: 'a1', filePath: '/a1.zip',
+          fileType: DriveUploadJobStatus.typeShapefile, fileName: 'a1.zip',
+          fileSizeBytes: 1000, capturedAt: DateTime(2026));
+      await repo.markCompleted('j1', driveFileId: 'drive-1');
+
+      expect(await repo.shapefileJobExistsForAssignment('a1'), isFalse);
+    });
+  });
+}

--- a/test/core/drive/drive_upload_repository_test.dart
+++ b/test/core/drive/drive_upload_repository_test.dart
@@ -136,7 +136,7 @@ void main() {
       expect(await repo.jobExistsForFilePath('/other.jpg'), isFalse);
     });
 
-    test('shapefileJobExistsForAssignment returns false when only completed', () async {
+    test('shapefileJobExistsForAssignment returns true when job is completed', () async {
       final db = _db();
       addTearDown(db.close);
       final repo = DriveUploadRepository(db);
@@ -146,7 +146,7 @@ void main() {
           fileSizeBytes: 1000, capturedAt: DateTime(2026));
       await repo.markCompleted('j1', driveFileId: 'drive-1');
 
-      expect(await repo.shapefileJobExistsForAssignment('a1'), isFalse);
+      expect(await repo.shapefileJobExistsForAssignment('a1'), isTrue);
     });
 
     test('markCompleted clears resumableUri', () async {

--- a/test/core/drive/drive_upload_worker_test.dart
+++ b/test/core/drive/drive_upload_worker_test.dart
@@ -95,8 +95,8 @@ void main() {
       rootFolderId: 'root-folder',
     );
 
-    // Drain 3× with retry time set to past each time
-    for (var i = 0; i < 3; i++) {
+    // Drain 4× with retry time set to past each time
+    for (var i = 0; i < 4; i++) {
       // Reset nextRetryAt to past so it's eligible
       await db.customStatement(
         'UPDATE drive_upload_jobs SET next_retry_at = NULL WHERE id = ?',

--- a/test/core/drive/drive_upload_worker_test.dart
+++ b/test/core/drive/drive_upload_worker_test.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/drive/drive_upload_worker.dart';
+import 'package:firecheck/core/drive/fake_drive_upload_api.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('worker_test_');
+  });
+  tearDown(() async {
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  Future<String> _seedPhoto(AppDatabase db, DriveUploadRepository repo, String id) async {
+    final path = '${tempDir.path}/$id.jpg';
+    await File(path).writeAsBytes([0xFF, 0xD8]);
+    await repo.insertJob(
+      id: id, assignmentId: 'a1', filePath: path,
+      fileType: DriveFileType.photo, fileName: '$id.jpg',
+      fileSizeBytes: 2, capturedAt: DateTime(2026),
+    );
+    return path;
+  }
+
+  // Seed the assignment row so _resolveParentFolder can find it
+  Future<void> _seedAssignment(AppDatabase db) async {
+    await db.into(db.assignments).insert(AssignmentsCompanion.insert(
+      id: 'a1', enumeratorId: 'e1', campaignId: 'c1',
+      boundaryPolygonGeojson: '{}', createdAt: DateTime(2026),
+    ));
+  }
+
+  test('drain marks job completed on successful upload', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    final api = FakeDriveUploadApi();
+    await _seedAssignment(db);
+    await _seedPhoto(db, repo, 'j1');
+
+    final worker = DriveUploadWorker(
+      api: api,
+      repo: repo,
+      db: db,
+      rootFolderId: 'root-folder',
+    );
+    await worker.drain();
+
+    final jobs = await db.select(db.driveUploadJobs).get();
+    expect(jobs.first.status, DriveUploadJobStatus.completed);
+    expect(jobs.first.driveFileId, isNotNull);
+    expect(api.uploadedPaths.length, 1);
+  });
+
+  test('drain marks job failed on transient error (retryCount increments)', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    final api = FakeDriveUploadApi(throwOnUpload: true);
+    await _seedAssignment(db);
+    await _seedPhoto(db, repo, 'j1');
+
+    final worker = DriveUploadWorker(
+      api: api,
+      repo: repo,
+      db: db,
+      rootFolderId: 'root-folder',
+    );
+    await worker.drain();
+
+    final jobs = await db.select(db.driveUploadJobs).get();
+    expect(jobs.first.status, DriveUploadJobStatus.failed);
+    expect(jobs.first.retryCount, 1);
+    expect(jobs.first.nextRetryAt, isNotNull);
+  });
+
+  test('drain marks job dead after 3 failures', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    final api = FakeDriveUploadApi(throwOnUpload: true);
+    await _seedAssignment(db);
+    await _seedPhoto(db, repo, 'j1');
+
+    final worker = DriveUploadWorker(
+      api: api,
+      repo: repo,
+      db: db,
+      rootFolderId: 'root-folder',
+    );
+
+    // Drain 3× with retry time set to past each time
+    for (var i = 0; i < 3; i++) {
+      // Reset nextRetryAt to past so it's eligible
+      await db.customStatement(
+        'UPDATE drive_upload_jobs SET next_retry_at = NULL WHERE id = ?',
+        ['j1'],
+      );
+      await worker.drain();
+    }
+
+    final jobs = await db.select(db.driveUploadJobs).get();
+    expect(jobs.first.status, DriveUploadJobStatus.dead);
+  });
+
+  test('drain skips job whose local file is missing', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    final api = FakeDriveUploadApi();
+    await _seedAssignment(db);
+    await repo.insertJob(
+      id: 'j1', assignmentId: 'a1',
+      filePath: '/nonexistent/missing.jpg',
+      fileType: DriveFileType.photo, fileName: 'missing.jpg',
+      fileSizeBytes: 0, capturedAt: DateTime(2026),
+    );
+
+    final worker = DriveUploadWorker(
+      api: api,
+      repo: repo,
+      db: db,
+      rootFolderId: 'root-folder',
+    );
+    await worker.drain();
+
+    final jobs = await db.select(db.driveUploadJobs).get();
+    expect(jobs.first.status, DriveUploadJobStatus.dead);
+    expect(jobs.first.failureReason, contains('missing'));
+    expect(api.uploadedPaths, isEmpty);
+  });
+}

--- a/test/core/drive/enqueue_assignment_use_case_test.dart
+++ b/test/core/drive/enqueue_assignment_use_case_test.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/drive/enqueue_assignment_use_case.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('enqueue_test_');
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  Future<AppDatabase> _seedDb() async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    await db.into(db.assignments).insert(AssignmentsCompanion.insert(
+      id: 'a1', enumeratorId: 'e1', campaignId: 'c1',
+      boundaryPolygonGeojson: '{}', createdAt: DateTime(2026),
+    ));
+    await db.into(db.features).insert(FeaturesCompanion.insert(
+      id: 'f1', assignmentId: 'a1', featureType: 'building',
+      geometryGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}',
+      status: const Value('complete'), createdAt: DateTime(2026),
+    ));
+    await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+      id: 's1', featureId: 'f1', createdAt: DateTime(2026), updatedAt: DateTime(2026),
+    ));
+    await db.into(db.buildingAttributes).insert(BuildingAttributesCompanion.insert(
+      submissionId: 's1',
+      fireFightingFacilitiesJson: const Value('[]'),
+      fireLoadJson: const Value('[]'),
+      costIsExact: const Value(false),
+    ));
+    await db.into(db.photos).insert(PhotosCompanion.insert(
+      id: 'ph1', submissionId: 's1',
+      localPath: '${tempDir.path}/photo1.jpg',
+      capturedAt: DateTime(2026), createdAt: DateTime(2026),
+    ));
+    // Create the photo file so File.length() succeeds
+    await File('${tempDir.path}/photo1.jpg').writeAsBytes([0xFF, 0xD8]);
+    return db;
+  }
+
+  test('enqueue creates shapefile job + photo job', () async {
+    final db = await _seedDb();
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    final exporter = ShapefileExporter(db: db, tempDirOverride: tempDir);
+    final useCase = EnqueueAssignmentUseCase(
+      db: db,
+      repo: repo,
+      exporter: exporter,
+    );
+
+    final count = await useCase.execute(assignmentId: 'a1');
+
+    expect(count, 2); // 1 shapefile + 1 photo
+    final jobs = await repo.getPendingJobs();
+    expect(jobs.length, 2);
+    expect(jobs.any((j) => j.fileType == DriveFileType.shapefile), isTrue);
+    expect(jobs.any((j) => j.fileType == DriveFileType.photo), isTrue);
+  });
+
+  test('enqueue is idempotent — second call adds no new jobs', () async {
+    final db = await _seedDb();
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    final exporter = ShapefileExporter(db: db, tempDirOverride: tempDir);
+    final useCase = EnqueueAssignmentUseCase(db: db, repo: repo, exporter: exporter);
+
+    await useCase.execute(assignmentId: 'a1');
+    final secondCount = await useCase.execute(assignmentId: 'a1');
+
+    expect(secondCount, 0);
+    final jobs = await db.select(db.driveUploadJobs).get();
+    expect(jobs.length, 2); // still 2, no duplicates
+  });
+}

--- a/test/core/sync/shapefile/export/shapefile_exporter_export_to_file_test.dart
+++ b/test/core/sync/shapefile/export/shapefile_exporter_export_to_file_test.dart
@@ -72,4 +72,40 @@ void main() {
     expect(p.extension(path!), '.zip');
     expect(File(path).existsSync(), isTrue);
   });
+
+  test('exportToFile never invokes shareFile even when one is provided', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    await db.into(db.assignments).insert(AssignmentsCompanion.insert(
+      id: 'a1', enumeratorId: 'e1', campaignId: 'c1',
+      boundaryPolygonGeojson: '{}', createdAt: DateTime(2026),
+    ));
+    await db.into(db.features).insert(FeaturesCompanion.insert(
+      id: 'f1', assignmentId: 'a1', featureType: 'building',
+      geometryGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}',
+      status: const Value('complete'),
+      createdAt: DateTime(2026),
+    ));
+    await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+      id: 's1', featureId: 'f1', createdAt: DateTime(2026), updatedAt: DateTime(2026),
+    ));
+    await db.into(db.buildingAttributes).insert(BuildingAttributesCompanion.insert(
+      submissionId: 's1',
+      fireFightingFacilitiesJson: const Value('[]'),
+      fireLoadJson: const Value('[]'),
+      costIsExact: const Value(false),
+    ));
+
+    var shareCalled = false;
+    final exporter = ShapefileExporter(
+      db: db,
+      shareFile: (_) async { shareCalled = true; },
+      tempDirOverride: tempDir,
+    );
+    final (failure, _) = await exporter.exportToFile(assignmentId: 'a1');
+
+    expect(failure, isNull);
+    expect(shareCalled, isFalse);
+  });
 }

--- a/test/core/sync/shapefile/export/shapefile_exporter_export_to_file_test.dart
+++ b/test/core/sync/shapefile/export/shapefile_exporter_export_to_file_test.dart
@@ -1,0 +1,75 @@
+// test/core/sync/shapefile/export/shapefile_exporter_export_to_file_test.dart
+import 'dart:io';
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/shapefile/export/export_failure.dart';
+import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('shapefile_test_');
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  test('exportToFile returns NoCompletedFeatures when assignment has no complete features', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    // Insert assignment + feature without completion
+    await db.into(db.assignments).insert(AssignmentsCompanion.insert(
+      id: 'a1',
+      enumeratorId: 'e1',
+      campaignId: 'c1',
+      boundaryPolygonGeojson: '{}',
+      createdAt: DateTime(2026),
+    ));
+
+    final exporter = ShapefileExporter(db: db, tempDirOverride: tempDir);
+    final (failure, path) = await exporter.exportToFile(assignmentId: 'a1');
+
+    expect(failure, isA<NoCompletedFeatures>());
+    expect(path, isNull);
+  });
+
+  test('exportToFile writes ZIP to tempDirOverride and returns path', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    // Seed a complete building feature
+    await db.into(db.assignments).insert(AssignmentsCompanion.insert(
+      id: 'a1', enumeratorId: 'e1', campaignId: 'c1',
+      boundaryPolygonGeojson: '{}', createdAt: DateTime(2026),
+    ));
+    await db.into(db.features).insert(FeaturesCompanion.insert(
+      id: 'f1', assignmentId: 'a1', featureType: 'building',
+      geometryGeojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}',
+      status: const Value('complete'),
+      createdAt: DateTime(2026),
+    ));
+    await db.into(db.submissions).insert(SubmissionsCompanion.insert(
+      id: 's1', featureId: 'f1', createdAt: DateTime(2026), updatedAt: DateTime(2026),
+    ));
+    await db.into(db.buildingAttributes).insert(BuildingAttributesCompanion.insert(
+      submissionId: 's1',
+      fireFightingFacilitiesJson: const Value('[]'),
+      fireLoadJson: const Value('[]'),
+      costIsExact: const Value(false),
+    ));
+
+    final exporter = ShapefileExporter(db: db, tempDirOverride: tempDir);
+    final (failure, path) = await exporter.exportToFile(assignmentId: 'a1');
+
+    expect(failure, isNull);
+    expect(path, isNotNull);
+    expect(p.extension(path!), '.zip');
+    expect(File(path).existsSync(), isTrue);
+  });
+}

--- a/test/features/auth/fake_google_auth_repository_test.dart
+++ b/test/features/auth/fake_google_auth_repository_test.dart
@@ -29,4 +29,9 @@ void main() {
     final repo = FakeGoogleAuthRepository();
     expect(await repo.getEnumeratorId(), 'test-enumerator');
   });
+
+  test('requestDriveUploadScope returns true', () async {
+    final repo = FakeGoogleAuthRepository();
+    expect(await repo.requestDriveUploadScope(), isTrue);
+  });
 }

--- a/test/features/auth/google_auth_notifier_test.dart
+++ b/test/features/auth/google_auth_notifier_test.dart
@@ -13,6 +13,8 @@ class _ThrowingAuthRepository implements GoogleAuthRepository {
   Future<void> signOut() async {}
   @override
   Future<String> getEnumeratorId() async => 'test-enumerator';
+  @override
+  Future<bool> requestDriveUploadScope() async => false;
 }
 
 void main() {

--- a/test/features/auth/google_auth_repository_drive_scope_test.dart
+++ b/test/features/auth/google_auth_repository_drive_scope_test.dart
@@ -1,0 +1,31 @@
+// test/features/auth/google_auth_repository_drive_scope_test.dart
+import 'package:firecheck/features/auth/data/google_auth_repository.dart';
+import 'package:firecheck/features/auth/data/google_sign_in_auth_repository.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+class _MockGoogleSignIn extends Mock implements GoogleSignIn {}
+
+class _MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
+
+void main() {
+  test('requestDriveUploadScope calls requestScopes with drive.file scope',
+      () async {
+    final mockSignIn = _MockGoogleSignIn();
+    final mockStorage = _MockFlutterSecureStorage();
+    when(() => mockSignIn.requestScopes(any())).thenAnswer((_) async => true);
+
+    final repo = GoogleSignInAuthRepository(
+      googleSignIn: mockSignIn,
+      secureStorage: mockStorage,
+    );
+    final result = await repo.requestDriveUploadScope();
+
+    expect(result, isTrue);
+    verify(() => mockSignIn.requestScopes(
+          [GoogleAuthRepository.driveFileScope],
+        )).called(1);
+  });
+}

--- a/test/features/home/home_screen_test.dart
+++ b/test/features/home/home_screen_test.dart
@@ -1,8 +1,10 @@
+import 'package:firecheck/core/drive/drive_upload_providers.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_lock_providers.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_lock_state.dart';
 import 'package:firecheck/features/home/domain/progress_snapshot.dart';
 import 'package:firecheck/features/home/presentation/home_providers.dart';
 import 'package:firecheck/features/home/presentation/home_screen.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
 import 'package:firecheck/generated/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -15,6 +17,9 @@ void main() {
         progressProvider.overrideWith((ref) => stream),
         assignmentLockStateProvider.overrideWith(
           (ref) => Stream.value(const Unlocked()),
+        ),
+        driveUploadNotifierProvider.overrideWith(
+          (_) => DriveUploadNotifier.seeded(const DriveUploadState(jobs: [])),
         ),
       ],
       child: const MaterialApp(

--- a/test/features/home/home_screen_upload_banner_test.dart
+++ b/test/features/home/home_screen_upload_banner_test.dart
@@ -19,7 +19,7 @@ void main() {
         driveFileId: null, retryCount: 0, failureReason: null,
         nextRetryAt: null, createdAt: DateTime(2026),
       ),
-    ]);
+    ],);
 
     await tester.pumpWidget(ProviderScope(
       overrides: [
@@ -27,9 +27,9 @@ void main() {
             .overrideWith((_) => DriveUploadNotifier.seeded(state)),
       ],
       child: const MaterialApp(home: Scaffold(body: UploadBanner())),
-    ));
+    ),);
 
-    expect(find.textContaining('file'), findsAtLeastNWidgets(1));
+    expect(find.text('1 file ready to upload'), findsOneWidget);
   });
 
   testWidgets('UploadBanner hidden when no pending jobs', (tester) async {
@@ -40,7 +40,7 @@ void main() {
         ),
       ],
       child: const MaterialApp(home: Scaffold(body: UploadBanner())),
-    ));
+    ),);
 
     expect(find.byType(Card), findsNothing);
   });

--- a/test/features/home/home_screen_upload_banner_test.dart
+++ b/test/features/home/home_screen_upload_banner_test.dart
@@ -1,0 +1,47 @@
+// test/features/home/home_screen_upload_banner_test.dart
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_providers.dart';
+import 'package:firecheck/features/upload/presentation/upload_banner.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('UploadBanner shows pending count on HomeScreen', (tester) async {
+    final state = DriveUploadState(jobs: [
+      DriveUploadJob(
+        id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+        fileType: DriveFileType.photo, fileName: 'p1.jpg',
+        fileSizeBytes: 1024, capturedAt: DateTime(2026),
+        status: DriveUploadJobStatus.pending, resumableUri: null,
+        driveFileId: null, retryCount: 0, failureReason: null,
+        nextRetryAt: null, createdAt: DateTime(2026),
+      ),
+    ]);
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        driveUploadNotifierProvider
+            .overrideWith((_) => DriveUploadNotifier.seeded(state)),
+      ],
+      child: const MaterialApp(home: Scaffold(body: UploadBanner())),
+    ));
+
+    expect(find.textContaining('file'), findsAtLeastNWidgets(1));
+  });
+
+  testWidgets('UploadBanner hidden when no pending jobs', (tester) async {
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        driveUploadNotifierProvider.overrideWith(
+          (_) => DriveUploadNotifier.seeded(const DriveUploadState(jobs: [])),
+        ),
+      ],
+      child: const MaterialApp(home: Scaffold(body: UploadBanner())),
+    ));
+
+    expect(find.byType(Card), findsNothing);
+  });
+}

--- a/test/features/home/home_screen_upload_data_test.dart
+++ b/test/features/home/home_screen_upload_data_test.dart
@@ -1,3 +1,4 @@
+import 'package:firecheck/core/drive/drive_upload_providers.dart';
 import 'package:firecheck/core/security/biometric_gate.dart';
 import 'package:firecheck/core/security/biometric_gate_provider.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_lock_providers.dart';
@@ -5,6 +6,7 @@ import 'package:firecheck/features/assignment/presentation/assignment_lock_state
 import 'package:firecheck/features/home/domain/progress_snapshot.dart';
 import 'package:firecheck/features/home/presentation/home_providers.dart';
 import 'package:firecheck/features/home/presentation/home_screen.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
 import 'package:firecheck/generated/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -31,6 +33,9 @@ void main() {
             (ref) =>
                 Stream.value(Submitted(submittedAt: DateTime(2026, 4, 27))),
           ),
+          driveUploadNotifierProvider.overrideWith(
+            (_) => DriveUploadNotifier.seeded(const DriveUploadState(jobs: [])),
+          ),
         ],
         child: const MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -55,6 +60,9 @@ void main() {
             (ref) => Stream.value(const Unlocked()),
           ),
           biometricGateProvider.overrideWithValue(_FakeBiometric()),
+          driveUploadNotifierProvider.overrideWith(
+            (_) => DriveUploadNotifier.seeded(const DriveUploadState(jobs: [])),
+          ),
         ],
         child: const MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/test/features/upload/upload_banner_test.dart
+++ b/test/features/upload/upload_banner_test.dart
@@ -1,0 +1,88 @@
+// test/features/upload/upload_banner_test.dart
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_providers.dart';
+import 'package:firecheck/features/upload/presentation/upload_banner.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(Widget child, DriveUploadState state) {
+  return ProviderScope(
+    overrides: [
+      driveUploadNotifierProvider
+          .overrideWith((_) => DriveUploadNotifier.seeded(state)),
+    ],
+    child: MaterialApp(home: Scaffold(body: child)),
+  );
+}
+
+DriveUploadJob _makeJob({
+  required String id,
+  required String status,
+  required int sizeBytes,
+}) {
+  return DriveUploadJob(
+    id: id,
+    assignmentId: 'a1',
+    filePath: '/p.jpg',
+    fileType: 'photo',
+    fileName: 'p.jpg',
+    fileSizeBytes: sizeBytes,
+    capturedAt: DateTime(2026),
+    status: status,
+    resumableUri: null,
+    driveFileId: null,
+    retryCount: 0,
+    failureReason: null,
+    nextRetryAt: null,
+    createdAt: DateTime(2026),
+  );
+}
+
+void main() {
+  testWidgets('banner is hidden when no pending jobs', (tester) async {
+    await tester.pumpWidget(
+      _wrap(const UploadBanner(), const DriveUploadState(jobs: [])),
+    );
+
+    expect(find.byType(Card), findsNothing);
+    expect(find.textContaining('file'), findsNothing);
+  });
+
+  testWidgets('banner shows singular label for one pending job', (tester) async {
+    final state = DriveUploadState(jobs: [
+      _makeJob(id: 'j1', status: 'pending', sizeBytes: 1024 * 1024),
+    ]);
+
+    await tester.pumpWidget(_wrap(const UploadBanner(), state));
+
+    expect(find.text('1 file ready to upload'), findsOneWidget);
+    expect(find.text('1.0 MB'), findsOneWidget);
+  });
+
+  testWidgets('banner shows plural label for multiple pending jobs',
+      (tester) async {
+    final state = DriveUploadState(jobs: [
+      _makeJob(id: 'j1', status: 'pending', sizeBytes: 1024 * 1024),
+      _makeJob(id: 'j2', status: 'failed', sizeBytes: 2 * 1024 * 1024),
+    ]);
+
+    await tester.pumpWidget(_wrap(const UploadBanner(), state));
+
+    expect(find.text('2 files ready to upload'), findsOneWidget);
+    expect(find.text('3.0 MB'), findsOneWidget);
+  });
+
+  testWidgets('banner excludes uploading jobs from pending count',
+      (tester) async {
+    final state = DriveUploadState(jobs: [
+      _makeJob(id: 'j1', status: 'pending', sizeBytes: 1024 * 1024),
+      _makeJob(id: 'j2', status: 'uploading', sizeBytes: 5 * 1024 * 1024),
+    ]);
+
+    await tester.pumpWidget(_wrap(const UploadBanner(), state));
+
+    expect(find.text('1 file ready to upload'), findsOneWidget);
+  });
+}

--- a/test/features/upload/upload_banner_test.dart
+++ b/test/features/upload/upload_banner_test.dart
@@ -1,5 +1,6 @@
 // test/features/upload/upload_banner_test.dart
 import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
 import 'package:firecheck/core/drive/drive_upload_providers.dart';
 import 'package:firecheck/features/upload/presentation/upload_banner.dart';
 import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
@@ -52,7 +53,7 @@ void main() {
 
   testWidgets('banner shows singular label for one pending job', (tester) async {
     final state = DriveUploadState(jobs: [
-      _makeJob(id: 'j1', status: 'pending', sizeBytes: 1024 * 1024),
+      _makeJob(id: 'j1', status: DriveUploadJobStatus.pending, sizeBytes: 1024 * 1024),
     ]);
 
     await tester.pumpWidget(_wrap(const UploadBanner(), state));
@@ -64,8 +65,8 @@ void main() {
   testWidgets('banner shows plural label for multiple pending jobs',
       (tester) async {
     final state = DriveUploadState(jobs: [
-      _makeJob(id: 'j1', status: 'pending', sizeBytes: 1024 * 1024),
-      _makeJob(id: 'j2', status: 'failed', sizeBytes: 2 * 1024 * 1024),
+      _makeJob(id: 'j1', status: DriveUploadJobStatus.pending, sizeBytes: 1024 * 1024),
+      _makeJob(id: 'j2', status: DriveUploadJobStatus.failed, sizeBytes: 2 * 1024 * 1024),
     ]);
 
     await tester.pumpWidget(_wrap(const UploadBanner(), state));
@@ -77,8 +78,8 @@ void main() {
   testWidgets('banner excludes uploading jobs from pending count',
       (tester) async {
     final state = DriveUploadState(jobs: [
-      _makeJob(id: 'j1', status: 'pending', sizeBytes: 1024 * 1024),
-      _makeJob(id: 'j2', status: 'uploading', sizeBytes: 5 * 1024 * 1024),
+      _makeJob(id: 'j1', status: DriveUploadJobStatus.pending, sizeBytes: 1024 * 1024),
+      _makeJob(id: 'j2', status: DriveUploadJobStatus.uploading, sizeBytes: 5 * 1024 * 1024),
     ]);
 
     await tester.pumpWidget(_wrap(const UploadBanner(), state));

--- a/test/features/upload/upload_queue_notifier_test.dart
+++ b/test/features/upload/upload_queue_notifier_test.dart
@@ -37,13 +37,12 @@ void main() {
     // Trigger notifier creation (subscribes to the stream).
     container.read(driveUploadNotifierProvider);
 
-    // Wait for the Drift watch stream to emit at least one event.
-    await container
-        .read(driveUploadRepoProvider)
-        .watchQueue()
-        .first;
+    // Wait for the notifier's own state stream to emit a non-empty job list.
+    final state = await container
+        .read(driveUploadNotifierProvider.notifier)
+        .stream
+        .firstWhere((s) => s.jobs.isNotEmpty);
 
-    final state = container.read(driveUploadNotifierProvider);
     expect(state.pendingCount, 1);
   });
 }

--- a/test/features/upload/upload_queue_notifier_test.dart
+++ b/test/features/upload/upload_queue_notifier_test.dart
@@ -1,0 +1,49 @@
+// test/features/upload/upload_queue_notifier_test.dart
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_repository.dart';
+import 'package:firecheck/core/drive/drive_upload_worker.dart';
+import 'package:firecheck/core/drive/fake_drive_upload_api.dart';
+import 'package:firecheck/core/drive/drive_upload_providers.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('pendingCount reflects queue', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = DriveUploadRepository(db);
+    await repo.insertJob(
+      id: 'j1', assignmentId: 'a1', filePath: '/p1.jpg',
+      fileType: DriveFileType.photo, fileName: 'p1.jpg',
+      fileSizeBytes: 100, capturedAt: DateTime(2026),
+    );
+
+    final container = ProviderContainer(overrides: [
+      driveUploadRepoProvider.overrideWithValue(repo),
+      driveUploadWorkerProvider.overrideWithValue(
+        DriveUploadWorker(
+          api: FakeDriveUploadApi(),
+          repo: repo,
+          db: db,
+          rootFolderId: 'root',
+        ),
+      ),
+    ]);
+    addTearDown(container.dispose);
+
+    // Trigger notifier creation (subscribes to the stream).
+    container.read(driveUploadNotifierProvider);
+
+    // Wait for the Drift watch stream to emit at least one event.
+    await container
+        .read(driveUploadRepoProvider)
+        .watchQueue()
+        .first;
+
+    final state = container.read(driveUploadNotifierProvider);
+    expect(state.pendingCount, 1);
+  });
+}

--- a/test/features/upload/upload_queue_screen_test.dart
+++ b/test/features/upload/upload_queue_screen_test.dart
@@ -61,7 +61,7 @@ void main() {
         status: DriveUploadJobStatus.pending,
         fileName: 'photo1.jpg',
       ),
-    ]);
+    ],);
 
     await tester.pumpWidget(_wrap(state));
 
@@ -77,7 +77,7 @@ void main() {
         status: DriveUploadJobStatus.pending,
         fileName: 'photo1.jpg',
       ),
-    ]);
+    ],);
 
     await tester.pumpWidget(_wrap(state));
 
@@ -94,7 +94,7 @@ void main() {
         status: DriveUploadJobStatus.uploading,
         fileName: 'photo1.jpg',
       ),
-    ]);
+    ],);
 
     await tester.pumpWidget(_wrap(state));
 

--- a/test/features/upload/upload_queue_screen_test.dart
+++ b/test/features/upload/upload_queue_screen_test.dart
@@ -1,0 +1,106 @@
+// test/features/upload/upload_queue_screen_test.dart
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/drive/drive_upload_job_status.dart';
+import 'package:firecheck/core/drive/drive_upload_preferences.dart';
+import 'package:firecheck/core/drive/drive_upload_providers.dart';
+import 'package:firecheck/core/security/secure_storage.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_notifier.dart';
+import 'package:firecheck/features/upload/presentation/upload_queue_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+DriveUploadJob _makeJob({
+  required String id,
+  required String status,
+  required String fileName,
+}) {
+  return DriveUploadJob(
+    id: id,
+    assignmentId: 'a1',
+    filePath: '/p.jpg',
+    fileType: DriveFileType.photo,
+    fileName: fileName,
+    fileSizeBytes: 1024,
+    capturedAt: DateTime(2026),
+    status: status,
+    resumableUri: null,
+    driveFileId: null,
+    retryCount: 0,
+    failureReason: null,
+    nextRetryAt: null,
+    createdAt: DateTime(2026),
+  );
+}
+
+List<Override> _overrides(DriveUploadState state) => [
+      driveUploadNotifierProvider
+          .overrideWith((_) => DriveUploadNotifier.seeded(state)),
+      driveUploadPreferencesProvider
+          .overrideWithValue(DriveUploadPreferences(InMemorySecureStorage())),
+    ];
+
+Widget _wrap(DriveUploadState state) {
+  return ProviderScope(
+    overrides: _overrides(state),
+    child: const MaterialApp(home: UploadQueueScreen()),
+  );
+}
+
+void main() {
+  testWidgets('shows empty message when no pending files', (tester) async {
+    await tester.pumpWidget(_wrap(const DriveUploadState(jobs: [])));
+
+    expect(find.text('No pending uploads'), findsOneWidget);
+  });
+
+  testWidgets('shows file rows when jobs exist', (tester) async {
+    final state = DriveUploadState(jobs: [
+      _makeJob(
+        id: 'j1',
+        status: DriveUploadJobStatus.pending,
+        fileName: 'photo1.jpg',
+      ),
+    ]);
+
+    await tester.pumpWidget(_wrap(state));
+
+    expect(find.text('photo1.jpg'), findsOneWidget);
+    expect(find.textContaining('PENDING'), findsOneWidget);
+  });
+
+  testWidgets('Upload All button is present and enabled with pending jobs',
+      (tester) async {
+    final state = DriveUploadState(jobs: [
+      _makeJob(
+        id: 'j1',
+        status: DriveUploadJobStatus.pending,
+        fileName: 'photo1.jpg',
+      ),
+    ]);
+
+    await tester.pumpWidget(_wrap(state));
+
+    final btn = tester.widget<ElevatedButton>(
+      find.widgetWithText(ElevatedButton, 'Upload All'),
+    );
+    expect(btn.onPressed, isNotNull);
+  });
+
+  testWidgets('Upload All button disabled when uploading', (tester) async {
+    final state = DriveUploadState(jobs: [
+      _makeJob(
+        id: 'j1',
+        status: DriveUploadJobStatus.uploading,
+        fileName: 'photo1.jpg',
+      ),
+    ]);
+
+    await tester.pumpWidget(_wrap(state));
+
+    final btn = tester.widget<ElevatedButton>(
+      find.widgetWithText(ElevatedButton, 'Upload All'),
+    );
+    expect(btn.onPressed, isNull);
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a persistent upload queue (`DriveUploadJobs` Drift table, DB v8) populated when an assignment is completed via `EnqueueAssignmentUseCase`
- `DriveUploadWorker` processes up to 3 concurrent jobs, retries up to 3× (30s → 2m → 10m), then marks dead
- `DriveUploadController` gates uploads to Wi-Fi only; `DriveUploadWorkmanager` runs a background tick every ~15 min
- `GoogleDriveUploadApi` uploads to `/FieldData/{enumerator_id}/{YYYY-MM-DD}/photos|shapefiles/` using Drive v3
- `UploadBanner` on HomeScreen shows pending count; `UploadQueueScreen` shows per-file status with Upload All and auto-upload toggle
- `main.dart` wired: `drive.file` scope, `googleSignInProvider` override, `_DriveUploadBootstrap` starts controller and enqueues on assignment completion

## Test plan

- [ ] Run `flutter test test/core/db/ test/core/drive/ test/core/sync/shapefile/export/ test/features/auth/ test/features/upload/ test/features/home/home_screen_upload_banner_test.dart` — expect 45/45 pass
- [ ] Build and run on device; complete an assignment and verify `UploadBanner` appears on HomeScreen
- [ ] Tap banner → `UploadQueueScreen` opens; tap **Upload All** and verify files reach Drive under the correct folder path
- [ ] Toggle **Auto-upload**, restart app, confirm toggle persists
- [ ] Simulate Wi-Fi drop mid-upload; confirm job shows FAILED and retries on reconnect
- [ ] Verify Drive folder structure: `/FieldData/{enumerator_id}/{YYYY-MM-DD}/photos/` and `.../shapefiles/`

## Known deferred items (not blocking)

- Resumable uploads: `resumableUri` column is reserved; current implementation restarts on failure (documented)
- Re-auth snackbar: auth failures surface as FAILED jobs; user re-signs in via existing flow and taps retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)