### PR TITLE
Multi-user attribution sync — Phase 3 (realtime subscription + connection state machine)

### DIFF
--- a/lib/core/sync/data/realtime_subscriber.dart
+++ b/lib/core/sync/data/realtime_subscriber.dart
@@ -1,0 +1,121 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' hide AuthState;
+
+/// Abstraction over a Supabase realtime channel so the realtime sync
+/// controller can be unit-tested without standing up a real socket. Tests
+/// provide a fake subscriber that emits events programmatically.
+///
+/// Each `subscribe` call returns a [RealtimeSubscription] that:
+///   - exposes a `Stream<void> events` — one tick per realtime payload,
+///   - exposes a `Future<bool> joined` — resolves once the channel reports
+///     `subscribed`, or false on `channelError` / `timedOut`,
+///   - has a `close()` that closes the channel and completes any pending
+///     joined-future as false.
+abstract class RealtimeSubscriber {
+  Future<RealtimeSubscription> subscribe();
+}
+
+abstract class RealtimeSubscription {
+  Stream<void> get events;
+
+  /// Resolves true on channel `subscribed`, false on `channelError` /
+  /// `timedOut` / explicit close. Never throws.
+  Future<bool> get joined;
+
+  Future<void> close();
+}
+
+/// Subscribes to inserts/updates/deletes on `public.submissions` and
+/// `public.features` filtered by RLS membership. The client side does
+/// **not** apply an `assignment_id` filter at the channel level — the
+/// `filter:` mechanism in Supabase realtime only supports a single-column
+/// equality, and `submissions` doesn't carry `assignment_id` directly.
+/// Instead the spec specifies "client-side filter on assignment_id" — we
+/// do that one level up by triggering a delta pull that itself scopes to
+/// the active assignment.
+class SupabaseRealtimeSubscriber implements RealtimeSubscriber {
+  SupabaseRealtimeSubscriber(this._client, {String channelTag = 'multi_user_sync'})
+      : _channelTag = channelTag;
+
+  final SupabaseClient _client;
+  final String _channelTag;
+
+  @override
+  Future<RealtimeSubscription> subscribe() async {
+    final eventsCtl = StreamController<void>.broadcast();
+    final joined = Completer<bool>();
+
+    void onAnyChange(PostgresChangePayload payload) {
+      eventsCtl.add(null);
+    }
+
+    final channel = _client.channel(_channelTag);
+
+    channel
+        .onPostgresChanges(
+          event: PostgresChangeEvent.all,
+          schema: 'public',
+          table: 'submissions',
+          callback: onAnyChange,
+        )
+        .onPostgresChanges(
+          event: PostgresChangeEvent.all,
+          schema: 'public',
+          table: 'features',
+          callback: onAnyChange,
+        )
+        .subscribe((status, error) {
+      debugPrint('[Realtime] channel status=$status err=$error');
+      switch (status) {
+        case RealtimeSubscribeStatus.subscribed:
+          if (!joined.isCompleted) joined.complete(true);
+        case RealtimeSubscribeStatus.channelError:
+        case RealtimeSubscribeStatus.timedOut:
+        case RealtimeSubscribeStatus.closed:
+          if (!joined.isCompleted) joined.complete(false);
+      }
+    });
+
+    return _SupabaseSubscription(
+      channel: channel,
+      eventsCtl: eventsCtl,
+      joined: joined,
+    );
+  }
+}
+
+class _SupabaseSubscription implements RealtimeSubscription {
+  _SupabaseSubscription({
+    required RealtimeChannel channel,
+    required StreamController<void> eventsCtl,
+    required Completer<bool> joined,
+  })  : _channel = channel,
+        _eventsCtl = eventsCtl,
+        _joined = joined;
+
+  final RealtimeChannel _channel;
+  final StreamController<void> _eventsCtl;
+  final Completer<bool> _joined;
+  bool _closed = false;
+
+  @override
+  Stream<void> get events => _eventsCtl.stream;
+
+  @override
+  Future<bool> get joined => _joined.future;
+
+  @override
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    if (!_joined.isCompleted) _joined.complete(false);
+    try {
+      await _channel.unsubscribe();
+    } on Object catch (e) {
+      debugPrint('[Realtime] unsubscribe failed: $e');
+    }
+    await _eventsCtl.close();
+  }
+}

