### PR TITLE
feat(us35): download_events table — schema draft

### DIFF
--- a/supabase/migrations/014_download_events.sql
+++ b/supabase/migrations/014_download_events.sql
@@ -1,0 +1,14 @@
+-- supabase/migrations/014_download_events.sql
+-- Logs every shapefile download with per-file granularity.
+-- file_id is the Drive file ID — assignments can contain multiple files.
+-- Index on (enumerator_id, created_at desc) supports "recent activity" queries.
+create table public.download_events (
+  id            uuid primary key default gen_random_uuid(),
+  assignment_id uuid not null references public.assignments(id) on delete cascade,
+  file_id       text not null,
+  enumerator_id uuid not null references public.enumerators(id) on delete cascade,
+  created_at    timestamptz not null default now()
+);
+
+create index download_events_enumerator_activity
+  on public.download_events (enumerator_id, created_at desc);


### PR DESCRIPTION
## What

Adds the \`download_events\` table to log per-file shapefile downloads attributed to the enumerator.

Schema only — write path not wired up yet. Requesting schema review before proceeding.

## Schema

\`\`\`sql
create table public.download_events (
  id            uuid primary key default gen_random_uuid(),
  assignment_id uuid not null references public.assignments(id) on delete cascade,
  file_id       text not null,
  enumerator_id uuid not null references public.enumerators(id) on delete cascade,
  created_at    timestamptz not null default now()
);

create index download_events_enumerator_activity
  on public.download_events (enumerator_id, created_at desc);
\`\`\`

## Questions for reviewer

- Is \`file_id text\` the right type for the Drive file ID, or do we want a length constraint?
- Should \`assignment_id\` cascade delete, or set null (preserve history if assignment is deleted)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)