### PR TITLE
feat(ux): show spinner immediately on 'Download Selected' tap (US-20)

### DIFF
--- a/lib/features/assignment/domain/get_maps_state.dart
+++ b/lib/features/assignment/domain/get_maps_state.dart
@@ -29,6 +29,14 @@ class PickingAssignment extends GetMapsState {
   double get overallProgress => 0.02;
 }
 
+/// Emitted immediately when the user taps "Download Selected", before any
+/// network calls, so the UI shows a spinner within one frame (US-20).
+class PreparingDownload extends GetMapsState {
+  const PreparingDownload();
+  @override
+  double get overallProgress => 0.02;
+}
+
 class InsufficientStorage extends GetMapsState {
   const InsufficientStorage({
     required this.requiredBytes,

--- a/lib/features/assignment/presentation/assignment_providers.dart
+++ b/lib/features/assignment/presentation/assignment_providers.dart
@@ -137,6 +137,9 @@ class GetMapsNotifier extends StateNotifier<GetMapsState> {
     final s = state;
     if (s is! PickingAssignment) return;
 
+    // Show spinner immediately so the user sees feedback within one frame (US-20).
+    state = const PreparingDownload();
+
     final selected =
         s.assignments.firstWhere((a) => a.assignmentId == s.selectedId);
     _selectedAssignment = selected;

--- a/lib/features/assignment/presentation/get_maps_screen.dart
+++ b/lib/features/assignment/presentation/get_maps_screen.dart
@@ -24,6 +24,7 @@ class GetMapsScreen extends ConsumerWidget {
               onStart: () => ref.read(getMapsNotifierProvider.notifier).start(),
             ),
           DiscoveringAssignments() => const _DiscoveringView(),
+          PreparingDownload() => const _DiscoveringView(),
           PickingAssignment() => _PickingAssignmentView(state: state),
           InsufficientStorage() => _InsufficientStorageView(state: state),
           DownloadingShapefiles() => _DownloadingShapefilesView(state: state),

--- a/test/features/assignment/get_maps_notifier_test.dart
+++ b/test/features/assignment/get_maps_notifier_test.dart
@@ -141,6 +141,20 @@ void main() {
     expect((n.state as PickingAssignment).selectedId, 'brgy-002');
   });
 
+  test('confirmDownload emits PreparingDownload immediately before any network call (US-20)', () async {
+    final n = _makeNotifier();
+    await n.start();
+    expect(n.state, isA<PickingAssignment>());
+
+    final states = <GetMapsState>[];
+    n.addListener(states.add, fireImmediately: false);
+
+    unawaited(n.confirmDownload());
+    await Future.microtask(() {});
+
+    expect(states.first, isA<PreparingDownload>());
+  });
+
   test('insufficient storage → InsufficientStorage state', () async {
     final n = _makeNotifier(availableBytes: 0);
     await n.start();


### PR DESCRIPTION
## Summary

- Adds `PreparingDownload` state to `GetMapsState` sealed class
- `confirmDownload()` emits `PreparingDownload` synchronously before any async network calls (`getTotalSize`, `getEnumeratorId`)
- Screen renders `_DiscoveringView` (spinner) for `PreparingDownload` — user sees feedback within one frame
- Test verifies `PreparingDownload` is the first state emitted on button tap

## Root cause

`confirmDownload()` previously stayed in `PickingAssignment` while performing two sequential network calls before transitioning to `DownloadingShapefiles`, making the UI feel unresponsive for 1–2 seconds after the tap.

## Test plan

- [ ] Tap "Download Selected" — spinner appears immediately (no lag on picker screen)
- [ ] Happy path still completes: spinner → download progress → import → tile download
- [ ] Insufficient storage path still works
- [ ] Already-downloaded delta skip still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)