--- a/lib/core/sync/domain/realtime_connection_state.dart
+++ b/lib/core/sync/domain/realtime_connection_state.dart
@@ -1,0 +1,24 @@
+/// State machine for the realtime sync subscription, per the spec's
+/// "Connection state machine" section:
+///
+/// ```text
+/// offline → reconnecting → online → backgrounded → offline
+/// ```
+///
+/// Transitions:
+///   - `offline → reconnecting`: network restored OR controller started.
+///   - `reconnecting → online`: delta pull completed AND channel reported
+///     `subscribed`. Subscription is opened **after** the delta pull, so
+///     realtime events can't land before the cache has caught up.
+///   - `online → backgrounded`: app moved to background. Subscription is
+///     kept open for `backgroundUnsubscribeAfter` (default 2 min) to keep
+///     the cache live for quick foreground returns.
+///   - `backgrounded → offline`: grace window elapsed; subscription closed.
+///   - `backgrounded → reconnecting`: app resumed before grace elapsed.
+///   - any state `→ offline`: network lost, error, or explicit stop.
+enum RealtimeConnectionState {
+  offline,
+  reconnecting,
+  online,
+  backgrounded,
+}

--- a/lib/core/sync/presentation/remote_cache_providers.dart
+++ b/lib/core/sync/presentation/remote_cache_providers.dart
@@ -1,8 +1,11 @@
 import 'package:drift/drift.dart';
 import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/data/realtime_subscriber.dart';
 import 'package:firecheck/core/sync/data/remote_attributions_cache_repository.dart';
 import 'package:firecheck/core/sync/data/remote_attributions_pull_service.dart';
 import 'package:firecheck/core/sync/data/remote_cache_api.dart';
+import 'package:firecheck/core/sync/worker/realtime_sync_controller.dart';
+import 'package:firecheck/core/sync/worker/realtime_wiring.dart';
 import 'package:firecheck/core/sync/worker/remote_cache_controller.dart';
 import 'package:firecheck/features/home/presentation/home_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -33,6 +36,29 @@ final remoteCacheControllerProvider =
   );
   ref.onDispose(controller.stop);
   return controller;
+});
+
+final realtimeSubscriberProvider = Provider<RealtimeSubscriber>((ref) {
+  return SupabaseRealtimeSubscriber(Supabase.instance.client);
+});
+
+final realtimeSyncControllerProvider =
+    Provider<RealtimeSyncController>((ref) {
+  final controller = RealtimeSyncController(
+    subscriber: ref.watch(realtimeSubscriberProvider),
+    pullService: ref.watch(remoteAttributionsPullServiceProvider),
+    db: ref.watch(appDatabaseProvider),
+  );
+  ref.onDispose(controller.stop);
+  return controller;
+});
+
+final realtimeWiringProvider = Provider<RealtimeWiring>((ref) {
+  final wiring = RealtimeWiring(
+    controller: ref.watch(realtimeSyncControllerProvider),
+  );
+  ref.onDispose(wiring.dispose);
+  return wiring;
 });
 
 /// Live stream of canonical remote attributions for an assignment.

