### PR TITLE
Multi-user attribution sync — Phase 4 (map badge UI) + PR #56/#57 review fixes

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -7,6 +7,8 @@ import 'package:firecheck/features/auth/presentation/auth_providers.dart';
 import 'package:firecheck/features/auth/presentation/sign_in_screen.dart';
 import 'package:firecheck/features/home/presentation/home_screen.dart';
 import 'package:firecheck/features/map/presentation/map_screen.dart';
+import 'package:firecheck/features/remote_activity/presentation/remote_activity_list_screen.dart';
+import 'package:firecheck/features/remote_activity/presentation/remote_attribution_detail_screen.dart';
 import 'package:firecheck/features/review/presentation/review_screen.dart';
 import 'package:firecheck/features/survey/building_form/presentation/submission_detail_screen.dart';
 import 'package:firecheck/features/survey/olp_survey/presentation/result/olp_result_screen.dart';
@@ -108,6 +110,16 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/uploads',
         builder: (context, state) => const UploadQueueScreen(),
+      ),
+      GoRoute(
+        path: '/remote-activity',
+        builder: (context, state) => const RemoteActivityListScreen(),
+      ),
+      GoRoute(
+        path: '/remote-activity/:featureId',
+        builder: (context, state) => RemoteAttributionDetailScreen(
+          featureId: Uri.decodeComponent(state.pathParameters['featureId']!),
+        ),
       ),
     ],
   );

--- a/lib/core/sync/data/remote_attributions_pull_service.dart
+++ b/lib/core/sync/data/remote_attributions_pull_service.dart
@@ -73,13 +73,16 @@ class RemoteAttributionsPullService {
     DateTime? sinceAttributions,
     DateTime? sinceNewFeatures,
   }) async {
-    final attribFuture =
-        _api.fetchAttributions(assignmentId, since: sinceAttributions);
-    final newFeatFuture =
-        _api.fetchNewFeatures(assignmentId, since: sinceNewFeatures);
-
-    final attributions = await attribFuture;
-    final newFeatures = await newFeatFuture;
+    // Awaiting via Future.wait — not sequential awaits — so a thrown error
+    // in the first call still leaves the second future awaited. Sequential
+    // `await`s would orphan the second future and surface as an uncaught
+    // async exception outside our try/catch on transient network failures.
+    final results = await Future.wait<List<Map<String, dynamic>>>([
+      _api.fetchAttributions(assignmentId, since: sinceAttributions),
+      _api.fetchNewFeatures(assignmentId, since: sinceNewFeatures),
+    ]);
+    final attributions = results[0];
+    final newFeatures = results[1];
 
     // Attach assignment_id sidecar so the upsert doesn't have to re-derive
     // it from the row (fetch_remote_attributions omits it on each row since

--- a/lib/core/sync/worker/realtime_sync_controller.dart
+++ b/lib/core/sync/worker/realtime_sync_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:drift/drift.dart';
 import 'package:firecheck/core/db/database.dart';
 import 'package:firecheck/core/sync/data/realtime_subscriber.dart';
 import 'package:firecheck/core/sync/data/remote_attributions_pull_service.dart';
@@ -215,9 +216,13 @@ class RealtimeSyncController {
   }
 
   Future<String?> _currentAssignmentId() async {
-    final row =
-        await (_db.select(_db.assignments)..limit(1)).getSingleOrNull();
-    return row?.id;
+    // Newest assignment by createdAt — matches the rest of the codebase's
+    // notion of "current assignment" (AssignmentRepository.getCurrentAssignment).
+    final rows = await (_db.select(_db.assignments)
+          ..orderBy([(t) => OrderingTerm.desc(t.createdAt)])
+          ..limit(1))
+        .get();
+    return rows.firstOrNull?.id;
   }
 
   void _transitionTo(RealtimeConnectionState next) {

--- a/lib/core/sync/worker/remote_cache_controller.dart
+++ b/lib/core/sync/worker/remote_cache_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:drift/drift.dart';
 import 'package:firecheck/core/db/database.dart';
 import 'package:firecheck/core/sync/data/remote_attributions_pull_service.dart';
 import 'package:firecheck/core/sync/worker/connectivity_listener.dart';
@@ -60,8 +61,14 @@ class RemoteCacheController {
   }
 
   Future<void> _pullForCurrentAssignment({required bool full}) async {
-    final assignment =
-        await (_db.select(_db.assignments)..limit(1)).getSingleOrNull();
+    // Deterministic selection — matches AssignmentRepository.getCurrentAssignment()
+    // ("newest by createdAt") so badges/cache reference the same assignment
+    // the rest of the app considers "current".
+    final rows = await (_db.select(_db.assignments)
+          ..orderBy([(t) => OrderingTerm.desc(t.createdAt)])
+          ..limit(1))
+        .get();
+    final assignment = rows.firstOrNull;
     if (assignment == null) return;
     try {
       final result = full

--- a/lib/features/map/presentation/map_screen.dart
+++ b/lib/features/map/presentation/map_screen.dart
@@ -20,6 +20,7 @@ import 'package:firecheck/features/map/presentation/recenter_button_state.dart';
 import 'package:firecheck/features/map/presentation/zoom_button.dart';
 import 'package:firecheck/features/map/presentation/zoom_button_state.dart';
 import 'package:firecheck/features/map/presentation/zoom_direction.dart';
+import 'package:firecheck/features/remote_activity/presentation/remote_activity_chip.dart';
 import 'package:firecheck/features/map/geometry_editor/domain/geometry_editor_state.dart';
 import 'package:firecheck/features/map/geometry_editor/domain/reshape_op.dart';
 import 'package:firecheck/features/map/geometry_editor/presentation/reshape_action_sheet.dart';
@@ -158,6 +159,15 @@ class _MapScreenState extends ConsumerState<MapScreen> {
                 key: ValueKey('editor-overlay-$_projectionEpoch'),
                 projection: _reshapeProjection!,
               ),
+            ),
+          // Phase 4 — multi-user attribution sync: shows "👥 N edited by
+          // others" when the remote_attributions_cache has rows from other
+          // enumerators. Hidden when count is zero. Sits below the AppBar.
+          if (!reshapeActive && !sketchActive)
+            const Positioned(
+              left: 12,
+              top: 12,
+              child: RemoteActivityChip(),
             ),
           Positioned(
             right: 16,

--- a/lib/features/remote_activity/domain/remote_attribution_flatten.dart
+++ b/lib/features/remote_activity/domain/remote_attribution_flatten.dart
@@ -1,0 +1,66 @@
+import 'package:firecheck/features/remote_activity/domain/remote_attribution_view.dart';
+
+/// Flattens a [RemoteAttributionView] into a single label → value map for
+/// display in [AttributeKvTable]. Picks the typed sub-shape that matches
+/// the feature type; falls back to the shared submission fields when no
+/// typed row was present (e.g. "does not exist" submissions).
+Map<String, Object?> flattenRemoteAttributionForDisplay(
+  RemoteAttributionView view,
+) {
+  final Map<String, Object?> out = {};
+
+  // Shared submission-level fields surface first.
+  if (view.doesNotExist) {
+    out['Does not exist'] = true;
+  }
+  if (view.remarks != null && (view.remarks?.isNotEmpty ?? false)) {
+    out['Remarks'] = view.remarks;
+  }
+
+  switch (view.featureType) {
+    case 'building':
+      final b = view.building;
+      if (b != null) {
+        out.addAll({
+          'CBMS ID': b['cbms_id'],
+          'Building name': b['building_name'],
+          'RA 9514 type': b['ra_9514_type'],
+          'Storeys': b['storeys'],
+          'Material': b['material'],
+          if (b['cost_is_exact'] == true)
+            'Estimated cost': b['cost_amount']
+          else if (b['cost_estimate_range'] != null)
+            'Cost range': b['cost_estimate_range'],
+          'Fire-fighting facilities': b['fire_fighting_facilities'],
+          'Fire load': b['fire_load'],
+        });
+      }
+      final h = view.household;
+      if (h != null) {
+        out['Homeowner acknowledged'] = h['homeowner_acknowledged'];
+        if (h['lebel_ng_kahinaan'] != null) {
+          out['Lebel ng kahinaan'] = h['lebel_ng_kahinaan'];
+        }
+        if (h['safety_suggestions'] != null) {
+          out['Safety suggestions'] = h['safety_suggestions'];
+        }
+      }
+    case 'road':
+      final r = view.road;
+      if (r != null) {
+        out.addAll({
+          'Road name': r['road_name'],
+          'Is bridge': r['is_bridge'],
+          'Width (m)': r['width_meters'],
+          'Road features': r['road_features'],
+          if (r['others_description'] != null)
+            'Other description': r['others_description'],
+        });
+      }
+  }
+
+  // Strip explicit null entries so the table doesn't show "Key: —" for
+  // truly absent fields.
+  out.removeWhere((_, v) => v == null);
+  return out;
+}

--- a/lib/features/remote_activity/domain/remote_attribution_view.dart
+++ b/lib/features/remote_activity/domain/remote_attribution_view.dart
@@ -1,0 +1,66 @@
+import 'dart:convert';
+
+import 'package:firecheck/core/db/database.dart';
+
+/// View-model wrapping a `remote_attributions_cache` row for the UI.
+/// Decodes the denormalized `attribute_values` JSON once so widgets
+/// don't have to.
+class RemoteAttributionView {
+  RemoteAttributionView({
+    required this.id,
+    required this.assignmentId,
+    required this.featureId,
+    required this.featureType,
+    required this.attributeValues,
+    required this.submittedBy,
+    required this.submittedAt,
+    required this.supersededAt,
+    required this.updatedAt,
+  });
+
+  factory RemoteAttributionView.fromRow(RemoteAttributionsCacheData row) {
+    final decoded = jsonDecode(row.attributeValuesJson);
+    return RemoteAttributionView(
+      id: row.id,
+      assignmentId: row.assignmentId,
+      featureId: row.featureId,
+      featureType: row.featureType,
+      attributeValues:
+          decoded is Map<String, dynamic> ? decoded : const <String, dynamic>{},
+      submittedBy: row.submittedBy,
+      submittedAt: row.submittedAt,
+      supersededAt: row.supersededAt,
+      updatedAt: row.updatedAt,
+    );
+  }
+
+  final String id;
+  final String assignmentId;
+  final String featureId;
+  final String featureType; // 'building' | 'road'
+  final Map<String, dynamic> attributeValues;
+  final String? submittedBy;
+  final DateTime submittedAt;
+  final DateTime? supersededAt;
+  final DateTime updatedAt;
+
+  bool get isCanonical => supersededAt == null;
+
+  /// Typed sub-shape — only one of these will be non-null for a given
+  /// submission, mirroring the typed child-table structure on the server.
+  Map<String, dynamic>? get building =>
+      _asMap(attributeValues['building']);
+  Map<String, dynamic>? get road => _asMap(attributeValues['road']);
+  Map<String, dynamic>? get household =>
+      _asMap(attributeValues['household']);
+
+  bool get doesNotExist =>
+      attributeValues['does_not_exist'] == true;
+  String? get remarks => attributeValues['remarks'] as String?;
+
+  static Map<String, dynamic>? _asMap(Object? v) {
+    if (v is Map<String, dynamic>) return v;
+    if (v is Map) return Map<String, dynamic>.from(v);
+    return null;
+  }
+}

--- a/lib/features/remote_activity/presentation/attribute_kv_table.dart
+++ b/lib/features/remote_activity/presentation/attribute_kv_table.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+/// Compact key/value table for attribute display. Renders nothing when
+/// the map is empty so callers can short-circuit on "no typed data".
+class AttributeKvTable extends StatelessWidget {
+  const AttributeKvTable({
+    required this.values,
+    super.key,
+    this.highlightKeys = const {},
+    this.title,
+  });
+
+  /// Map from human-readable key → value (string-coerced).
+  final Map<String, Object?> values;
+
+  /// Keys to highlight (used in side-by-side compare to mark fields that
+  /// differ from the other side).
+  final Set<String> highlightKeys;
+
+  final String? title;
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = values.entries.toList();
+    if (entries.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.all(12),
+        child: Text(
+          'No typed values.',
+          style: TextStyle(
+            color: Colors.grey.shade600,
+            fontStyle: FontStyle.italic,
+          ),
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (title != null) ...[
+          Padding(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            child: Text(title!,
+                style: const TextStyle(fontWeight: FontWeight.w700)),
+          ),
+        ],
+        Table(
+          columnWidths: const {
+            0: IntrinsicColumnWidth(),
+            1: FlexColumnWidth(),
+          },
+          defaultVerticalAlignment: TableCellVerticalAlignment.top,
+          children: [
+            for (final e in entries)
+              TableRow(
+                decoration: highlightKeys.contains(e.key)
+                    ? BoxDecoration(color: Colors.amber.shade50)
+                    : null,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 12, vertical: 6),
+                    child: Text(
+                      e.key,
+                      style: TextStyle(
+                        color: Colors.grey.shade700,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 12, vertical: 6),
+                    child: Text(
+                      _format(e.value),
+                      style: const TextStyle(fontWeight: FontWeight.w600),
+                    ),
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  String _format(Object? v) {
+    if (v == null) return '—';
+    if (v is List) return v.isEmpty ? '—' : v.join(', ');
+    if (v is bool) return v ? 'yes' : 'no';
+    return v.toString();
+  }
+}

--- a/lib/features/remote_activity/presentation/remote_activity_chip.dart
+++ b/lib/features/remote_activity/presentation/remote_activity_chip.dart
@@ -1,0 +1,48 @@
+import 'package:firecheck/features/remote_activity/presentation/remote_activity_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Small pill placed on the map screen showing "👥 N edited by others".
+/// Hidden when the count is zero. Tap opens the remote-activity list.
+class RemoteActivityChip extends ConsumerWidget {
+  const RemoteActivityChip({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final count = ref.watch(remoteActivityCountProvider);
+    if (count == 0) return const SizedBox.shrink();
+
+    return Material(
+      key: const Key('remote-activity.chip'),
+      color: Colors.deepOrange.shade50,
+      elevation: 1,
+      shape: const StadiumBorder(),
+      child: InkWell(
+        customBorder: const StadiumBorder(),
+        onTap: () => context.push('/remote-activity'),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.people_alt_outlined,
+                  size: 18, color: Colors.deepOrange),
+              const SizedBox(width: 8),
+              Text(
+                count == 1
+                    ? '1 feature edited by others'
+                    : '$count features edited by others',
+                style: TextStyle(
+                  color: Colors.deepOrange.shade900,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/remote_activity/presentation/remote_activity_list_screen.dart
+++ b/lib/features/remote_activity/presentation/remote_activity_list_screen.dart
@@ -1,0 +1,124 @@
+import 'package:firecheck/features/remote_activity/domain/remote_attribution_view.dart';
+import 'package:firecheck/features/remote_activity/presentation/remote_activity_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Scrollable list of features that other enumerators have attributed,
+/// fed by the phase-2 remote_attributions_cache. Empty-state shows a
+/// friendly note; the cold-open + realtime pipeline keeps this in sync
+/// without per-screen polling.
+class RemoteActivityListScreen extends ConsumerWidget {
+  const RemoteActivityListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final attribsAsync = ref.watch(othersRemoteAttributionsProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edited by others')),
+      body: attribsAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (err, _) => Center(child: Text('Error: $err')),
+        data: (rows) {
+          if (rows.isEmpty) {
+            return const _Empty();
+          }
+          return ListView.separated(
+            key: const Key('remote-activity.list'),
+            itemCount: rows.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (context, i) => _RemoteAttributionTile(view: rows[i]),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _Empty extends StatelessWidget {
+  const _Empty();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(32),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.people_alt_outlined,
+                size: 56, color: Colors.grey.shade400),
+            const SizedBox(height: 12),
+            const Text(
+              'No remote activity yet.',
+              style: TextStyle(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'When another enumerator attributes a feature in this '
+              'assignment, it shows up here.',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Colors.grey.shade700),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RemoteAttributionTile extends StatelessWidget {
+  const _RemoteAttributionTile({required this.view});
+  final RemoteAttributionView view;
+
+  @override
+  Widget build(BuildContext context) {
+    final relTime = _relativeTime(view.submittedAt);
+    return ListTile(
+      key: Key('remote-activity.tile.${view.featureId}'),
+      leading: CircleAvatar(
+        backgroundColor: view.featureType == 'building'
+            ? Colors.blueGrey.shade100
+            : Colors.brown.shade100,
+        child: Icon(
+          view.featureType == 'building'
+              ? Icons.home_work_outlined
+              : Icons.alt_route_outlined,
+          color: view.featureType == 'building'
+              ? Colors.blueGrey.shade700
+              : Colors.brown.shade700,
+          size: 20,
+        ),
+      ),
+      title: Text(
+        '${_capitalize(view.featureType)} ${_shortId(view.featureId)}',
+        style: const TextStyle(fontWeight: FontWeight.w600),
+      ),
+      subtitle: Text(
+        'by ${view.submittedBy ?? 'unknown'} • $relTime',
+      ),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () => context.push(
+        '/remote-activity/${Uri.encodeComponent(view.featureId)}',
+      ),
+    );
+  }
+
+  String _shortId(String id) {
+    if (id.length <= 8) return id;
+    return id.substring(0, 8);
+  }
+
+  String _capitalize(String s) =>
+      s.isEmpty ? s : '${s[0].toUpperCase()}${s.substring(1)}';
+
+  String _relativeTime(DateTime t) {
+    final delta = DateTime.now().difference(t);
+    if (delta.inMinutes < 1) return 'just now';
+    if (delta.inMinutes < 60) return '${delta.inMinutes} min ago';
+    if (delta.inHours < 24) return '${delta.inHours}h ago';
+    if (delta.inDays < 7) return '${delta.inDays}d ago';
+    return '${t.year}-${t.month.toString().padLeft(2, '0')}-${t.day.toString().padLeft(2, '0')}';
+  }
+}

--- a/lib/features/remote_activity/presentation/remote_activity_providers.dart
+++ b/lib/features/remote_activity/presentation/remote_activity_providers.dart
@@ -1,0 +1,77 @@
+import 'package:drift/drift.dart';
+import 'package:firecheck/core/auth/current_user_provider.dart';
+import 'package:firecheck/features/assignment/presentation/assignment_providers.dart';
+import 'package:firecheck/features/home/presentation/home_providers.dart';
+import 'package:firecheck/features/remote_activity/domain/remote_attribution_view.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// All non-superseded remote attributions for the *current* assignment,
+/// excluding the current user's own. The exclusion rule is "show me what
+/// OTHER enumerators did" — my own work already lives in the local
+/// submissions table.
+///
+/// Synchronous Stream-returning body (not `async*`) so a transient
+/// "assignment still loading" state doesn't terminate the stream — when
+/// the assignment resolves, Riverpod re-evaluates and swaps in the real
+/// Drift watch.
+final othersRemoteAttributionsProvider =
+    StreamProvider<List<RemoteAttributionView>>((ref) {
+  final assignment = ref.watch(currentAssignmentProvider).value;
+  if (assignment == null) {
+    return Stream<List<RemoteAttributionView>>.value(const []);
+  }
+  final me = ref.watch(currentUserIdProvider);
+  final db = ref.watch(appDatabaseProvider);
+
+  final query = db.select(db.remoteAttributionsCache)
+    ..where((t) =>
+        t.assignmentId.equals(assignment.id) &
+        t.supersededAt.isNull() &
+        (me == null
+            ? const Constant<bool>(true)
+            : t.submittedBy.isNotValue(me) | t.submittedBy.isNull()),)
+    ..orderBy([
+      (t) => OrderingTerm(expression: t.submittedAt, mode: OrderingMode.desc),
+    ]);
+
+  return query.watch().map(
+        (rows) => rows.map(RemoteAttributionView.fromRow).toList(),
+      );
+});
+
+/// Convenience: the canonical remote attribution (if any) for a given
+/// feature, by anyone OTHER than the current user. Phase 5 will read
+/// this at upload time to compute base_version_id.
+final remoteAttributionForFeatureProvider =
+    StreamProvider.family<RemoteAttributionView?, String>(
+  (ref, featureId) {
+    final me = ref.watch(currentUserIdProvider);
+    final db = ref.watch(appDatabaseProvider);
+    final query = db.select(db.remoteAttributionsCache)
+      ..where((t) =>
+          t.featureId.equals(featureId) &
+          t.supersededAt.isNull() &
+          (me == null
+              ? const Constant<bool>(true)
+              : t.submittedBy.isNotValue(me) | t.submittedBy.isNull()),)
+      ..orderBy([
+        (t) =>
+            OrderingTerm(expression: t.submittedAt, mode: OrderingMode.desc),
+      ])
+      ..limit(1);
+
+    return query.watchSingleOrNull().map(
+          (row) => row == null ? null : RemoteAttributionView.fromRow(row),
+        );
+  },
+);
+
+/// Count of features (not submissions) with at least one non-superseded
+/// remote attribution authored by a different user. Used by the
+/// `RemoteActivityChip` badge.
+final remoteActivityCountProvider = Provider<int>((ref) {
+  final attribs = ref.watch(othersRemoteAttributionsProvider).valueOrNull ?? [];
+  // Distinct by feature_id — a feature can have multiple non-superseded
+  // submissions during conflict resolution windows.
+  return attribs.map((a) => a.featureId).toSet().length;
+});

--- a/lib/features/remote_activity/presentation/remote_attribution_detail_screen.dart
+++ b/lib/features/remote_activity/presentation/remote_attribution_detail_screen.dart
@@ -1,0 +1,153 @@
+import 'package:firecheck/features/remote_activity/domain/remote_attribution_flatten.dart';
+import 'package:firecheck/features/remote_activity/presentation/attribute_kv_table.dart';
+import 'package:firecheck/features/remote_activity/presentation/remote_activity_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Read-only view of another enumerator's attribution for a feature.
+/// Phase 5 will reuse the underlying widgets in the side-by-side compare
+/// during conflict review.
+class RemoteAttributionDetailScreen extends ConsumerWidget {
+  const RemoteAttributionDetailScreen({required this.featureId, super.key});
+  final String featureId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final viewAsync =
+        ref.watch(remoteAttributionForFeatureProvider(featureId));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Their answers')),
+      body: viewAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (err, _) => Center(child: Text('Error: $err')),
+        data: (view) {
+          if (view == null) {
+            return const _NoData();
+          }
+          final values = flattenRemoteAttributionForDisplay(view);
+          return ListView(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            children: [
+              _Header(
+                featureId: view.featureId,
+                featureType: view.featureType,
+                submittedBy: view.submittedBy,
+                submittedAt: view.submittedAt,
+              ),
+              const SizedBox(height: 12),
+              Material(
+                color: Theme.of(context).colorScheme.surface,
+                elevation: 0,
+                child: AttributeKvTable(values: values),
+              ),
+              const SizedBox(height: 12),
+              // Phase-5 hook: open form for local edit / "compare with mine".
+              // For phase 4 we surface a "Open feature" CTA that drops the
+              // user back into the standard feature form, where any local
+              // submission can be inspected.
+              Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: ElevatedButton.icon(
+                  key: const Key('remote-activity.open-feature'),
+                  onPressed: () => context.push(
+                    '/feature/${Uri.encodeComponent(view.featureId)}',
+                  ),
+                  icon: const Icon(Icons.edit_note),
+                  label: const Text('Open feature'),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({
+    required this.featureId,
+    required this.featureType,
+    required this.submittedBy,
+    required this.submittedAt,
+  });
+  final String featureId;
+  final String featureType;
+  final String? submittedBy;
+  final DateTime submittedAt;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Row(
+        children: [
+          CircleAvatar(
+            backgroundColor: featureType == 'building'
+                ? Colors.blueGrey.shade100
+                : Colors.brown.shade100,
+            child: Icon(
+              featureType == 'building'
+                  ? Icons.home_work_outlined
+                  : Icons.alt_route_outlined,
+              color: featureType == 'building'
+                  ? Colors.blueGrey.shade700
+                  : Colors.brown.shade700,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '${_capitalize(featureType)} ${_shortId(featureId)}',
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w700,
+                    fontSize: 16,
+                  ),
+                ),
+                Text(
+                  'by ${submittedBy ?? 'unknown'} • ${_absTime(submittedAt)}',
+                  style: TextStyle(color: Colors.grey.shade700),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _shortId(String id) =>
+      id.length <= 8 ? id : id.substring(0, 8);
+
+  String _capitalize(String s) =>
+      s.isEmpty ? s : '${s[0].toUpperCase()}${s.substring(1)}';
+
+  String _absTime(DateTime t) {
+    final l = t.toLocal();
+    return '${l.year}-${l.month.toString().padLeft(2, '0')}-${l.day.toString().padLeft(2, '0')} '
+        '${l.hour.toString().padLeft(2, '0')}:${l.minute.toString().padLeft(2, '0')}';
+  }
+}
+
+class _NoData extends StatelessWidget {
+  const _NoData();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.all(24),
+        child: Text(
+          'No remote attribution found for this feature.',
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -165,23 +165,62 @@ class _SyncBootstrap extends ConsumerStatefulWidget {
 }
 
 class _SyncBootstrapState extends ConsumerState<_SyncBootstrap> {
+  StreamSubscription<AuthState>? _authSub;
+  bool _remoteStarted = false;
+
   @override
   void initState() {
     super.initState();
     Future.microtask(() async {
       await ref.read(syncControllerProvider).start();
-      // Phases 2 + 3 of multi-user attribution sync: cold-open full pull
-      // (phase 2) plus realtime subscription with connection state
-      // machine (phase 3). Runs only when authenticated — the server RPCs
-      // RLS-filter to membership, but skipping when signed-out avoids
-      // noisy logs.
-      if (Supabase.instance.client.auth.currentSession != null) {
-        await ref.read(remoteCacheControllerProvider).start();
-        ref.read(realtimeWiringProvider).start();
-        await ref.read(realtimeSyncControllerProvider).start();
-      }
       _attachSubmittedLock();
+      _wireRemoteSyncToAuth();
     });
+  }
+
+  @override
+  void dispose() {
+    _authSub?.cancel();
+    super.dispose();
+  }
+
+  /// Phases 2 + 3 of multi-user attribution sync: cold-open full pull
+  /// (phase 2) plus realtime subscription with connection state machine
+  /// (phase 3). Must be (re)evaluated on every auth state change — the
+  /// common flow is app launch → sign-in screen → user signs in, so a
+  /// one-shot check at `initState` would never fire start() for that
+  /// session and the cache would stay empty until app restart.
+  void _wireRemoteSyncToAuth() {
+    final client = Supabase.instance.client;
+    if (client.auth.currentSession != null) {
+      unawaited(_startRemoteSync());
+    }
+    _authSub = client.auth.onAuthStateChange.listen((event) {
+      if (event.session != null) {
+        unawaited(_startRemoteSync());
+      } else {
+        _stopRemoteSync();
+      }
+    });
+  }
+
+  Future<void> _startRemoteSync() async {
+    if (_remoteStarted) return;
+    _remoteStarted = true;
+    await ref.read(remoteCacheControllerProvider).start();
+    ref.read(realtimeWiringProvider).start();
+    await ref.read(realtimeSyncControllerProvider).start();
+  }
+
+  void _stopRemoteSync() {
+    if (!_remoteStarted) return;
+    _remoteStarted = false;
+    // Invalidate so the controllers' onDispose hooks (which call stop())
+    // run, and the next sign-in starts from fresh instances.
+    ref
+      ..invalidate(realtimeSyncControllerProvider)
+      ..invalidate(realtimeWiringProvider)
+      ..invalidate(remoteCacheControllerProvider);
   }
 
   void _attachSubmittedLock() {

--- a/test/core/sync/data/remote_attributions_pull_service_test.dart
+++ b/test/core/sync/data/remote_attributions_pull_service_test.dart
@@ -43,6 +43,32 @@ class _RecordingApi implements RemoteCacheApi {
   }
 }
 
+/// fetchAttributions throws synchronously-on-async; fetchNewFeatures
+/// resolves a tick later (would surface as uncaught if orphaned).
+class _ThrowingThenSucceedingApi implements RemoteCacheApi {
+  int attribCalls = 0;
+  int newFeatCalls = 0;
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchAttributions(
+    String assignmentId, {
+    DateTime? since,
+  }) async {
+    attribCalls++;
+    throw StateError('boom');
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchNewFeatures(
+    String assignmentId, {
+    DateTime? since,
+  }) async {
+    newFeatCalls++;
+    await Future<void>.delayed(Duration.zero);
+    return const [];
+  }
+}
+
 Map<String, dynamic> _attrib({
   required String id,
   required String featureId,
@@ -209,6 +235,25 @@ void main() {
     final live = await cache.liveAttributionsFor('a1');
     expect(live, hasLength(1));
     expect(live.first.id, 's1');
+  });
+
+  test('pullAll throws atomically — second future is awaited, not orphaned',
+      () async {
+    // The bug we're guarding against: if fetchAttributions throws while
+    // fetchNewFeatures is still in-flight, sequential awaits would leave
+    // the second future unawaited and its later error becomes an uncaught
+    // async exception. Future.wait awaits both, so we get a single
+    // rejection from pullAll() and no zombie futures.
+    final throwingApi = _ThrowingThenSucceedingApi();
+    final svc = RemoteAttributionsPullService(api: throwingApi, cache: cache);
+
+    await expectLater(svc.pullAll('a1'), throwsA(isA<StateError>()));
+    // Both calls were initiated even though the first errored:
+    expect(throwingApi.attribCalls, 1);
+    expect(throwingApi.newFeatCalls, 1);
+    // Yielding a microtask is enough for any orphan to surface as uncaught;
+    // none does, because Future.wait propagated the rejection synchronously.
+    await Future<void>.delayed(Duration.zero);
   });
 
   test('pullAll preserves cursor when response is empty', () async {

--- a/test/core/sync/worker/realtime_sync_controller_test.dart
+++ b/test/core/sync/worker/realtime_sync_controller_test.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:drift/drift.dart';
+import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:drift/native.dart';
 import 'package:firecheck/core/db/database.dart';
 import 'package:firecheck/core/sync/data/realtime_subscriber.dart';
@@ -294,6 +294,35 @@ void main() {
 
     expect(controller.state, RealtimeConnectionState.offline);
     expect(sub.closed, isTrue);
+  });
+
+  test('with multiple assignments, picks the newest by createdAt',
+      () async {
+    // Insert an older sibling.
+    await db.into(db.assignments).insert(
+          AssignmentsCompanion.insert(
+            id: 'a0',
+            enumeratorId: 'me',
+            campaignId: 'c1',
+            boundaryPolygonGeojson: '{}',
+            createdAt: DateTime(2024),
+          ),
+        );
+
+    await controller.start();
+    await _pump();
+
+    expect(controller.state, RealtimeConnectionState.online);
+    // The pull service's RecordingApi was called with assignmentId='a1'
+    // (the newer one) — we infer that here from the fact that the test
+    // succeeded; explicit verification would require RecordingApi to
+    // remember the assignmentId. Mirror in the cache repository:
+    final cur = await cache.getCursor('a1');
+    expect(cur, isNotNull,
+        reason: 'pull should target newest assignment a1, not older a0');
+    final cur0 = await cache.getCursor('a0');
+    expect(cur0, isNull,
+        reason: 'older assignment must not be pulled');
   });
 
   test('start with no assignment stays offline (no subscribe)', () async {

--- a/test/features/map/map_screen_recenter_test.dart
+++ b/test/features/map/map_screen_recenter_test.dart
@@ -12,6 +12,7 @@ import 'package:firecheck/features/map/presentation/map_providers.dart';
 import 'package:firecheck/features/map/presentation/map_renderer.dart';
 import 'package:firecheck/features/map/presentation/map_screen.dart';
 import 'package:firecheck/features/map/presentation/recenter_button.dart';
+import 'package:firecheck/features/remote_activity/presentation/remote_activity_providers.dart';
 import 'package:firecheck/generated/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -64,6 +65,12 @@ Future<void> pumpMap(
       analyticsServiceProvider.overrideWithValue(analytics),
       currentFeaturesProvider.overrideWith((_) => Stream.value(const [])),
       currentAssignmentProvider.overrideWith((_) => Stream.value(fakeAssignment())),
+      // Phase 4 map-badge chip watches the remote attribution cache via
+      // Drift; in the map screen tests we don't wire a real DB, so short-
+      // circuit the data source to avoid a pending-timer leak at teardown.
+      othersRemoteAttributionsProvider.overrideWith(
+        (_) => Stream.value(const []),
+      ),
       assignmentLockStateProvider.overrideWith((_) => Stream.value(const Unlocked())),
       if (positionStream != null)
         currentPositionProvider.overrideWith((_) => positionStream),

--- a/test/features/map/map_screen_reshape_test.dart
+++ b/test/features/map/map_screen_reshape_test.dart
@@ -13,6 +13,7 @@ import 'package:firecheck/features/map/presentation/map_providers.dart';
 import 'package:firecheck/features/map/presentation/map_renderer.dart';
 import 'package:firecheck/features/map/presentation/map_screen.dart';
 import 'package:firecheck/features/map/geometry_editor/presentation/geometry_editor_providers.dart';
+import 'package:firecheck/features/remote_activity/presentation/remote_activity_providers.dart';
 import 'package:firecheck/generated/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -85,6 +86,9 @@ Future<ProviderContainer> pumpMap(
       currentFeaturesProvider.overrideWith((_) => Stream.value(features)),
       currentAssignmentProvider.overrideWith((_) => Stream.value(fakeAssignment())),
       assignmentLockStateProvider.overrideWith((_) => Stream.value(const Unlocked())),
+      othersRemoteAttributionsProvider.overrideWith(
+        (_) => Stream.value(const []),
+      ),
       // For lock-blocker tests, route the synchronous bool through a
       // mutable ValueNotifier so the test can flip the lock mid-flight.
       if (lockNotifier != null)

--- a/test/features/map/map_screen_road_test.dart
+++ b/test/features/map/map_screen_road_test.dart
@@ -12,6 +12,7 @@ import 'package:firecheck/features/home/presentation/home_providers.dart';
 import 'package:firecheck/features/map/presentation/map_providers.dart';
 import 'package:firecheck/features/map/presentation/map_renderer.dart';
 import 'package:firecheck/features/map/presentation/map_screen.dart';
+import 'package:firecheck/features/remote_activity/presentation/remote_activity_providers.dart';
 import 'package:firecheck/generated/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -67,6 +68,11 @@ Widget _buildSubject({
       assignmentLockStateProvider
           .overrideWith((_) => Stream.value(const Unlocked())),
       currentUserIdProvider.overrideWith((ref) => 'u1'),
+      // Phase 4 map-badge chip — short-circuit its Drift watch so pending
+      // timers don't leak across the test boundary.
+      othersRemoteAttributionsProvider.overrideWith(
+        (_) => Stream.value(const []),
+      ),
       // Emit a position exactly at the road midpoint so _resolvePosition
       // returns immediately (distance = 0 m → no override dialog, no
       // CircularProgressIndicator, no infinite animation for pumpAndSettle).

--- a/test/features/map/map_screen_test.dart
+++ b/test/features/map/map_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:firecheck/features/assignment/presentation/assignment_providers.
 import 'package:firecheck/features/map/presentation/map_providers.dart';
 import 'package:firecheck/features/map/presentation/map_renderer.dart';
 import 'package:firecheck/features/map/presentation/map_screen.dart';
+import 'package:firecheck/features/remote_activity/presentation/remote_activity_providers.dart';
 import 'package:firecheck/generated/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -23,6 +24,9 @@ void main() {
             .overrideWith((ref) => Stream.value(assignment)),
         assignmentLockStateProvider
             .overrideWith((_) => Stream.value(const Unlocked())),
+        othersRemoteAttributionsProvider.overrideWith(
+          (_) => Stream.value(const []),
+        ),
       ],
       child: const MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -87,6 +91,9 @@ void main() {
         currentFeaturesProvider.overrideWith((_) => Stream.value(const [])),
         currentAssignmentProvider.overrideWith((_) => Stream.value(assignment)),
         assignmentLockStateProvider.overrideWith((_) => Stream.value(const Unlocked())),
+        othersRemoteAttributionsProvider.overrideWith(
+          (_) => Stream.value(const []),
+        ),
       ],
       child: const MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/test/features/map/map_screen_zoom_test.dart
+++ b/test/features/map/map_screen_zoom_test.dart
@@ -9,6 +9,7 @@ import 'package:firecheck/features/assignment/presentation/assignment_providers.
 import 'package:firecheck/features/map/presentation/camera_target.dart';
 import 'package:firecheck/features/map/presentation/map_providers.dart';
 import 'package:firecheck/features/map/presentation/map_renderer.dart';
+import 'package:firecheck/features/remote_activity/presentation/remote_activity_providers.dart';
 import 'package:firecheck/features/map/presentation/map_screen.dart';
 import 'package:firecheck/generated/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
@@ -44,6 +45,9 @@ Future<void> pumpMap(
       currentAssignmentProvider.overrideWith((_) => Stream.value(fakeAssignment())),
       assignmentLockStateProvider.overrideWith((_) => Stream.value(const Unlocked())),
       currentPositionProvider.overrideWith((_) => const Stream<Position>.empty()),
+      othersRemoteAttributionsProvider.overrideWith(
+        (_) => Stream.value(const []),
+      ),
     ],
     child: const MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/test/features/map/sketch_flow_test.dart
+++ b/test/features/map/sketch_flow_test.dart
@@ -12,6 +12,7 @@ import 'package:firecheck/features/map/geometry_editor/presentation/geometry_edi
 import 'package:firecheck/features/map/presentation/map_providers.dart';
 import 'package:firecheck/features/map/presentation/map_renderer.dart';
 import 'package:firecheck/features/map/presentation/map_screen.dart';
+import 'package:firecheck/features/remote_activity/presentation/remote_activity_providers.dart';
 import 'package:firecheck/generated/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -87,6 +88,9 @@ Future<({ProviderContainer container, AppDatabase db, GoRouter router})>
       // Avoid the real geolocator plugin (MissingPluginException in widget
       // tests). MapScreen subscribes to currentPositionProvider on mount.
       currentPositionProvider.overrideWith((_) => const Stream<Position>.empty()),
+      othersRemoteAttributionsProvider.overrideWith(
+        (_) => Stream.value(const []),
+      ),
     ],
   );
   addTearDown(container.dispose);

--- a/test/features/remote_activity/remote_activity_providers_test.dart
+++ b/test/features/remote_activity/remote_activity_providers_test.dart
@@ -1,0 +1,122 @@
+import 'package:drift/native.dart';
+import 'package:firecheck/core/auth/current_user_provider.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/data/remote_attributions_cache_repository.dart';
+import 'package:firecheck/features/assignment/data/assignment_repository.dart';
+import 'package:firecheck/features/assignment/presentation/assignment_providers.dart';
+import 'package:firecheck/features/home/presentation/home_providers.dart';
+import 'package:firecheck/features/remote_activity/presentation/remote_activity_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Map<String, dynamic> _row({
+  required String id,
+  required String featureId,
+  required String submittedBy,
+}) => {
+      'id': id,
+      '__assignment_id': 'a1',
+      'feature_id': featureId,
+      'feature_type': 'building',
+      'submitted_by': submittedBy,
+      'submitted_at': '2026-05-18T09:00:00Z',
+      'superseded_at': null,
+      'superseded_by_id': null,
+      'updated_at': '2026-05-18T10:00:00Z',
+      'attribute_values': {
+        'building': {'storeys': 2},
+      },
+    };
+
+void main() {
+  late AppDatabase db;
+  late RemoteAttributionsCacheRepository cache;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    cache = RemoteAttributionsCacheRepository(db);
+    await db.into(db.assignments).insert(
+          AssignmentsCompanion.insert(
+            id: 'a1',
+            enumeratorId: 'me',
+            campaignId: 'c1',
+            boundaryPolygonGeojson: '{}',
+            createdAt: DateTime(2026, 5, 18),
+          ),
+        );
+  });
+
+  tearDown(() => db.close());
+
+  ProviderContainer makeContainer({String? userId = 'me'}) {
+    return ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWithValue(db),
+        currentUserIdProvider.overrideWithValue(userId),
+        assignmentRepositoryProvider
+            .overrideWithValue(AssignmentRepository(db: db)),
+      ],
+    );
+  }
+
+  test('othersRemoteAttributionsProvider excludes my own submissions',
+      () async {
+    await cache
+        .upsertAttribution(_row(id: 's1', featureId: 'f1', submittedBy: 'me'));
+    await cache.upsertAttribution(
+      _row(id: 's2', featureId: 'f2', submittedBy: 'alice'),
+    );
+
+    final container = makeContainer();
+    addTearDown(container.dispose);
+
+    // Make sure currentAssignmentProvider has resolved before reading the
+    // dependent provider — its initial AsyncLoading emission would yield
+    // an empty stream from othersRemoteAttributionsProvider.
+    await container.read(currentAssignmentProvider.future);
+    final views =
+        await container.read(othersRemoteAttributionsProvider.future);
+    expect(views.map((v) => v.id), ['s2']);
+  });
+
+  test('remoteActivityCountProvider de-duplicates by feature', () async {
+    await cache.upsertAttribution(
+      _row(id: 's1', featureId: 'f1', submittedBy: 'alice'),
+    );
+    await cache.upsertAttribution(
+      _row(id: 's2', featureId: 'f1', submittedBy: 'bob'),
+    );
+    await cache.upsertAttribution(
+      _row(id: 's3', featureId: 'f2', submittedBy: 'alice'),
+    );
+
+    final container = makeContainer();
+    addTearDown(container.dispose);
+
+    // Drain the stream once so .read on the count provider sees data.
+    await container.read(currentAssignmentProvider.future);
+    await container.read(othersRemoteAttributionsProvider.future);
+    expect(container.read(remoteActivityCountProvider), 2);
+  });
+
+  test('when signed-out, all non-null submitted_by rows still surface',
+      () async {
+    // Spec: cache is "Clearable on logout" but if we're between sessions
+    // and rows still exist locally, we don't crash — we just show
+    // everything (the chip / list will appear, sign-in flow will overwrite).
+    await cache.upsertAttribution(
+      _row(id: 's1', featureId: 'f1', submittedBy: 'alice'),
+    );
+
+    final container = makeContainer(userId: null);
+    addTearDown(container.dispose);
+
+    // Make sure currentAssignmentProvider has resolved before reading the
+    // dependent provider — its initial AsyncLoading emission would yield
+    // an empty stream from othersRemoteAttributionsProvider.
+    await container.read(currentAssignmentProvider.future);
+    final views =
+        await container.read(othersRemoteAttributionsProvider.future);
+    expect(views, hasLength(1));
+  });
+}

--- a/test/features/remote_activity/remote_activity_widgets_test.dart
+++ b/test/features/remote_activity/remote_activity_widgets_test.dart
@@ -1,0 +1,123 @@
+import 'package:firecheck/features/remote_activity/domain/remote_attribution_view.dart';
+import 'package:firecheck/features/remote_activity/presentation/remote_activity_chip.dart';
+import 'package:firecheck/features/remote_activity/presentation/remote_activity_list_screen.dart';
+import 'package:firecheck/features/remote_activity/presentation/remote_activity_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Widget tests override `othersRemoteAttributionsProvider` directly with
+/// a synthetic stream — that way we don't pull in Drift / Supabase /
+/// `currentAssignmentProvider` (which would require a real DB or extra
+/// overrides). Provider behaviour is covered separately in
+/// `remote_activity_providers_test.dart`.
+
+RemoteAttributionView _view(
+  String submissionId, {
+  required String featureId,
+  String submittedBy = 'alice',
+}) {
+  return RemoteAttributionView(
+    id: submissionId,
+    assignmentId: 'a1',
+    featureId: featureId,
+    featureType: 'building',
+    attributeValues: {
+      'building': {'storeys': 2},
+    },
+    submittedBy: submittedBy,
+    submittedAt: DateTime.utc(2026, 5, 18, 10),
+    supersededAt: null,
+    updatedAt: DateTime.utc(2026, 5, 18, 10),
+  );
+}
+
+Override _stub(List<RemoteAttributionView> views) {
+  return othersRemoteAttributionsProvider.overrideWith(
+    (ref) => Stream.value(views),
+  );
+}
+
+void main() {
+  testWidgets('chip is hidden when count is zero', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [_stub(const [])],
+        child: const MaterialApp(
+          home: Scaffold(body: RemoteActivityChip()),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('remote-activity.chip')), findsNothing);
+  });
+
+  testWidgets('chip shows "1 feature edited by others" with one row',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [_stub([_view('s1', featureId: 'f1')])],
+        child: const MaterialApp(
+          home: Scaffold(body: RemoteActivityChip()),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('remote-activity.chip')), findsOneWidget);
+    expect(find.textContaining('1 feature edited by others'), findsOneWidget);
+  });
+
+  testWidgets('chip counts distinct features, not submissions',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          _stub([
+            _view('s1', featureId: 'f1'),
+            _view('s2', featureId: 'f1', submittedBy: 'bob'),
+            _view('s3', featureId: 'f2'),
+          ]),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(body: RemoteActivityChip()),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.textContaining('2 features edited by others'), findsOneWidget);
+  });
+
+  testWidgets('list screen shows empty state when no rows', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [_stub(const [])],
+        child: const MaterialApp(home: RemoteActivityListScreen()),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('No remote activity yet.'), findsOneWidget);
+  });
+
+  testWidgets('list screen renders one tile per remote attribution',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          _stub([
+            _view('s1', featureId: 'f1'),
+            _view('s2', featureId: 'f2'),
+          ]),
+        ],
+        child: const MaterialApp(home: RemoteActivityListScreen()),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('remote-activity.tile.f1')), findsOneWidget);
+    expect(find.byKey(const Key('remote-activity.tile.f2')), findsOneWidget);
+  });
+}

--- a/test/features/remote_activity/remote_attribution_flatten_test.dart
+++ b/test/features/remote_activity/remote_attribution_flatten_test.dart
@@ -1,0 +1,109 @@
+import 'package:firecheck/features/remote_activity/domain/remote_attribution_flatten.dart';
+import 'package:firecheck/features/remote_activity/domain/remote_attribution_view.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+RemoteAttributionView _view({
+  required String featureType,
+  Map<String, dynamic>? building,
+  Map<String, dynamic>? road,
+  Map<String, dynamic>? household,
+  bool doesNotExist = false,
+  String? remarks,
+}) {
+  return RemoteAttributionView(
+    id: 's1',
+    assignmentId: 'a1',
+    featureId: 'f1',
+    featureType: featureType,
+    attributeValues: {
+      'does_not_exist': doesNotExist,
+      'remarks': remarks,
+      'building': building,
+      'road': road,
+      'household': household,
+    },
+    submittedBy: 'alice',
+    submittedAt: DateTime.utc(2026, 5, 18, 10),
+    supersededAt: null,
+    updatedAt: DateTime.utc(2026, 5, 18, 10),
+  );
+}
+
+void main() {
+  test('building flattens into typed key/values', () {
+    final v = _view(
+      featureType: 'building',
+      building: {
+        'cbms_id': 'CBMS-001',
+        'storeys': 3,
+        'material': 'concrete',
+        'cost_is_exact': true,
+        'cost_amount': 1500000,
+        'fire_fighting_facilities': ['extinguisher'],
+      },
+    );
+    final flat = flattenRemoteAttributionForDisplay(v);
+    expect(flat['CBMS ID'], 'CBMS-001');
+    expect(flat['Storeys'], 3);
+    expect(flat['Material'], 'concrete');
+    expect(flat['Estimated cost'], 1500000);
+    expect(flat['Fire-fighting facilities'], ['extinguisher']);
+    expect(flat.containsKey('Cost range'), isFalse,
+        reason: 'exact cost path excludes the estimate range');
+  });
+
+  test('cost range is shown only when cost_is_exact is false', () {
+    final v = _view(
+      featureType: 'building',
+      building: {
+        'cost_is_exact': false,
+        'cost_estimate_range': '1M-2M',
+      },
+    );
+    final flat = flattenRemoteAttributionForDisplay(v);
+    expect(flat['Cost range'], '1M-2M');
+    expect(flat.containsKey('Estimated cost'), isFalse);
+  });
+
+  test('road flattens typed fields', () {
+    final v = _view(
+      featureType: 'road',
+      road: {
+        'road_name': 'Rizal Ave.',
+        'is_bridge': false,
+        'width_meters': 6,
+        'road_features': ['drainage'],
+      },
+    );
+    final flat = flattenRemoteAttributionForDisplay(v);
+    expect(flat['Road name'], 'Rizal Ave.');
+    expect(flat['Is bridge'], false);
+    expect(flat['Width (m)'], 6);
+  });
+
+  test('does_not_exist + remarks surface at the top', () {
+    final v = _view(
+      featureType: 'building',
+      doesNotExist: true,
+      remarks: 'demolished',
+    );
+    final flat = flattenRemoteAttributionForDisplay(v);
+    expect(flat['Does not exist'], true);
+    expect(flat['Remarks'], 'demolished');
+  });
+
+  test('null values are stripped — no "Key: —" rows', () {
+    final v = _view(
+      featureType: 'building',
+      building: {
+        'cbms_id': null,
+        'storeys': 2,
+        'material': null,
+      },
+    );
+    final flat = flattenRemoteAttributionForDisplay(v);
+    expect(flat.containsKey('CBMS ID'), isFalse);
+    expect(flat.containsKey('Material'), isFalse);
+    expect(flat['Storeys'], 2);
+  });
+}


### PR DESCRIPTION
## Summary

Phase 4 of multi-user attribution sync — **first user-visible piece** of the multi-user feature. Plus the three PR #56/#57 review fixes bundled in (per request to commit them with phase 4).

> ⚠ Depends on **PR #56** (phase 2 cache + pulls) and **PR #57** (phase 3 realtime). Merge after those.

## Phase 4: map badge UI

User-visible additions:
- Map screen now shows a "👥 N features edited by others" chip in the top-left when the cache has rows authored by someone else. Hidden when count is zero. Tap → list screen.
- `/remote-activity` — scrollable list of features with remote activity, ordered by `submitted_at desc`, with author + relative time. Friendly empty state for the common "no one else is working here" case.
- `/remote-activity/:featureId` — read-only "Their answers" view. Decodes the cached jsonb into typed key/value rows (building / road / household). "Open feature" CTA jumps to the user's standard form for the feature.

Architecture:
- `RemoteAttributionView` decodes `attributeValuesJson` once at the cache→view boundary.
- `othersRemoteAttributionsProvider` does the join: current-assignment cache rows where `submittedBy != currentUser`, non-superseded, ordered by `submittedAt desc`. Synchronous Stream-returning body (not `async*`) so the loading→loaded transition doesn't terminate the stream.
- `remoteActivityCountProvider` de-duplicates by `feature_id` — conflict-resolution windows can produce multiple non-superseded rows per feature.
- `flattenRemoteAttributionForDisplay` is the single canonical mapping from typed child shape to display labels; phase 5's side-by-side compare will reuse it.

Existing map widget tests gained one new override (`othersRemoteAttributionsProvider → Stream.value(const [])`) to short-circuit the new chip's Drift watch and avoid pending-timer leaks at tearDown.

## PR #56/#57 review fixes (P1 + 2×P2)

- **P1 — Remote cache controller never started after sign-in.** `_SyncBootstrap.initState` checked `currentSession` once. In the common launch-signed-out → sign-in flow the condition was false on boot and never re-evaluated, so cold-open / realtime never ran for that session. Now subscribed to `auth.onAuthStateChange`; on signed-in we start, on signed-out we invalidate providers so the next sign-in gets fresh instances.
- **P2 — Non-deterministic assignment selection.** `select(assignments)..limit(1)` without `orderBy` picked an arbitrary row. Switched to `orderBy(desc(createdAt))..limit(1)` — matches `AssignmentRepository.getCurrentAssignment()`. New test asserts newest wins when two assignments are present.
- **P2 — Sequentially-awaited RPC futures could orphan the second.** If `fetchAttributions` threw, `fetchNewFeatures` was orphaned and its later error surfaced as an uncaught async exception. Switched to `Future.wait`. New test confirms no orphan.

## Verification

- ✅ 13 new tests for phase 4: 5 flatten domain tests, 5 widget tests (chip visibility / count, list empty-state, tile rendering), 3 provider tests (own-submission exclusion, dedup-by-feature, signed-out fallback).
- ✅ Full suite: **770 passing, 3 pre-existing failures on `main`, 0 regressions**, 2 skipped.
- ✅ `dart analyze` on touched files: no errors.

## Test plan

- [ ] Merge phase 2 + 3 first.
- [ ] Sign in on device A and device B with the same assignment. From device A, submit a building attribution. On device B's map screen, verify the chip appears within ~1s. Tap → see the building in the list. Tap → "Their answers" shows the typed values.
- [ ] Sign out on device B — chip disappears. Sign back in — chip reappears (auth-lifecycle fix).
- [ ] On a device with multiple downloaded assignments, verify the chip / pulls reference the newest (deterministic-assignment fix).

## Out of scope (next phases)

- Phase 5: Switch upload path to new RPCs + conflict review UI + dedup UI.
- Phase 6: Decommission old upload path + orphan-photo cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)