--- a/lib/core/sync/worker/realtime_sync_controller.dart
+++ b/lib/core/sync/worker/realtime_sync_controller.dart
@@ -1,0 +1,229 @@
+import 'dart:async';
+
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/data/realtime_subscriber.dart';
+import 'package:firecheck/core/sync/data/remote_attributions_pull_service.dart';
+import 'package:firecheck/core/sync/domain/realtime_connection_state.dart';
+import 'package:flutter/foundation.dart';
+
+/// Phase 3 of multi-user attribution sync.
+///
+/// Owns the `offline → reconnecting → online → backgrounded → offline`
+/// state machine and the realtime subscription that drives it. Realtime
+/// events trigger a debounced delta pull through [RemoteAttributionsPullService]
+/// so cache writes go through the same upsert path as cold-open and
+/// reconnect pulls (the spec's `cacheUpsertFromServerRows` invariant).
+///
+/// The controller deliberately does **not** parse realtime payloads — the
+/// Supabase realtime row for `public.submissions` doesn't include the
+/// joined typed-attribute child rows we need for the cache's
+/// `attribute_values` field, and `public.features` events deliver
+/// PostGIS WKB that's not trivially decodable on the client. Treating
+/// every event as "something changed, refetch the delta" trades a few
+/// hundred ms of latency for one well-tested code path.
+///
+/// The controller does **not** itself run the cold-open full pull — that
+/// happens via the phase-2 `RemoteCacheController`. Phase 3 layers
+/// realtime on top of the existing pull infrastructure.
+class RealtimeSyncController {
+  RealtimeSyncController({
+    required RealtimeSubscriber subscriber,
+    required RemoteAttributionsPullService pullService,
+    required AppDatabase db,
+    Duration backgroundUnsubscribeAfter = const Duration(minutes: 2),
+    Duration eventDebounce = const Duration(milliseconds: 250),
+  })  : _subscriber = subscriber,
+        _pullService = pullService,
+        _db = db,
+        _backgroundUnsubscribeAfter = backgroundUnsubscribeAfter,
+        _eventDebounce = eventDebounce;
+
+  final RealtimeSubscriber _subscriber;
+  final RemoteAttributionsPullService _pullService;
+  final AppDatabase _db;
+  final Duration _backgroundUnsubscribeAfter;
+  final Duration _eventDebounce;
+
+  final StreamController<RealtimeConnectionState> _stateCtl =
+      StreamController.broadcast();
+
+  RealtimeConnectionState _state = RealtimeConnectionState.offline;
+  RealtimeSubscription? _subscription;
+  StreamSubscription<void>? _eventsSub;
+  Timer? _debounceTimer;
+  Timer? _backgroundGraceTimer;
+  bool _disposed = false;
+  // Used to ignore late-arriving subscription completions from a previous
+  // connect attempt that's already been superseded.
+  int _connectGeneration = 0;
+
+  /// Current state. Initial value is [RealtimeConnectionState.offline].
+  RealtimeConnectionState get state => _state;
+
+  /// Broadcasts transitions in order. Replays nothing on subscribe — use
+  /// [state] for the current value.
+  Stream<RealtimeConnectionState> get states => _stateCtl.stream;
+
+  /// Triggered each time a realtime event was just consumed (after debounce).
+  /// Tests use this; production code reads the cache directly.
+  final StreamController<void> _onPullCtl = StreamController.broadcast();
+  Stream<void> get onDeltaPulled => _onPullCtl.stream;
+
+  /// Begin: starts in offline, attempts an immediate connect.
+  Future<void> start() async {
+    if (_disposed) return;
+    await _connect();
+  }
+
+  /// Tear down — closes subscription, cancels timers, transitions to offline.
+  Future<void> stop() async {
+    if (_disposed) return;
+    _disposed = true;
+    _connectGeneration++;
+    _debounceTimer?.cancel();
+    _backgroundGraceTimer?.cancel();
+    await _eventsSub?.cancel();
+    await _subscription?.close();
+    _subscription = null;
+    _transitionTo(RealtimeConnectionState.offline);
+    await _stateCtl.close();
+    await _onPullCtl.close();
+  }
+
+  /// Called by the connectivity listener when the network is restored.
+  Future<void> onNetworkRestored() async {
+    if (_disposed) return;
+    if (_state == RealtimeConnectionState.online ||
+        _state == RealtimeConnectionState.reconnecting) {
+      return;
+    }
+    await _connect();
+  }
+
+  /// Called by the connectivity listener when the network is lost.
+  Future<void> onNetworkLost() async {
+    if (_disposed) return;
+    await _teardownSubscription();
+    _transitionTo(RealtimeConnectionState.offline);
+  }
+
+  /// Called by the lifecycle listener when the app moves to background.
+  void onAppBackgrounded() {
+    if (_disposed) return;
+    if (_state != RealtimeConnectionState.online) return;
+    _transitionTo(RealtimeConnectionState.backgrounded);
+    _backgroundGraceTimer?.cancel();
+    _backgroundGraceTimer = Timer(_backgroundUnsubscribeAfter, () async {
+      if (_disposed) return;
+      if (_state != RealtimeConnectionState.backgrounded) return;
+      // Grace window elapsed — drop the subscription. Next foreground
+      // (or network-restore) reconnects.
+      await _teardownSubscription();
+      _transitionTo(RealtimeConnectionState.offline);
+    });
+  }
+
+  /// Called by the lifecycle listener when the app returns to foreground.
+  Future<void> onAppResumed() async {
+    if (_disposed) return;
+    _backgroundGraceTimer?.cancel();
+    _backgroundGraceTimer = null;
+
+    if (_state == RealtimeConnectionState.backgrounded &&
+        _subscription != null) {
+      // Subscription still alive — fire a catch-up delta pull and go online.
+      // We don't have to renegotiate the socket; the channel ride-alongs.
+      await _runDeltaPull();
+      _transitionTo(RealtimeConnectionState.online);
+      return;
+    }
+
+    // Subscription has been torn down (grace expired) or never existed.
+    await _connect();
+  }
+
+  // ----- internals -------------------------------------------------------
+
+  Future<void> _connect() async {
+    if (_disposed) return;
+    final assignmentId = await _currentAssignmentId();
+    if (assignmentId == null) {
+      _transitionTo(RealtimeConnectionState.offline);
+      return;
+    }
+
+    _connectGeneration++;
+    final myGen = _connectGeneration;
+
+    _transitionTo(RealtimeConnectionState.reconnecting);
+
+    // Per spec: subscription opens AFTER delta pull completes — otherwise
+    // realtime events could land before the cache catches up.
+    try {
+      await _pullService.pullDelta(assignmentId);
+    } on Object catch (e) {
+      debugPrint('[Realtime] pre-subscribe delta pull failed: $e');
+      // Keep going — events on the live channel will trigger their own pulls.
+    }
+
+    if (_disposed || myGen != _connectGeneration) return;
+
+    await _teardownSubscription();
+    final sub = await _subscriber.subscribe();
+    _subscription = sub;
+
+    _eventsSub = sub.events.listen((_) => _scheduleDeltaPull());
+
+    final joined = await sub.joined;
+    if (_disposed || myGen != _connectGeneration) {
+      await sub.close();
+      return;
+    }
+
+    if (joined) {
+      _transitionTo(RealtimeConnectionState.online);
+    } else {
+      await _teardownSubscription();
+      _transitionTo(RealtimeConnectionState.offline);
+    }
+  }
+
+  Future<void> _teardownSubscription() async {
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    await _eventsSub?.cancel();
+    _eventsSub = null;
+    await _subscription?.close();
+    _subscription = null;
+  }
+
+  void _scheduleDeltaPull() {
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(_eventDebounce, _runDeltaPull);
+  }
+
+  Future<void> _runDeltaPull() async {
+    if (_disposed) return;
+    final assignmentId = await _currentAssignmentId();
+    if (assignmentId == null) return;
+    try {
+      await _pullService.pullDelta(assignmentId);
+      if (!_onPullCtl.isClosed) _onPullCtl.add(null);
+    } on Object catch (e) {
+      debugPrint('[Realtime] delta pull failed: $e');
+    }
+  }
+
+  Future<String?> _currentAssignmentId() async {
+    final row =
+        await (_db.select(_db.assignments)..limit(1)).getSingleOrNull();
+    return row?.id;
+  }
+
+  void _transitionTo(RealtimeConnectionState next) {
+    if (_state == next) return;
+    debugPrint('[Realtime] ${_state.name} → ${next.name}');
+    _state = next;
+    if (!_stateCtl.isClosed) _stateCtl.add(next);
+  }
+}

--- a/lib/core/sync/worker/realtime_wiring.dart
+++ b/lib/core/sync/worker/realtime_wiring.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:firecheck/core/sync/worker/realtime_sync_controller.dart';
+import 'package:flutter/widgets.dart';
+
+/// Glue between platform inputs (connectivity, app lifecycle) and the
+/// [RealtimeSyncController]'s state-machine entry points.
+///
+/// Phase 2's `ConnectivityListener` / `SyncLifecycleListener` fire only on
+/// the "good" transition (connect / resume). The realtime state machine
+/// also needs the inverse transitions (disconnect / background) so we
+/// can drop the channel correctly. Rather than widen the existing
+/// listeners (and affect the push-side sync controller), this bridge
+/// owns its own stream subscriptions and translates them into controller
+/// method calls.
+class RealtimeWiring {
+  RealtimeWiring({
+    required RealtimeSyncController controller,
+    Stream<List<ConnectivityResult>>? connectivityStream,
+  })  : _controller = controller,
+        _connectivityStream = connectivityStream ??
+            Connectivity()
+                .onConnectivityChanged
+                .map((r) => <ConnectivityResult>[r]);
+
+  final RealtimeSyncController _controller;
+  final Stream<List<ConnectivityResult>> _connectivityStream;
+
+  StreamSubscription<List<ConnectivityResult>>? _connSub;
+  AppLifecycleListener? _lifecycle;
+
+  void start() {
+    _connSub = _connectivityStream.listen((results) async {
+      final online = results.any((r) => r != ConnectivityResult.none);
+      if (online) {
+        await _controller.onNetworkRestored();
+      } else {
+        await _controller.onNetworkLost();
+      }
+    });
+
+    _lifecycle = AppLifecycleListener(
+      onResume: () async => _controller.onAppResumed(),
+      onPause: _controller.onAppBackgrounded,
+      onHide: _controller.onAppBackgrounded,
+    );
+  }
+
+  Future<void> dispose() async {
+    await _connSub?.cancel();
+    _lifecycle?.dispose();
+    _lifecycle = null;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -170,13 +170,15 @@ class _SyncBootstrapState extends ConsumerState<_SyncBootstrap> {
     super.initState();
     Future.microtask(() async {
       await ref.read(syncControllerProvider).start();
-      // Phase 2 of multi-user attribution sync: cold-open full pull of
-      // remote canonical state for the active assignment, then listen for
-      // reconnects/resumes to fire delta pulls. Runs only when authenticated
-      // (the RPCs RLS-filter to membership, but skipping when signed-out
-      // avoids noisy logs).
+      // Phases 2 + 3 of multi-user attribution sync: cold-open full pull
+      // (phase 2) plus realtime subscription with connection state
+      // machine (phase 3). Runs only when authenticated — the server RPCs
+      // RLS-filter to membership, but skipping when signed-out avoids
+      // noisy logs.
       if (Supabase.instance.client.auth.currentSession != null) {
         await ref.read(remoteCacheControllerProvider).start();
+        ref.read(realtimeWiringProvider).start();
+        await ref.read(realtimeSyncControllerProvider).start();
       }
       _attachSubmittedLock();
     });

--- a/test/core/sync/worker/realtime_sync_controller_test.dart
+++ b/test/core/sync/worker/realtime_sync_controller_test.dart
@@ -1,0 +1,307 @@
+import 'dart:async';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/data/realtime_subscriber.dart';
+import 'package:firecheck/core/sync/data/remote_attributions_cache_repository.dart';
+import 'package:firecheck/core/sync/data/remote_attributions_pull_service.dart';
+import 'package:firecheck/core/sync/data/remote_cache_api.dart';
+import 'package:firecheck/core/sync/domain/realtime_connection_state.dart';
+import 'package:firecheck/core/sync/worker/realtime_sync_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Fake subscriber the test drives manually: trigger join success/failure,
+/// emit events on demand, observe close calls.
+class _FakeSubscriber implements RealtimeSubscriber {
+  _FakeSubscriber({this.autoJoin = true});
+
+  /// If true, the next subscribe completes the `joined` future with `true`
+  /// on the same microtask. Tests that want to assert the reconnecting →
+  /// online transition use this. Set to false to test reconnecting-then-
+  /// error paths.
+  bool autoJoin;
+
+  final List<_FakeSubscription> subs = [];
+
+  int subscribeCalls = 0;
+
+  @override
+  Future<RealtimeSubscription> subscribe() async {
+    subscribeCalls++;
+    final s = _FakeSubscription();
+    subs.add(s);
+    if (autoJoin) {
+      // Complete on a microtask so awaiters of `joined` get scheduled.
+      Future.microtask(() => s.completeJoin(true));
+    }
+    return s;
+  }
+}
+
+class _FakeSubscription implements RealtimeSubscription {
+  final StreamController<void> _eventsCtl = StreamController.broadcast();
+  final Completer<bool> _joined = Completer<bool>();
+  bool closed = false;
+
+  void emit() => _eventsCtl.add(null);
+
+  void completeJoin(bool ok) {
+    if (!_joined.isCompleted) _joined.complete(ok);
+  }
+
+  @override
+  Stream<void> get events => _eventsCtl.stream;
+
+  @override
+  Future<bool> get joined => _joined.future;
+
+  @override
+  Future<void> close() async {
+    closed = true;
+    if (!_joined.isCompleted) _joined.complete(false);
+    await _eventsCtl.close();
+  }
+}
+
+class _RecordingApi implements RemoteCacheApi {
+  int attribCalls = 0;
+  int newFeatCalls = 0;
+  DateTime? lastAttribSince;
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchAttributions(
+    String assignmentId, {
+    DateTime? since,
+  }) async {
+    attribCalls++;
+    lastAttribSince = since;
+    return const [];
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchNewFeatures(
+    String assignmentId, {
+    DateTime? since,
+  }) async {
+    newFeatCalls++;
+    return const [];
+  }
+}
+
+Future<void> _pump([int times = 8]) async {
+  for (var i = 0; i < times; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+void main() {
+  late AppDatabase db;
+  late RemoteAttributionsCacheRepository cache;
+  late _RecordingApi api;
+  late RemoteAttributionsPullService pull;
+  late _FakeSubscriber subscriber;
+  late RealtimeSyncController controller;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    cache = RemoteAttributionsCacheRepository(db);
+    api = _RecordingApi();
+    pull = RemoteAttributionsPullService(api: api, cache: cache);
+    subscriber = _FakeSubscriber();
+    controller = RealtimeSyncController(
+      subscriber: subscriber,
+      pullService: pull,
+      db: db,
+      eventDebounce: const Duration(milliseconds: 10),
+      backgroundUnsubscribeAfter: const Duration(milliseconds: 30),
+    );
+
+    await db.into(db.assignments).insert(
+          AssignmentsCompanion.insert(
+            id: 'a1',
+            enumeratorId: 'me',
+            campaignId: 'c1',
+            boundaryPolygonGeojson: '{}',
+            createdAt: DateTime(2026, 5, 18),
+          ),
+        );
+  });
+
+  tearDown(() async {
+    await controller.stop();
+    await db.close();
+  });
+
+  test('start: offline → reconnecting → online when join succeeds',
+      () async {
+    final transitions = <RealtimeConnectionState>[];
+    controller.states.listen(transitions.add);
+
+    expect(controller.state, RealtimeConnectionState.offline);
+    await controller.start();
+    await _pump();
+
+    expect(controller.state, RealtimeConnectionState.online);
+    expect(
+      transitions,
+      [
+        RealtimeConnectionState.reconnecting,
+        RealtimeConnectionState.online,
+      ],
+    );
+
+    expect(api.attribCalls, 1,
+        reason: 'pre-subscribe delta pull runs before opening the channel');
+    expect(subscriber.subscribeCalls, 1);
+  });
+
+  test('start returns to offline when channel fails to join', () async {
+    subscriber.autoJoin = false;
+    final transitions = <RealtimeConnectionState>[];
+    controller.states.listen(transitions.add);
+
+    final fut = controller.start();
+    await _pump();
+    // Now force the join future to resolve as false.
+    subscriber.subs.single.completeJoin(false);
+    await fut;
+    await _pump();
+
+    expect(controller.state, RealtimeConnectionState.offline);
+    expect(
+      transitions,
+      [
+        RealtimeConnectionState.reconnecting,
+        RealtimeConnectionState.offline,
+      ],
+    );
+  });
+
+  test('events fire debounced delta pulls', () async {
+    await controller.start();
+    await _pump();
+    expect(api.attribCalls, 1);
+
+    // Burst of events arrives within the debounce window — only one
+    // additional pull should fire.
+    subscriber.subs.single.emit();
+    subscriber.subs.single.emit();
+    subscriber.subs.single.emit();
+
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+    expect(api.attribCalls, 2,
+        reason: 'three events within debounce coalesce into one pull');
+  });
+
+  test('onNetworkLost drops subscription and goes offline', () async {
+    await controller.start();
+    await _pump();
+
+    final firstSub = subscriber.subs.single;
+    await controller.onNetworkLost();
+
+    expect(controller.state, RealtimeConnectionState.offline);
+    expect(firstSub.closed, isTrue);
+  });
+
+  test('onNetworkRestored from offline triggers reconnect', () async {
+    await controller.start();
+    await _pump();
+    await controller.onNetworkLost();
+    await _pump();
+    expect(controller.state, RealtimeConnectionState.offline);
+
+    await controller.onNetworkRestored();
+    await _pump();
+
+    expect(controller.state, RealtimeConnectionState.online);
+    expect(subscriber.subscribeCalls, 2);
+  });
+
+  test('onNetworkRestored is a no-op when already online', () async {
+    await controller.start();
+    await _pump();
+    expect(controller.state, RealtimeConnectionState.online);
+
+    await controller.onNetworkRestored();
+    await _pump();
+
+    expect(subscriber.subscribeCalls, 1,
+        reason: 'no fresh subscribe when already online');
+  });
+
+  test('backgrounded → resumed before grace expires keeps subscription',
+      () async {
+    await controller.start();
+    await _pump();
+    final sub = subscriber.subs.single;
+
+    controller.onAppBackgrounded();
+    expect(controller.state, RealtimeConnectionState.backgrounded);
+
+    // Resume well within the 30ms grace window.
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    await controller.onAppResumed();
+    await _pump();
+
+    expect(controller.state, RealtimeConnectionState.online);
+    expect(sub.closed, isFalse,
+        reason: 'subscription survives a short background interval');
+    expect(subscriber.subscribeCalls, 1);
+    expect(api.attribCalls, greaterThanOrEqualTo(2),
+        reason: 'resume should fire a catch-up delta pull');
+  });
+
+  test('backgrounded → grace expires → offline (subscription dropped)',
+      () async {
+    await controller.start();
+    await _pump();
+    final sub = subscriber.subs.single;
+
+    controller.onAppBackgrounded();
+    expect(controller.state, RealtimeConnectionState.backgrounded);
+
+    // Wait past the 30ms grace.
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    expect(controller.state, RealtimeConnectionState.offline);
+    expect(sub.closed, isTrue);
+  });
+
+  test('resume after grace-expired offline reconnects from scratch',
+      () async {
+    await controller.start();
+    await _pump();
+
+    controller.onAppBackgrounded();
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(controller.state, RealtimeConnectionState.offline);
+
+    await controller.onAppResumed();
+    await _pump();
+
+    expect(controller.state, RealtimeConnectionState.online);
+    expect(subscriber.subscribeCalls, 2);
+  });
+
+  test('stop tears down cleanly', () async {
+    await controller.start();
+    await _pump();
+    final sub = subscriber.subs.single;
+
+    await controller.stop();
+
+    expect(controller.state, RealtimeConnectionState.offline);
+    expect(sub.closed, isTrue);
+  });
+
+  test('start with no assignment stays offline (no subscribe)', () async {
+    await db.delete(db.assignments).go();
+    await controller.start();
+    await _pump();
+
+    expect(controller.state, RealtimeConnectionState.offline);
+    expect(subscriber.subscribeCalls, 0);
+  });
+}


### PR DESCRIPTION
## Summary

Phase 3 of multi-user attribution sync — **no UI yet**. Layers Supabase realtime on top of phase 2's pull infrastructure. Realtime events on `public.submissions` and `public.features` fire debounced delta pulls through the existing pull service, so cache writes always go through the same upsert path (the spec's `cacheUpsertFromServerRows` invariant).

> ⚠ Depends on **PR #56** (phase 2). Should be merged after #56.

## Key decisions

- **Subscription opens after the pre-subscribe delta pull completes**, per the spec — otherwise events could land before the cache has caught up.
- **Realtime events trigger a 250ms-debounced delta pull**, not inline payload parsing. The submissions realtime row doesn't include the joined typed-attribute child rows, and features events deliver PostGIS WKB; trading a few hundred ms of latency for one well-tested code path is the right call.
- **Client-side assignment filtering** (per spec) — Supabase realtime can't filter on a non-direct column, and `submissions` doesn't carry `assignment_id` directly. RLS membership filters at the channel level; the delta-pull RPCs filter to the active assignment.
- **2-minute background grace window** keeps the cache live for quick foreground returns; subscription drops afterwards to save battery.

## Structure

- `lib/core/sync/data/realtime_subscriber.dart` — `RealtimeSubscriber` interface + `SupabaseRealtimeSubscriber` impl so tests stub the channel surface without a real socket.
- `lib/core/sync/domain/realtime_connection_state.dart` — the enum + state-machine doc.
- `lib/core/sync/worker/realtime_sync_controller.dart` — owns the state machine, debounce timer, and background grace timer.
- `lib/core/sync/worker/realtime_wiring.dart` — bridges connectivity + `AppLifecycleListener` into the controller (needed both directions, not just onConnect/onResume).

## Verification

- ✅ 11 new tests cover every state transition deterministically with a fake subscriber + fake API:
  - `offline → reconnecting → online` on successful join.
  - `reconnecting → offline` on join failure.
  - Debounced delta pull on event bursts.
  - `online → offline` on `onNetworkLost`.
  - `offline → online` on `onNetworkRestored`.
  - `onNetworkRestored` is a no-op when already online.
  - `online → backgrounded → online` on quick resume (subscription survives).
  - `online → backgrounded → offline` when grace window elapses.
  - Resume after grace-expired offline reconnects from scratch.
  - `stop` tears down cleanly.
  - `start` with no assignment stays offline.
- ✅ Full suite: 755 passing, 3 pre-existing failures on `main`, no regressions.
- ✅ `dart analyze` on touched files: no errors.

## Test plan

- [ ] Apply phase 2 first (PR #56) — phase 3 builds on its pull infrastructure.
- [ ] Sign in on two devices with the same assignment; submit an attribution on device A; verify device B's cache row appears within ~1s (without leaving the app).
- [ ] Background the app on device B for >2 min, then foreground; verify a delta pull fires on resume.
- [ ] Toggle airplane mode on device B during a session; verify state transitions to offline; turn airplane mode off; verify `reconnecting → online`.

## Out of scope (next phases)

- Phase 4: Map badge UI driven by the cache.
- Phase 5: Switch upload path to new RPCs + conflict review + dedup UI.
- Phase 6: Decommission old upload path + orphan-photo cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)