### PR TITLE
Multi-user attribution sync — conflict-aware upload + review UI

### DIFF
--- a/lib/core/db/database.dart
+++ b/lib/core/db/database.dart
@@ -11,6 +11,7 @@ import 'package:firecheck/core/db/tables/feature_geometry_revisions.dart';
 import 'package:firecheck/core/db/tables/features.dart';
 import 'package:firecheck/core/db/tables/household_surveys.dart';
 import 'package:firecheck/core/db/tables/offline_tile_packs.dart';
+import 'package:firecheck/core/db/tables/pending_resolutions.dart';
 import 'package:firecheck/core/db/tables/photos.dart';
 import 'package:firecheck/core/db/tables/ra_9514_types.dart';
 import 'package:firecheck/core/db/tables/remote_attributions_cache.dart';
@@ -41,6 +42,7 @@ part 'database.g.dart';
     RemoteAttributionsCache,
     RemoteNewFeaturesCache,
     AssignmentSyncCursors,
+    PendingResolutions,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -50,7 +52,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 10;
+  int get schemaVersion => 11;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -84,41 +86,47 @@ class AppDatabase extends _$AppDatabase {
             await m.addColumn(assignments, assignments.closedRemotely);
           }
           if (from < 6) {
-            // v5 → v6: feature_geometry_revisions table for US-9 reshape.
+            // v5 → v6: feature_geometry_revisions table for polygon reshape.
             await m.createTable(featureGeometryRevisions);
             await m.createIndex(fgrFeatureIdIdx);
             await m.createIndex(fgrSyncStatusIdx);
           }
           if (from < 7) {
-            // v6 → v7: drive_modified_time and drive_folder_id for US-17 Get Maps.
+            // v6 → v7: drive_modified_time and drive_folder_id for Get Maps.
             await m.addColumn(assignments, assignments.driveModifiedTime);
             await m.addColumn(assignments, assignments.driveFolderId);
           }
           if (from < 8) {
-            // v7 → v8: drive_upload_jobs table for US-29 upload to Drive.
+            // v7 → v8: drive_upload_jobs table for upload to Drive.
             await m.createTable(driveUploadJobs);
             await m.createIndex(driveUploadJobsStatusIdx);
             await m.createIndex(driveUploadJobsAssignmentIdx);
           }
           if (from < 9) {
-            // v8 → v9: Drive upload confirmation columns for US-30.
+            // v8 → v9: Drive upload confirmation columns.
             await m.addColumn(assignments, assignments.driveFolderPath);
             await m.addColumn(assignments, assignments.driveFolderUrl);
             await m.addColumn(assignments, assignments.driveUploadConfirmedAt);
           }
           if (from < 10) {
-            // v9 → v10: Phase 2 of multi-user attribution sync.
-            // Local read-only cache of remote canonical state, plus per-
+            // v9 → v10: local mirror of remote canonical state + per-
             // assignment cursors for delta pulls. The cache is populated by
-            // cold-open / reconnect pulls (and by realtime in phase 3); the
-            // user's own submissions stay in `submissions` — the cache
-            // never touches them.
+            // cold-open / reconnect pulls and by realtime; the user's own
+            // submissions stay in `submissions` — the cache never touches them.
             await m.createTable(remoteAttributionsCache);
             await m.createIndex(remoteAttributionsCacheFeatureIdx);
             await m.createIndex(remoteAttributionsCacheUpdatedAtIdx);
             await m.createTable(remoteNewFeaturesCache);
             await m.createIndex(remoteNewFeaturesCacheAssignmentIdx);
             await m.createTable(assignmentSyncCursors);
+          }
+          if (from < 11) {
+            // v10 → v11: pendingTheirsId tracks the conflicting canonical
+            // on a parked submission so the review UI can render side-by-
+            // side without re-querying. pending_resolutions stores the
+            // chosen decision while it awaits the resolve_* RPC call.
+            await m.addColumn(submissions, submissions.pendingTheirsId);
+            await m.createTable(pendingResolutions);
           }
         },
         beforeOpen: (details) async {

--- a/lib/core/db/database.g.dart
+++ b/lib/core/db/database.g.dart
@@ -1957,6 +1957,12 @@ class $SubmissionsTable extends Submissions
   late final GeneratedColumn<String> overrideReason = GeneratedColumn<String>(
       'override_reason', aliasedName, true,
       type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _pendingTheirsIdMeta =
+      const VerificationMeta('pendingTheirsId');
+  @override
+  late final GeneratedColumn<String> pendingTheirsId = GeneratedColumn<String>(
+      'pending_theirs_id', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
   static const VerificationMeta _createdAtMeta =
       const VerificationMeta('createdAt');
   @override
@@ -1978,6 +1984,7 @@ class $SubmissionsTable extends Submissions
         remarks,
         syncStatus,
         overrideReason,
+        pendingTheirsId,
         createdAt,
         updatedAt
       ];
@@ -2030,6 +2037,12 @@ class $SubmissionsTable extends Submissions
           overrideReason.isAcceptableOrUnknown(
               data['override_reason']!, _overrideReasonMeta));
     }
+    if (data.containsKey('pending_theirs_id')) {
+      context.handle(
+          _pendingTheirsIdMeta,
+          pendingTheirsId.isAcceptableOrUnknown(
+              data['pending_theirs_id']!, _pendingTheirsIdMeta));
+    }
     if (data.containsKey('created_at')) {
       context.handle(_createdAtMeta,
           createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
@@ -2065,6 +2078,8 @@ class $SubmissionsTable extends Submissions
           .read(DriftSqlType.string, data['${effectivePrefix}sync_status'])!,
       overrideReason: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}override_reason']),
+      pendingTheirsId: attachedDatabase.typeMapping.read(
+          DriftSqlType.string, data['${effectivePrefix}pending_theirs_id']),
       createdAt: attachedDatabase.typeMapping
           .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
       updatedAt: attachedDatabase.typeMapping
@@ -2086,6 +2101,7 @@ class Submission extends DataClass implements Insertable<Submission> {
   final String? remarks;
   final String syncStatus;
   final String? overrideReason;
+  final String? pendingTheirsId;
   final DateTime createdAt;
   final DateTime updatedAt;
   const Submission(
@@ -2096,6 +2112,7 @@ class Submission extends DataClass implements Insertable<Submission> {
       this.remarks,
       required this.syncStatus,
       this.overrideReason,
+      this.pendingTheirsId,
       required this.createdAt,
       required this.updatedAt});
   @override
@@ -2113,6 +2130,9 @@ class Submission extends DataClass implements Insertable<Submission> {
     map['sync_status'] = Variable<String>(syncStatus);
     if (!nullToAbsent || overrideReason != null) {
       map['override_reason'] = Variable<String>(overrideReason);
+    }
+    if (!nullToAbsent || pendingTheirsId != null) {
+      map['pending_theirs_id'] = Variable<String>(pendingTheirsId);
     }
     map['created_at'] = Variable<DateTime>(createdAt);
     map['updated_at'] = Variable<DateTime>(updatedAt);
@@ -2134,6 +2154,9 @@ class Submission extends DataClass implements Insertable<Submission> {
       overrideReason: overrideReason == null && nullToAbsent
           ? const Value.absent()
           : Value(overrideReason),
+      pendingTheirsId: pendingTheirsId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(pendingTheirsId),
       createdAt: Value(createdAt),
       updatedAt: Value(updatedAt),
     );
@@ -2150,6 +2173,7 @@ class Submission extends DataClass implements Insertable<Submission> {
       remarks: serializer.fromJson<String?>(json['remarks']),
       syncStatus: serializer.fromJson<String>(json['syncStatus']),
       overrideReason: serializer.fromJson<String?>(json['overrideReason']),
+      pendingTheirsId: serializer.fromJson<String?>(json['pendingTheirsId']),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
       updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
     );
@@ -2165,6 +2189,7 @@ class Submission extends DataClass implements Insertable<Submission> {
       'remarks': serializer.toJson<String?>(remarks),
       'syncStatus': serializer.toJson<String>(syncStatus),
       'overrideReason': serializer.toJson<String?>(overrideReason),
+      'pendingTheirsId': serializer.toJson<String?>(pendingTheirsId),
       'createdAt': serializer.toJson<DateTime>(createdAt),
       'updatedAt': serializer.toJson<DateTime>(updatedAt),
     };
@@ -2178,6 +2203,7 @@ class Submission extends DataClass implements Insertable<Submission> {
           Value<String?> remarks = const Value.absent(),
           String? syncStatus,
           Value<String?> overrideReason = const Value.absent(),
+          Value<String?> pendingTheirsId = const Value.absent(),
           DateTime? createdAt,
           DateTime? updatedAt}) =>
       Submission(
@@ -2189,6 +2215,9 @@ class Submission extends DataClass implements Insertable<Submission> {
         syncStatus: syncStatus ?? this.syncStatus,
         overrideReason:
             overrideReason.present ? overrideReason.value : this.overrideReason,
+        pendingTheirsId: pendingTheirsId.present
+            ? pendingTheirsId.value
+            : this.pendingTheirsId,
         createdAt: createdAt ?? this.createdAt,
         updatedAt: updatedAt ?? this.updatedAt,
       );
@@ -2207,6 +2236,9 @@ class Submission extends DataClass implements Insertable<Submission> {
       overrideReason: data.overrideReason.present
           ? data.overrideReason.value
           : this.overrideReason,
+      pendingTheirsId: data.pendingTheirsId.present
+          ? data.pendingTheirsId.value
+          : this.pendingTheirsId,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
@@ -2222,6 +2254,7 @@ class Submission extends DataClass implements Insertable<Submission> {
           ..write('remarks: $remarks, ')
           ..write('syncStatus: $syncStatus, ')
           ..write('overrideReason: $overrideReason, ')
+          ..write('pendingTheirsId: $pendingTheirsId, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt')
           ..write(')'))
@@ -2229,8 +2262,17 @@ class Submission extends DataClass implements Insertable<Submission> {
   }
 
   @override
-  int get hashCode => Object.hash(id, featureId, submittedBy, doesNotExist,
-      remarks, syncStatus, overrideReason, createdAt, updatedAt);
+  int get hashCode => Object.hash(
+      id,
+      featureId,
+      submittedBy,
+      doesNotExist,
+      remarks,
+      syncStatus,
+      overrideReason,
+      pendingTheirsId,
+      createdAt,
+      updatedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -2242,6 +2284,7 @@ class Submission extends DataClass implements Insertable<Submission> {
           other.remarks == this.remarks &&
           other.syncStatus == this.syncStatus &&
           other.overrideReason == this.overrideReason &&
+          other.pendingTheirsId == this.pendingTheirsId &&
           other.createdAt == this.createdAt &&
           other.updatedAt == this.updatedAt);
 }
@@ -2254,6 +2297,7 @@ class SubmissionsCompanion extends UpdateCompanion<Submission> {
   final Value<String?> remarks;
   final Value<String> syncStatus;
   final Value<String?> overrideReason;
+  final Value<String?> pendingTheirsId;
   final Value<DateTime> createdAt;
   final Value<DateTime> updatedAt;
   final Value<int> rowid;
@@ -2265,6 +2309,7 @@ class SubmissionsCompanion extends UpdateCompanion<Submission> {
     this.remarks = const Value.absent(),
     this.syncStatus = const Value.absent(),
     this.overrideReason = const Value.absent(),
+    this.pendingTheirsId = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -2277,6 +2322,7 @@ class SubmissionsCompanion extends UpdateCompanion<Submission> {
     this.remarks = const Value.absent(),
     this.syncStatus = const Value.absent(),
     this.overrideReason = const Value.absent(),
+    this.pendingTheirsId = const Value.absent(),
     required DateTime createdAt,
     required DateTime updatedAt,
     this.rowid = const Value.absent(),
@@ -2292,6 +2338,7 @@ class SubmissionsCompanion extends UpdateCompanion<Submission> {
     Expression<String>? remarks,
     Expression<String>? syncStatus,
     Expression<String>? overrideReason,
+    Expression<String>? pendingTheirsId,
     Expression<DateTime>? createdAt,
     Expression<DateTime>? updatedAt,
     Expression<int>? rowid,
@@ -2304,6 +2351,7 @@ class SubmissionsCompanion extends UpdateCompanion<Submission> {
       if (remarks != null) 'remarks': remarks,
       if (syncStatus != null) 'sync_status': syncStatus,
       if (overrideReason != null) 'override_reason': overrideReason,
+      if (pendingTheirsId != null) 'pending_theirs_id': pendingTheirsId,
       if (createdAt != null) 'created_at': createdAt,
       if (updatedAt != null) 'updated_at': updatedAt,
       if (rowid != null) 'rowid': rowid,
@@ -2318,6 +2366,7 @@ class SubmissionsCompanion extends UpdateCompanion<Submission> {
       Value<String?>? remarks,
       Value<String>? syncStatus,
       Value<String?>? overrideReason,
+      Value<String?>? pendingTheirsId,
       Value<DateTime>? createdAt,
       Value<DateTime>? updatedAt,
       Value<int>? rowid}) {
@@ -2329,6 +2378,7 @@ class SubmissionsCompanion extends UpdateCompanion<Submission> {
       remarks: remarks ?? this.remarks,
       syncStatus: syncStatus ?? this.syncStatus,
       overrideReason: overrideReason ?? this.overrideReason,
+      pendingTheirsId: pendingTheirsId ?? this.pendingTheirsId,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       rowid: rowid ?? this.rowid,
@@ -2359,6 +2409,9 @@ class SubmissionsCompanion extends UpdateCompanion<Submission> {
     if (overrideReason.present) {
       map['override_reason'] = Variable<String>(overrideReason.value);
     }
+    if (pendingTheirsId.present) {
+      map['pending_theirs_id'] = Variable<String>(pendingTheirsId.value);
+    }
     if (createdAt.present) {
       map['created_at'] = Variable<DateTime>(createdAt.value);
     }
@@ -2381,6 +2434,7 @@ class SubmissionsCompanion extends UpdateCompanion<Submission> {
           ..write('remarks: $remarks, ')
           ..write('syncStatus: $syncStatus, ')
           ..write('overrideReason: $overrideReason, ')
+          ..write('pendingTheirsId: $pendingTheirsId, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt, ')
           ..write('rowid: $rowid')
@@ -7885,6 +7939,333 @@ class AssignmentSyncCursorsCompanion
   }
 }
 
+class $PendingResolutionsTable extends PendingResolutions
+    with TableInfo<$PendingResolutionsTable, PendingResolution> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PendingResolutionsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _targetIdMeta =
+      const VerificationMeta('targetId');
+  @override
+  late final GeneratedColumn<String> targetId = GeneratedColumn<String>(
+      'target_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _kindMeta = const VerificationMeta('kind');
+  @override
+  late final GeneratedColumn<String> kind = GeneratedColumn<String>(
+      'kind', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _decisionMeta =
+      const VerificationMeta('decision');
+  @override
+  late final GeneratedColumn<String> decision = GeneratedColumn<String>(
+      'decision', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _resolutionNoteMeta =
+      const VerificationMeta('resolutionNote');
+  @override
+  late final GeneratedColumn<String> resolutionNote = GeneratedColumn<String>(
+      'resolution_note', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+      'created_at', aliasedName, false,
+      type: DriftSqlType.dateTime, requiredDuringInsert: true);
+  @override
+  List<GeneratedColumn> get $columns =>
+      [targetId, kind, decision, resolutionNote, createdAt];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'pending_resolutions';
+  @override
+  VerificationContext validateIntegrity(Insertable<PendingResolution> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('target_id')) {
+      context.handle(_targetIdMeta,
+          targetId.isAcceptableOrUnknown(data['target_id']!, _targetIdMeta));
+    } else if (isInserting) {
+      context.missing(_targetIdMeta);
+    }
+    if (data.containsKey('kind')) {
+      context.handle(
+          _kindMeta, kind.isAcceptableOrUnknown(data['kind']!, _kindMeta));
+    } else if (isInserting) {
+      context.missing(_kindMeta);
+    }
+    if (data.containsKey('decision')) {
+      context.handle(_decisionMeta,
+          decision.isAcceptableOrUnknown(data['decision']!, _decisionMeta));
+    } else if (isInserting) {
+      context.missing(_decisionMeta);
+    }
+    if (data.containsKey('resolution_note')) {
+      context.handle(
+          _resolutionNoteMeta,
+          resolutionNote.isAcceptableOrUnknown(
+              data['resolution_note']!, _resolutionNoteMeta));
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {targetId, kind};
+  @override
+  PendingResolution map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return PendingResolution(
+      targetId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}target_id'])!,
+      kind: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}kind'])!,
+      decision: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}decision'])!,
+      resolutionNote: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}resolution_note']),
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+    );
+  }
+
+  @override
+  $PendingResolutionsTable createAlias(String alias) {
+    return $PendingResolutionsTable(attachedDatabase, alias);
+  }
+}
+
+class PendingResolution extends DataClass
+    implements Insertable<PendingResolution> {
+  /// The submission UUID (kind=attribution) or feature UUID
+  /// (kind=new_feature) being resolved.
+  final String targetId;
+
+  /// `attribution` | `new_feature`.
+  final String kind;
+
+  /// Wire-form decision: `keep_theirs`, `force_overwrite`, `keep_both`,
+  /// `replace_theirs`, `discard_mine`.
+  final String decision;
+
+  /// Optional free-text note attached to the audit log on the server.
+  final String? resolutionNote;
+  final DateTime createdAt;
+  const PendingResolution(
+      {required this.targetId,
+      required this.kind,
+      required this.decision,
+      this.resolutionNote,
+      required this.createdAt});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['target_id'] = Variable<String>(targetId);
+    map['kind'] = Variable<String>(kind);
+    map['decision'] = Variable<String>(decision);
+    if (!nullToAbsent || resolutionNote != null) {
+      map['resolution_note'] = Variable<String>(resolutionNote);
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    return map;
+  }
+
+  PendingResolutionsCompanion toCompanion(bool nullToAbsent) {
+    return PendingResolutionsCompanion(
+      targetId: Value(targetId),
+      kind: Value(kind),
+      decision: Value(decision),
+      resolutionNote: resolutionNote == null && nullToAbsent
+          ? const Value.absent()
+          : Value(resolutionNote),
+      createdAt: Value(createdAt),
+    );
+  }
+
+  factory PendingResolution.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return PendingResolution(
+      targetId: serializer.fromJson<String>(json['targetId']),
+      kind: serializer.fromJson<String>(json['kind']),
+      decision: serializer.fromJson<String>(json['decision']),
+      resolutionNote: serializer.fromJson<String?>(json['resolutionNote']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'targetId': serializer.toJson<String>(targetId),
+      'kind': serializer.toJson<String>(kind),
+      'decision': serializer.toJson<String>(decision),
+      'resolutionNote': serializer.toJson<String?>(resolutionNote),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+    };
+  }
+
+  PendingResolution copyWith(
+          {String? targetId,
+          String? kind,
+          String? decision,
+          Value<String?> resolutionNote = const Value.absent(),
+          DateTime? createdAt}) =>
+      PendingResolution(
+        targetId: targetId ?? this.targetId,
+        kind: kind ?? this.kind,
+        decision: decision ?? this.decision,
+        resolutionNote:
+            resolutionNote.present ? resolutionNote.value : this.resolutionNote,
+        createdAt: createdAt ?? this.createdAt,
+      );
+  PendingResolution copyWithCompanion(PendingResolutionsCompanion data) {
+    return PendingResolution(
+      targetId: data.targetId.present ? data.targetId.value : this.targetId,
+      kind: data.kind.present ? data.kind.value : this.kind,
+      decision: data.decision.present ? data.decision.value : this.decision,
+      resolutionNote: data.resolutionNote.present
+          ? data.resolutionNote.value
+          : this.resolutionNote,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PendingResolution(')
+          ..write('targetId: $targetId, ')
+          ..write('kind: $kind, ')
+          ..write('decision: $decision, ')
+          ..write('resolutionNote: $resolutionNote, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(targetId, kind, decision, resolutionNote, createdAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PendingResolution &&
+          other.targetId == this.targetId &&
+          other.kind == this.kind &&
+          other.decision == this.decision &&
+          other.resolutionNote == this.resolutionNote &&
+          other.createdAt == this.createdAt);
+}
+
+class PendingResolutionsCompanion extends UpdateCompanion<PendingResolution> {
+  final Value<String> targetId;
+  final Value<String> kind;
+  final Value<String> decision;
+  final Value<String?> resolutionNote;
+  final Value<DateTime> createdAt;
+  final Value<int> rowid;
+  const PendingResolutionsCompanion({
+    this.targetId = const Value.absent(),
+    this.kind = const Value.absent(),
+    this.decision = const Value.absent(),
+    this.resolutionNote = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  PendingResolutionsCompanion.insert({
+    required String targetId,
+    required String kind,
+    required String decision,
+    this.resolutionNote = const Value.absent(),
+    required DateTime createdAt,
+    this.rowid = const Value.absent(),
+  })  : targetId = Value(targetId),
+        kind = Value(kind),
+        decision = Value(decision),
+        createdAt = Value(createdAt);
+  static Insertable<PendingResolution> custom({
+    Expression<String>? targetId,
+    Expression<String>? kind,
+    Expression<String>? decision,
+    Expression<String>? resolutionNote,
+    Expression<DateTime>? createdAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (targetId != null) 'target_id': targetId,
+      if (kind != null) 'kind': kind,
+      if (decision != null) 'decision': decision,
+      if (resolutionNote != null) 'resolution_note': resolutionNote,
+      if (createdAt != null) 'created_at': createdAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  PendingResolutionsCompanion copyWith(
+      {Value<String>? targetId,
+      Value<String>? kind,
+      Value<String>? decision,
+      Value<String?>? resolutionNote,
+      Value<DateTime>? createdAt,
+      Value<int>? rowid}) {
+    return PendingResolutionsCompanion(
+      targetId: targetId ?? this.targetId,
+      kind: kind ?? this.kind,
+      decision: decision ?? this.decision,
+      resolutionNote: resolutionNote ?? this.resolutionNote,
+      createdAt: createdAt ?? this.createdAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (targetId.present) {
+      map['target_id'] = Variable<String>(targetId.value);
+    }
+    if (kind.present) {
+      map['kind'] = Variable<String>(kind.value);
+    }
+    if (decision.present) {
+      map['decision'] = Variable<String>(decision.value);
+    }
+    if (resolutionNote.present) {
+      map['resolution_note'] = Variable<String>(resolutionNote.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PendingResolutionsCompanion(')
+          ..write('targetId: $targetId, ')
+          ..write('kind: $kind, ')
+          ..write('decision: $decision, ')
+          ..write('resolutionNote: $resolutionNote, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -7912,6 +8293,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       $RemoteNewFeaturesCacheTable(this);
   late final $AssignmentSyncCursorsTable assignmentSyncCursors =
       $AssignmentSyncCursorsTable(this);
+  late final $PendingResolutionsTable pendingResolutions =
+      $PendingResolutionsTable(this);
   late final Index featuresAssignmentIdIdx = Index('features_assignment_id_idx',
       'CREATE INDEX features_assignment_id_idx ON features (assignment_id)');
   late final Index fgrFeatureIdIdx = Index('fgr_feature_id_idx',
@@ -7963,6 +8346,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
         remoteAttributionsCache,
         remoteNewFeaturesCache,
         assignmentSyncCursors,
+        pendingResolutions,
         featuresAssignmentIdIdx,
         fgrFeatureIdIdx,
         fgrSyncStatusIdx,
@@ -8896,6 +9280,7 @@ typedef $$SubmissionsTableCreateCompanionBuilder = SubmissionsCompanion
   Value<String?> remarks,
   Value<String> syncStatus,
   Value<String?> overrideReason,
+  Value<String?> pendingTheirsId,
   required DateTime createdAt,
   required DateTime updatedAt,
   Value<int> rowid,
@@ -8909,6 +9294,7 @@ typedef $$SubmissionsTableUpdateCompanionBuilder = SubmissionsCompanion
   Value<String?> remarks,
   Value<String> syncStatus,
   Value<String?> overrideReason,
+  Value<String?> pendingTheirsId,
   Value<DateTime> createdAt,
   Value<DateTime> updatedAt,
   Value<int> rowid,
@@ -8943,6 +9329,10 @@ class $$SubmissionsTableFilterComposer
 
   ColumnFilters<String> get overrideReason => $composableBuilder(
       column: $table.overrideReason,
+      builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get pendingTheirsId => $composableBuilder(
+      column: $table.pendingTheirsId,
       builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get createdAt => $composableBuilder(
@@ -8984,6 +9374,10 @@ class $$SubmissionsTableOrderingComposer
       column: $table.overrideReason,
       builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<String> get pendingTheirsId => $composableBuilder(
+      column: $table.pendingTheirsId,
+      builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<DateTime> get createdAt => $composableBuilder(
       column: $table.createdAt, builder: (column) => ColumnOrderings(column));
 
@@ -9020,6 +9414,9 @@ class $$SubmissionsTableAnnotationComposer
 
   GeneratedColumn<String> get overrideReason => $composableBuilder(
       column: $table.overrideReason, builder: (column) => column);
+
+  GeneratedColumn<String> get pendingTheirsId => $composableBuilder(
+      column: $table.pendingTheirsId, builder: (column) => column);
 
   GeneratedColumn<DateTime> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
@@ -9058,6 +9455,7 @@ class $$SubmissionsTableTableManager extends RootTableManager<
             Value<String?> remarks = const Value.absent(),
             Value<String> syncStatus = const Value.absent(),
             Value<String?> overrideReason = const Value.absent(),
+            Value<String?> pendingTheirsId = const Value.absent(),
             Value<DateTime> createdAt = const Value.absent(),
             Value<DateTime> updatedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -9070,6 +9468,7 @@ class $$SubmissionsTableTableManager extends RootTableManager<
             remarks: remarks,
             syncStatus: syncStatus,
             overrideReason: overrideReason,
+            pendingTheirsId: pendingTheirsId,
             createdAt: createdAt,
             updatedAt: updatedAt,
             rowid: rowid,
@@ -9082,6 +9481,7 @@ class $$SubmissionsTableTableManager extends RootTableManager<
             Value<String?> remarks = const Value.absent(),
             Value<String> syncStatus = const Value.absent(),
             Value<String?> overrideReason = const Value.absent(),
+            Value<String?> pendingTheirsId = const Value.absent(),
             required DateTime createdAt,
             required DateTime updatedAt,
             Value<int> rowid = const Value.absent(),
@@ -9094,6 +9494,7 @@ class $$SubmissionsTableTableManager extends RootTableManager<
             remarks: remarks,
             syncStatus: syncStatus,
             overrideReason: overrideReason,
+            pendingTheirsId: pendingTheirsId,
             createdAt: createdAt,
             updatedAt: updatedAt,
             rowid: rowid,
@@ -11731,6 +12132,183 @@ typedef $$AssignmentSyncCursorsTableProcessedTableManager
         ),
         AssignmentSyncCursor,
         PrefetchHooks Function()>;
+typedef $$PendingResolutionsTableCreateCompanionBuilder
+    = PendingResolutionsCompanion Function({
+  required String targetId,
+  required String kind,
+  required String decision,
+  Value<String?> resolutionNote,
+  required DateTime createdAt,
+  Value<int> rowid,
+});
+typedef $$PendingResolutionsTableUpdateCompanionBuilder
+    = PendingResolutionsCompanion Function({
+  Value<String> targetId,
+  Value<String> kind,
+  Value<String> decision,
+  Value<String?> resolutionNote,
+  Value<DateTime> createdAt,
+  Value<int> rowid,
+});
+
+class $$PendingResolutionsTableFilterComposer
+    extends Composer<_$AppDatabase, $PendingResolutionsTable> {
+  $$PendingResolutionsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get targetId => $composableBuilder(
+      column: $table.targetId, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get kind => $composableBuilder(
+      column: $table.kind, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get decision => $composableBuilder(
+      column: $table.decision, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get resolutionNote => $composableBuilder(
+      column: $table.resolutionNote,
+      builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+      column: $table.createdAt, builder: (column) => ColumnFilters(column));
+}
+
+class $$PendingResolutionsTableOrderingComposer
+    extends Composer<_$AppDatabase, $PendingResolutionsTable> {
+  $$PendingResolutionsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get targetId => $composableBuilder(
+      column: $table.targetId, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get kind => $composableBuilder(
+      column: $table.kind, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get decision => $composableBuilder(
+      column: $table.decision, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get resolutionNote => $composableBuilder(
+      column: $table.resolutionNote,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+      column: $table.createdAt, builder: (column) => ColumnOrderings(column));
+}
+
+class $$PendingResolutionsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $PendingResolutionsTable> {
+  $$PendingResolutionsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get targetId =>
+      $composableBuilder(column: $table.targetId, builder: (column) => column);
+
+  GeneratedColumn<String> get kind =>
+      $composableBuilder(column: $table.kind, builder: (column) => column);
+
+  GeneratedColumn<String> get decision =>
+      $composableBuilder(column: $table.decision, builder: (column) => column);
+
+  GeneratedColumn<String> get resolutionNote => $composableBuilder(
+      column: $table.resolutionNote, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+}
+
+class $$PendingResolutionsTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $PendingResolutionsTable,
+    PendingResolution,
+    $$PendingResolutionsTableFilterComposer,
+    $$PendingResolutionsTableOrderingComposer,
+    $$PendingResolutionsTableAnnotationComposer,
+    $$PendingResolutionsTableCreateCompanionBuilder,
+    $$PendingResolutionsTableUpdateCompanionBuilder,
+    (
+      PendingResolution,
+      BaseReferences<_$AppDatabase, $PendingResolutionsTable, PendingResolution>
+    ),
+    PendingResolution,
+    PrefetchHooks Function()> {
+  $$PendingResolutionsTableTableManager(
+      _$AppDatabase db, $PendingResolutionsTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PendingResolutionsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$PendingResolutionsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$PendingResolutionsTableAnnotationComposer(
+                  $db: db, $table: table),
+          updateCompanionCallback: ({
+            Value<String> targetId = const Value.absent(),
+            Value<String> kind = const Value.absent(),
+            Value<String> decision = const Value.absent(),
+            Value<String?> resolutionNote = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              PendingResolutionsCompanion(
+            targetId: targetId,
+            kind: kind,
+            decision: decision,
+            resolutionNote: resolutionNote,
+            createdAt: createdAt,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String targetId,
+            required String kind,
+            required String decision,
+            Value<String?> resolutionNote = const Value.absent(),
+            required DateTime createdAt,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              PendingResolutionsCompanion.insert(
+            targetId: targetId,
+            kind: kind,
+            decision: decision,
+            resolutionNote: resolutionNote,
+            createdAt: createdAt,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$PendingResolutionsTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $PendingResolutionsTable,
+    PendingResolution,
+    $$PendingResolutionsTableFilterComposer,
+    $$PendingResolutionsTableOrderingComposer,
+    $$PendingResolutionsTableAnnotationComposer,
+    $$PendingResolutionsTableCreateCompanionBuilder,
+    $$PendingResolutionsTableUpdateCompanionBuilder,
+    (
+      PendingResolution,
+      BaseReferences<_$AppDatabase, $PendingResolutionsTable, PendingResolution>
+    ),
+    PendingResolution,
+    PrefetchHooks Function()>;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -11770,4 +12348,6 @@ class $AppDatabaseManager {
           _db, _db.remoteNewFeaturesCache);
   $$AssignmentSyncCursorsTableTableManager get assignmentSyncCursors =>
       $$AssignmentSyncCursorsTableTableManager(_db, _db.assignmentSyncCursors);
+  $$PendingResolutionsTableTableManager get pendingResolutions =>
+      $$PendingResolutionsTableTableManager(_db, _db.pendingResolutions);
 }

--- a/lib/core/db/tables/assignments.dart
+++ b/lib/core/db/tables/assignments.dart
@@ -13,7 +13,7 @@ class Assignments extends Table {
   DateTimeColumn get createdAt => dateTime()();
   TextColumn get driveModifiedTime => text().nullable()();
   TextColumn get driveFolderId => text().nullable()();
-  // US-30: Drive upload confirmation
+  // Drive upload confirmation
   TextColumn get driveFolderPath => text().nullable()();
   TextColumn get driveFolderUrl => text().nullable()();
   DateTimeColumn get driveUploadConfirmedAt => dateTime().nullable()();

--- a/lib/core/db/tables/pending_resolutions.dart
+++ b/lib/core/db/tables/pending_resolutions.dart
@@ -1,0 +1,28 @@
+import 'package:drift/drift.dart';
+
+/// Decisions queued by the conflict / dedup review UI, waiting for the
+/// sync worker to call the corresponding `resolve_*` RPC. One row per
+/// pending submission (kind=`attribution`) or feature (kind=`new_feature`).
+///
+/// Rows survive process restarts so the user can resolve offline and the
+/// worker drains the queue once connectivity returns.
+class PendingResolutions extends Table {
+  /// The submission UUID (kind=attribution) or feature UUID
+  /// (kind=new_feature) being resolved.
+  TextColumn get targetId => text()();
+
+  /// `attribution` | `new_feature`.
+  TextColumn get kind => text()();
+
+  /// Wire-form decision: `keep_theirs`, `force_overwrite`, `keep_both`,
+  /// `replace_theirs`, `discard_mine`.
+  TextColumn get decision => text()();
+
+  /// Optional free-text note attached to the audit log on the server.
+  TextColumn get resolutionNote => text().nullable()();
+
+  DateTimeColumn get createdAt => dateTime()();
+
+  @override
+  Set<Column> get primaryKey => {targetId, kind};
+}

--- a/lib/core/db/tables/remote_attributions_cache.dart
+++ b/lib/core/db/tables/remote_attributions_cache.dart
@@ -2,8 +2,8 @@ import 'package:drift/drift.dart';
 
 /// Local mirror of remote `public.submissions` rows for assignments the
 /// current user is a member of. Populated by cold-open pull, on-reconnect
-/// delta pull, and realtime events (phase 3). Read-only from the UI's
-/// perspective — never blocks local edits.
+/// delta pull, and realtime events. Read-only from the UI's perspective —
+/// never blocks local edits.
 ///
 /// `attributeValuesJson` is the denormalized child-table data shaped as
 /// jsonb: `{ "building": {...}, "road": null, "household": null }`.

--- a/lib/core/db/tables/submissions.dart
+++ b/lib/core/db/tables/submissions.dart
@@ -12,6 +12,11 @@ class Submissions extends Table {
   TextColumn get remarks => text().nullable()();
   TextColumn get syncStatus => text().withDefault(const Constant('draft'))();
   TextColumn get overrideReason => text().nullable()();
+  // When the server returns status=conflict, we store the conflicting
+  // canonical's UUID here so the review UI can render side-by-side
+  // comparison without re-querying. Null for non-conflict submissions;
+  // cleared on resolve.
+  TextColumn get pendingTheirsId => text().nullable()();
   DateTimeColumn get createdAt => dateTime()();
   DateTimeColumn get updatedAt => dateTime()();
 

--- a/lib/core/forms/form_variant.dart
+++ b/lib/core/forms/form_variant.dart
@@ -1,8 +1,6 @@
-// lib/core/forms/form_variant.dart
-//
-// Form-variant model used by US-41 to let a form designer push pilot or
-// region-specific survey variations without changing app code. Variants
-// live in assets/form_variants.json and are loaded once at startup.
+// Form-variant model that lets a form designer push pilot or region-specific
+// survey variations without changing app code. Variants live in
+// assets/form_variants.json and are loaded once at startup.
 import 'package:firecheck/features/survey/building_form/domain/building_form_applicability.dart';
 import 'package:firecheck/features/survey/road_form/domain/road_form_applicability.dart';
 

--- a/lib/core/geo/centroid.dart
+++ b/lib/core/geo/centroid.dart
@@ -48,7 +48,7 @@ LatLng polygonCentroid(List<List<double>> ring) {
 
 /// Best-effort GeoJSON decode. Returns the first (outer) ring of a Polygon
 /// as a list of `[lng, lat]` pairs, or null if the input isn't a parseable
-/// Polygon. Holes are ignored (Phase 2 doesn't model them).
+/// Polygon. Holes are ignored.
 List<List<double>>? decodePolygonGeojson(String geojson) {
   if (geojson.isEmpty) return null;
   try {

--- a/lib/core/mapbox/offline_pack_adapter.dart
+++ b/lib/core/mapbox/offline_pack_adapter.dart
@@ -45,7 +45,7 @@ abstract class OfflinePackAdapter {
 
 /// Real adapter backed by Mapbox [TileStore].
 ///
-/// Notes for Phase 1 T19 (MapboxMapRenderer) wiring:
+/// Notes on MapboxMapRenderer wiring:
 /// - Mapbox 2.22 `TileStore.loadTileRegion` takes the region `id`, a
 ///   [TileRegionLoadOptions], and an optional progress listener. It returns
 ///   a `Future<TileRegion>` that completes on success or throws on failure.

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -6,6 +6,9 @@ import 'package:firecheck/features/assignment/presentation/get_maps_screen.dart'
 import 'package:firecheck/features/auth/presentation/auth_providers.dart';
 import 'package:firecheck/features/auth/presentation/sign_in_screen.dart';
 import 'package:firecheck/features/home/presentation/home_screen.dart';
+import 'package:firecheck/features/conflict_review/presentation/attribution_conflict_screen.dart';
+import 'package:firecheck/features/conflict_review/presentation/conflict_review_list_screen.dart';
+import 'package:firecheck/features/conflict_review/presentation/dedup_review_screen.dart';
 import 'package:firecheck/features/map/presentation/map_screen.dart';
 import 'package:firecheck/features/remote_activity/presentation/remote_activity_list_screen.dart';
 import 'package:firecheck/features/remote_activity/presentation/remote_attribution_detail_screen.dart';
@@ -118,6 +121,23 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/remote-activity/:featureId',
         builder: (context, state) => RemoteAttributionDetailScreen(
+          featureId: Uri.decodeComponent(state.pathParameters['featureId']!),
+        ),
+      ),
+      GoRoute(
+        path: '/resolve',
+        builder: (context, state) => const ConflictReviewListScreen(),
+      ),
+      GoRoute(
+        path: '/resolve/attribution/:submissionId',
+        builder: (context, state) => AttributionConflictScreen(
+          submissionId:
+              Uri.decodeComponent(state.pathParameters['submissionId']!),
+        ),
+      ),
+      GoRoute(
+        path: '/resolve/dedup/:featureId',
+        builder: (context, state) => DedupReviewScreen(
           featureId: Uri.decodeComponent(state.pathParameters['featureId']!),
         ),
       ),

--- a/lib/core/sync/data/fake_sync_api.dart
+++ b/lib/core/sync/data/fake_sync_api.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:firecheck/core/db/database.dart';
 import 'package:firecheck/core/sync/data/sync_api.dart';
+import 'package:firecheck/core/sync/domain/resolution_decision.dart';
+import 'package:firecheck/core/sync/domain/submit_attribution_result.dart';
 import 'package:firecheck/core/sync/domain/sync_outcome.dart';
 
 /// Test double whose responses are seeded by the test. Each method consumes
@@ -72,5 +74,112 @@ class FakeSyncApi implements SyncApi {
   ) async {
     uploadFeatureGeometryUpdateCalls.add(revision);
     return _next(_featureGeometryUpdateResponses);
+  }
+
+  // -------- Conflict-aware upload + resolution -------------------------
+
+  final List<
+      ({SyncOutcome outcome, SubmitAttributionResult? result})>
+      _submitAttributionResponses = [];
+  final List<
+      ({SyncOutcome outcome, SubmitNewFeatureResult? result})>
+      _submitNewFeatureResponses = [];
+  final List<SyncOutcome> _resolveAttributionResponses = [];
+  final List<SyncOutcome> _resolveNewFeatureResponses = [];
+
+  final List<({Map<String, dynamic> payload, String? baseVersionId})>
+      submitAttributionCalls = [];
+  final List<Map<String, dynamic>> submitNewFeatureCalls = [];
+  final List<({String pendingId, AttributionDecision decision, String? note})>
+      resolveAttributionCalls = [];
+  final List<({String pendingId, DedupDecision decision, String? note})>
+      resolveNewFeatureCalls = [];
+
+  void enqueueSubmitAttribution({
+    SyncOutcome outcome = const Success(),
+    SubmitAttributionResult? result,
+  }) {
+    _submitAttributionResponses.add((outcome: outcome, result: result));
+  }
+
+  void enqueueSubmitNewFeature({
+    SyncOutcome outcome = const Success(),
+    SubmitNewFeatureResult? result,
+  }) {
+    _submitNewFeatureResponses.add((outcome: outcome, result: result));
+  }
+
+  void enqueueResolveAttribution(SyncOutcome o) =>
+      _resolveAttributionResponses.add(o);
+  void enqueueResolveNewFeature(SyncOutcome o) =>
+      _resolveNewFeatureResponses.add(o);
+
+  @override
+  Future<({SyncOutcome outcome, SubmitAttributionResult? result})>
+      submitAttribution({
+    required Map<String, dynamic> payload,
+    String? baseVersionId,
+  }) async {
+    submitAttributionCalls
+        .add((payload: payload, baseVersionId: baseVersionId));
+    String defaultId() =>
+        (payload['submission'] as Map<String, dynamic>)['id'] as String;
+
+    if (_submitAttributionResponses.isEmpty) {
+      // Default: committed with the payload's submission id.
+      return (
+        outcome: const Success(),
+        result: AttributionCommitted(defaultId()),
+      );
+    }
+    final next = _submitAttributionResponses.removeAt(0);
+    if (next.outcome is Success && next.result == null) {
+      // Enqueued shorthand: a bare Success with no explicit result still
+      // means "committed with the payload's id".
+      return (
+        outcome: next.outcome,
+        result: AttributionCommitted(defaultId()),
+      );
+    }
+    return next;
+  }
+
+  @override
+  Future<({SyncOutcome outcome, SubmitNewFeatureResult? result})>
+      submitNewFeatureWithDedup(Map<String, dynamic> payload) async {
+    submitNewFeatureCalls.add(payload);
+    if (_submitNewFeatureResponses.isEmpty) {
+      final id = payload['id'] as String;
+      return (outcome: const Success(), result: NewFeatureCommitted(id));
+    }
+    return _submitNewFeatureResponses.removeAt(0);
+  }
+
+  @override
+  Future<SyncOutcome> resolveAttribution({
+    required String pendingId,
+    required AttributionDecision decision,
+    String? resolutionNote,
+  }) async {
+    resolveAttributionCalls.add((
+      pendingId: pendingId,
+      decision: decision,
+      note: resolutionNote,
+    ));
+    return _next(_resolveAttributionResponses);
+  }
+
+  @override
+  Future<SyncOutcome> resolveNewFeature({
+    required String pendingId,
+    required DedupDecision decision,
+    String? resolutionNote,
+  }) async {
+    resolveNewFeatureCalls.add((
+      pendingId: pendingId,
+      decision: decision,
+      note: resolutionNote,
+    ));
+    return _next(_resolveNewFeatureResponses);
   }
 }

--- a/lib/core/sync/data/remote_attributions_pull_service.dart
+++ b/lib/core/sync/data/remote_attributions_pull_service.dart
@@ -13,8 +13,7 @@ import 'package:flutter/foundation.dart';
 ///                              disappear correctly.
 ///
 /// Both paths feed the same upsert in `RemoteAttributionsCacheRepository`, so
-/// merge semantics are identical (and identical to the realtime path added in
-/// phase 3).
+/// merge semantics are identical (and identical to the realtime path).
 ///
 /// Stale-cache rule: if the cursor is older than `staleAge` (default 24h) we
 /// force a full pull rather than a delta, matching the spec's "Cache

--- a/lib/core/sync/data/supabase_sync_api.dart
+++ b/lib/core/sync/data/supabase_sync_api.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:firecheck/core/db/database.dart';
 import 'package:firecheck/core/sync/data/sync_api.dart';
+import 'package:firecheck/core/sync/domain/resolution_decision.dart';
+import 'package:firecheck/core/sync/domain/submit_attribution_result.dart';
 import 'package:firecheck/core/sync/domain/sync_outcome.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' hide AuthState;
 
@@ -158,5 +160,151 @@ class SupabaseSyncApi implements SyncApi {
     if (code == '401') return const AuthExpired();
     if (code.startsWith('4')) return PermanentFailure('$code ${e.message}');
     return TransientFailure('$code ${e.message}');
+  }
+
+  // -------- Conflict-aware upload + resolution -------------------------
+
+  @override
+  Future<({SyncOutcome outcome, SubmitAttributionResult? result})>
+      submitAttribution({
+    required Map<String, dynamic> payload,
+    String? baseVersionId,
+  }) async {
+    // The RPC expects base_version_id INSIDE the payload jsonb; tucking it
+    // in here keeps the existing payload-builder unaware of conflict
+    // semantics.
+    final wrapped = Map<String, dynamic>.from(payload);
+    if (baseVersionId != null) {
+      wrapped['base_version_id'] = baseVersionId;
+    }
+    try {
+      final raw = await _client.rpc<dynamic>(
+        'submit_attribution_with_conflict_check',
+        params: {'payload': wrapped},
+      );
+      final result = _parseAttributionResult(raw);
+      if (result == null) {
+        return (
+          outcome: PermanentFailure('unexpected_response: $raw'),
+          result: null,
+        );
+      }
+      return (outcome: const Success(), result: result);
+    } on PostgrestException catch (e) {
+      return (outcome: _mapPostgrestException(e, payload), result: null);
+    } on AuthException {
+      return (outcome: const AuthExpired(), result: null);
+    } on Object catch (e) {
+      return (outcome: TransientFailure(e.toString()), result: null);
+    }
+  }
+
+  @override
+  Future<({SyncOutcome outcome, SubmitNewFeatureResult? result})>
+      submitNewFeatureWithDedup(Map<String, dynamic> payload) async {
+    try {
+      final raw = await _client.rpc<dynamic>(
+        'submit_new_feature_with_dedup_check',
+        params: {'payload': payload},
+      );
+      final result = _parseNewFeatureResult(raw);
+      if (result == null) {
+        return (
+          outcome: PermanentFailure('unexpected_response: $raw'),
+          result: null,
+        );
+      }
+      return (outcome: const Success(), result: result);
+    } on PostgrestException catch (e) {
+      return (outcome: _mapPostgrestException(e, null), result: null);
+    } on AuthException {
+      return (outcome: const AuthExpired(), result: null);
+    } on Object catch (e) {
+      return (outcome: TransientFailure(e.toString()), result: null);
+    }
+  }
+
+  @override
+  Future<SyncOutcome> resolveAttribution({
+    required String pendingId,
+    required AttributionDecision decision,
+    String? resolutionNote,
+  }) async {
+    try {
+      await _client.rpc<dynamic>(
+        'resolve_attribution',
+        params: {
+          'pending_id': pendingId,
+          'decision': decision.wire,
+          'resolution_note': resolutionNote,
+        },
+      );
+      return const Success();
+    } on PostgrestException catch (e) {
+      return _mapPostgrestException(e, null);
+    } on AuthException {
+      return const AuthExpired();
+    } on Object catch (e) {
+      return TransientFailure(e.toString());
+    }
+  }
+
+  @override
+  Future<SyncOutcome> resolveNewFeature({
+    required String pendingId,
+    required DedupDecision decision,
+    String? resolutionNote,
+  }) async {
+    try {
+      await _client.rpc<dynamic>(
+        'resolve_new_feature',
+        params: {
+          'pending_id': pendingId,
+          'decision': decision.wire,
+          'resolution_note': resolutionNote,
+        },
+      );
+      return const Success();
+    } on PostgrestException catch (e) {
+      return _mapPostgrestException(e, null);
+    } on AuthException {
+      return const AuthExpired();
+    } on Object catch (e) {
+      return TransientFailure(e.toString());
+    }
+  }
+
+  SubmitAttributionResult? _parseAttributionResult(Object? raw) {
+    if (raw is! Map) return null;
+    final status = raw['status'];
+    switch (status) {
+      case 'committed':
+        return AttributionCommitted(raw['submission_id'] as String);
+      case 'agreed_skip':
+        return AttributionAgreedSkip(raw['submission_id'] as String);
+      case 'conflict':
+        return AttributionConflict(
+          pendingId: raw['pending_id'] as String,
+          theirSubmissionId: raw['their_submission_id'] as String,
+        );
+      default:
+        return null;
+    }
+  }
+
+  SubmitNewFeatureResult? _parseNewFeatureResult(Object? raw) {
+    if (raw is! Map) return null;
+    final status = raw['status'];
+    switch (status) {
+      case 'committed':
+        return NewFeatureCommitted(raw['feature_id'] as String);
+      case 'dedup_pending':
+        return NewFeatureDedupPending(
+          pendingId: raw['pending_id'] as String,
+          possibleDuplicateOf: raw['possible_duplicate_of'] as String,
+        );
+      default:
+        return null;
+    }
   }
 }

--- a/lib/core/sync/data/sync_api.dart
+++ b/lib/core/sync/data/sync_api.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
 import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/domain/resolution_decision.dart';
+import 'package:firecheck/core/sync/domain/submit_attribution_result.dart';
 import 'package:firecheck/core/sync/domain/sync_outcome.dart';
 
 /// Network surface area required by SyncWorker. Real impl in
@@ -24,4 +26,35 @@ abstract class SyncApi {
   Future<SyncOutcome> uploadNewFeature(Feature feature);
 
   Future<SyncOutcome> uploadFeatureGeometryUpdate(FeatureGeometryRevision revision);
+
+  // -------- Conflict-aware upload + resolution -------------------------
+
+  /// Calls `submit_attribution_with_conflict_check`. Returns a structured
+  /// result the worker can pattern-match on. Network / auth / closed-
+  /// assignment errors come through `outcome`; structured results come
+  /// through `result` (non-null when `outcome` is `Success`).
+  Future<({SyncOutcome outcome, SubmitAttributionResult? result})>
+      submitAttribution({
+    required Map<String, dynamic> payload,
+    String? baseVersionId,
+  });
+
+  /// Calls `submit_new_feature_with_dedup_check`. Same shape as
+  /// `submitAttribution`.
+  Future<({SyncOutcome outcome, SubmitNewFeatureResult? result})>
+      submitNewFeatureWithDedup(Map<String, dynamic> payload);
+
+  /// Calls `resolve_attribution(pending_id, decision, resolution_note?)`.
+  Future<SyncOutcome> resolveAttribution({
+    required String pendingId,
+    required AttributionDecision decision,
+    String? resolutionNote,
+  });
+
+  /// Calls `resolve_new_feature(pending_id, decision, resolution_note?)`.
+  Future<SyncOutcome> resolveNewFeature({
+    required String pendingId,
+    required DedupDecision decision,
+    String? resolutionNote,
+  });
 }

--- a/lib/core/sync/data/sync_jobs_repository.dart
+++ b/lib/core/sync/data/sync_jobs_repository.dart
@@ -1,6 +1,5 @@
 import 'package:drift/drift.dart';
 import 'package:firecheck/core/db/database.dart';
-import 'package:firecheck/core/sync/domain/sync_entity_type.dart';
 import 'package:firecheck/core/sync/domain/sync_job_status.dart';
 
 class SyncJobsRepository {
@@ -15,6 +14,18 @@ class SyncJobsRepository {
   Future<List<SyncJob>> claimUpToN(int n, {DateTime? now}) async {
     final cutoff = now ?? DateTime.now();
     return _db.transaction(() async {
+      // Gate two interlocking conditions:
+      //   1. Photo jobs that block on a submission wait for the local
+      //      submission row to reach sync_status='uploaded' — that's the
+      //      same terminal state for both the legacy `submission` path
+      //      and the new `attribution_upload` path, so this gate is
+      //      type-agnostic.
+      //   2. Attribution upload jobs whose feature is new wait for the
+      //      corresponding new-feature upload job to reach `success`.
+      //      Otherwise the submission's feature_id FK fails on the
+      //      server. Both legacy (`submission` / `new_feature`) and new
+      //      (`attribution_upload` / `new_feature_upload`) variants are
+      //      accepted on either side.
       final raw = await _db.customSelect(
         '''
         SELECT j.* FROM sync_jobs j
@@ -27,11 +38,8 @@ class SyncJobsRepository {
               WHERE s.id = j.blocks_on_submission_id AND s.sync_status = 'uploaded'
             )
           )
-          -- Gate: a submission job whose feature is_new=true must wait for the
-          -- corresponding new_feature job to reach success. Otherwise the
-          -- submission's feature_id FK fails on the server.
           AND NOT (
-            j.entity_type = 'submission'
+            j.entity_type IN ('submission','attribution_upload')
             AND EXISTS (
               SELECT 1 FROM submissions s2
               JOIN features f2 ON f2.id = s2.feature_id
@@ -39,7 +47,7 @@ class SyncJobsRepository {
                 AND f2.is_new = 1
                 AND NOT EXISTS (
                   SELECT 1 FROM sync_jobs nf
-                  WHERE nf.entity_type = 'new_feature'
+                  WHERE nf.entity_type IN ('new_feature','new_feature_upload')
                     AND nf.entity_id = f2.id
                     AND nf.status = 'success'
                 )
@@ -47,9 +55,11 @@ class SyncJobsRepository {
           )
         ORDER BY (
           CASE j.entity_type
-            WHEN 'new_feature' THEN 0
-            WHEN ?           THEN 1
-            ELSE                  2
+            WHEN 'new_feature'         THEN 0
+            WHEN 'new_feature_upload'  THEN 0
+            WHEN 'submission'          THEN 1
+            WHEN 'attribution_upload'  THEN 1
+            ELSE                            2
           END
         ), j.created_at
         LIMIT ?
@@ -57,7 +67,6 @@ class SyncJobsRepository {
         variables: [
           Variable.withString(SyncJobStatus.pending),
           Variable.withDateTime(cutoff),
-          Variable.withString(SyncEntityType.submission),
           Variable.withInt(n),
         ],
         readsFrom: {_db.syncJobs, _db.submissions, _db.features},

--- a/lib/core/sync/domain/finalize_submission.dart
+++ b/lib/core/sync/domain/finalize_submission.dart
@@ -29,13 +29,18 @@ class FinalizeSubmissionUseCase {
         updatedAt: Value(DateTime.now()),
       ),);
 
-      // 2. Submission sync_job (skip-if-exists)
-      final existingSub =
+      // 2. Submission sync_job (skip-if-exists). Routes through the
+      // conflict-aware RPC. A stale enqueue under the legacy
+      // `submission` type is also treated as "already queued" so we
+      // don't double-upload mid-rollout.
+      final existingNew =
+          await _findJob(SyncEntityType.attributionUpload, submissionId);
+      final existingLegacy =
           await _findJob(SyncEntityType.submission, submissionId);
-      if (existingSub == null) {
+      if (existingNew == null && existingLegacy == null) {
         await _db.into(_db.syncJobs).insert(SyncJobsCompanion.insert(
               id: _uuid.v4(),
-              entityType: SyncEntityType.submission,
+              entityType: SyncEntityType.attributionUpload,
               entityId: submissionId,
               createdAt: DateTime.now(),
             ),);
@@ -59,7 +64,8 @@ class FinalizeSubmissionUseCase {
         photoCount++;
       }
 
-      // 4. New-feature sync_job if applicable (skip-if-exists)
+      // 4. New-feature sync_job if applicable (skip-if-exists). Routes
+      // through the dedup-aware RPC; legacy entry tolerated.
       final submission = await (_db.select(_db.submissions)
             ..where((t) => t.id.equals(submissionId)))
           .getSingle();
@@ -68,12 +74,14 @@ class FinalizeSubmissionUseCase {
           .getSingle();
       var newFeatureQueued = false;
       if (feature.isNew) {
-        final existing =
+        final existingNew =
+            await _findJob(SyncEntityType.newFeatureUpload, feature.id);
+        final existingLegacy =
             await _findJob(SyncEntityType.newFeature, feature.id);
-        if (existing == null) {
+        if (existingNew == null && existingLegacy == null) {
           await _db.into(_db.syncJobs).insert(SyncJobsCompanion.insert(
                 id: _uuid.v4(),
-                entityType: SyncEntityType.newFeature,
+                entityType: SyncEntityType.newFeatureUpload,
                 entityId: feature.id,
                 createdAt: DateTime.now(),
               ),);

--- a/lib/core/sync/domain/resolution_decision.dart
+++ b/lib/core/sync/domain/resolution_decision.dart
@@ -1,0 +1,28 @@
+/// Decisions the user can pick at the conflict review screen.
+/// Maps to `resolve_attribution(decision text)` on the server.
+enum AttributionDecision {
+  /// Drop the local pending row; the prior canonical (theirs) wins.
+  keepTheirs('keep_theirs'),
+
+  /// Supersede the prior canonical with the local row; audit it.
+  forceOverwrite('force_overwrite');
+
+  const AttributionDecision(this.wire);
+  final String wire;
+}
+
+/// Decisions the user can pick at the new-feature dedup review screen.
+/// Maps to `resolve_new_feature(decision text)` on the server.
+enum DedupDecision {
+  /// Both rows coexist as separate features. Just mark them reviewed.
+  keepBoth('keep_both'),
+
+  /// Supersede the older feature with this one; audit.
+  replaceTheirs('replace_theirs'),
+
+  /// Soft-delete the local pending feature; audit.
+  discardMine('discard_mine');
+
+  const DedupDecision(this.wire);
+  final String wire;
+}

--- a/lib/core/sync/domain/submission_sync_status.dart
+++ b/lib/core/sync/domain/submission_sync_status.dart
@@ -1,0 +1,22 @@
+/// String constants used in `submissions.sync_status` (Drift + Supabase).
+///
+/// Lifecycle:
+///   draft (form open / partial) → queued (Finish tapped) → uploaded
+///                                                       ↘ awaitingUserResolution (conflict)
+///                                                             ↘ uploaded (force_overwrite)
+///                                                             ↘ withdrawn (keep_theirs / discard_mine)
+class SubmissionSyncStatus {
+  SubmissionSyncStatus._();
+  static const draft = 'draft';
+  static const inProgress = 'in_progress';
+  static const queued = 'queued';
+  static const uploaded = 'uploaded';
+
+  /// Server returned `conflict` or `dedup_pending` for this submission;
+  /// the row sits parked until the user picks a side in the review UI.
+  static const awaitingUserResolution = 'awaiting_user_resolution';
+
+  /// User chose "keep theirs" / "discard mine" — the local row is
+  /// effectively cancelled. Kept for audit; never re-uploaded.
+  static const withdrawn = 'withdrawn';
+}

--- a/lib/core/sync/domain/submit_attribution_result.dart
+++ b/lib/core/sync/domain/submit_attribution_result.dart
@@ -1,0 +1,51 @@
+/// Server's response to `submit_attribution_with_conflict_check`,
+/// translated into a sealed Dart type so the sync worker can pattern-match
+/// without sniffing string keys.
+sealed class SubmitAttributionResult {
+  const SubmitAttributionResult();
+}
+
+/// The server accepted the submission as canonical. No prior canonical
+/// existed, OR the user explicitly knew about it (`base_version_id`).
+class AttributionCommitted extends SubmitAttributionResult {
+  const AttributionCommitted(this.submissionId);
+  final String submissionId;
+}
+
+/// The server already has a canonical row with identical typed values;
+/// the upload was a no-op. The local row should be marked withdrawn.
+class AttributionAgreedSkip extends SubmitAttributionResult {
+  const AttributionAgreedSkip(this.canonicalSubmissionId);
+  final String canonicalSubmissionId;
+}
+
+/// A real value conflict — both rows now exist on the server, with the
+/// new one *not* superseding the old. The user must pick a side via the
+/// review UI.
+class AttributionConflict extends SubmitAttributionResult {
+  const AttributionConflict({
+    required this.pendingId,
+    required this.theirSubmissionId,
+  });
+  final String pendingId;
+  final String theirSubmissionId;
+}
+
+/// Server's response to `submit_new_feature_with_dedup_check`.
+sealed class SubmitNewFeatureResult {
+  const SubmitNewFeatureResult();
+}
+
+class NewFeatureCommitted extends SubmitNewFeatureResult {
+  const NewFeatureCommitted(this.featureId);
+  final String featureId;
+}
+
+class NewFeatureDedupPending extends SubmitNewFeatureResult {
+  const NewFeatureDedupPending({
+    required this.pendingId,
+    required this.possibleDuplicateOf,
+  });
+  final String pendingId;
+  final String possibleDuplicateOf;
+}

--- a/lib/core/sync/domain/sync_entity_type.dart
+++ b/lib/core/sync/domain/sync_entity_type.dart
@@ -1,8 +1,24 @@
 /// String constants used in sync_jobs.entity_type.
+///
+/// The conflict/dedup-aware types route through their respective RPCs:
+///   - attributionUpload     → submit_attribution_with_conflict_check
+///   - attributionResolve    → resolve_attribution
+///   - newFeatureUpload      → submit_new_feature_with_dedup_check
+///   - newFeatureResolve     → resolve_new_feature
+///
+/// The legacy [submission] and [newFeature] types remain (and still work)
+/// for one release as a fallback. New submissions enqueue under the new
+/// types; the legacy code paths will be removed in a follow-up release.
 class SyncEntityType {
   SyncEntityType._();
   static const submission = 'submission';
   static const photo = 'photo';
   static const newFeature = 'new_feature';
   static const featureGeometryUpdate = 'feature_geometry_update';
+
+  // Multi-user attribution sync types.
+  static const attributionUpload = 'attribution_upload';
+  static const attributionResolve = 'attribution_resolve';
+  static const newFeatureUpload = 'new_feature_upload';
+  static const newFeatureResolve = 'new_feature_resolve';
 }

--- a/lib/core/sync/worker/realtime_sync_controller.dart
+++ b/lib/core/sync/worker/realtime_sync_controller.dart
@@ -7,13 +7,11 @@ import 'package:firecheck/core/sync/data/remote_attributions_pull_service.dart';
 import 'package:firecheck/core/sync/domain/realtime_connection_state.dart';
 import 'package:flutter/foundation.dart';
 
-/// Phase 3 of multi-user attribution sync.
-///
 /// Owns the `offline → reconnecting → online → backgrounded → offline`
 /// state machine and the realtime subscription that drives it. Realtime
 /// events trigger a debounced delta pull through [RemoteAttributionsPullService]
 /// so cache writes go through the same upsert path as cold-open and
-/// reconnect pulls (the spec's `cacheUpsertFromServerRows` invariant).
+/// reconnect pulls (the `cacheUpsertFromServerRows` invariant).
 ///
 /// The controller deliberately does **not** parse realtime payloads — the
 /// Supabase realtime row for `public.submissions` doesn't include the
@@ -24,8 +22,8 @@ import 'package:flutter/foundation.dart';
 /// hundred ms of latency for one well-tested code path.
 ///
 /// The controller does **not** itself run the cold-open full pull — that
-/// happens via the phase-2 `RemoteCacheController`. Phase 3 layers
-/// realtime on top of the existing pull infrastructure.
+/// happens via [RemoteCacheController]. This controller layers realtime
+/// on top of the existing pull infrastructure.
 class RealtimeSyncController {
   RealtimeSyncController({
     required RealtimeSubscriber subscriber,

--- a/lib/core/sync/worker/realtime_wiring.dart
+++ b/lib/core/sync/worker/realtime_wiring.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 /// Glue between platform inputs (connectivity, app lifecycle) and the
 /// [RealtimeSyncController]'s state-machine entry points.
 ///
-/// Phase 2's `ConnectivityListener` / `SyncLifecycleListener` fire only on
+/// The existing `ConnectivityListener` / `SyncLifecycleListener` fire only on
 /// the "good" transition (connect / resume). The realtime state machine
 /// also needs the inverse transitions (disconnect / background) so we
 /// can drop the channel correctly. Rather than widen the existing

--- a/lib/core/sync/worker/remote_cache_controller.dart
+++ b/lib/core/sync/worker/remote_cache_controller.dart
@@ -7,15 +7,14 @@ import 'package:firecheck/core/sync/worker/connectivity_listener.dart';
 import 'package:firecheck/core/sync/worker/lifecycle_listener.dart';
 import 'package:flutter/foundation.dart';
 
-/// Phase 2 controller: drives the non-realtime pull paths for the remote
-/// attribution cache.
+/// Drives the non-realtime pull paths for the remote attribution cache.
 ///
 ///   - On `start()` (cold-open of an assignment): full pull.
 ///   - On connectivity restore: delta pull (falls back to full if stale).
 ///   - On app resume: delta pull.
 ///
-/// Phase 3 will add a `RemoteRealtimeController` alongside this; the two
-/// share the same cache so order doesn't matter — the upsert is idempotent.
+/// Runs alongside `RealtimeSyncController`; the two share the same cache
+/// so order doesn't matter — the upsert is idempotent.
 class RemoteCacheController {
   RemoteCacheController({
     required RemoteAttributionsPullService pullService,

--- a/lib/core/sync/worker/sync_worker.dart
+++ b/lib/core/sync/worker/sync_worker.dart
@@ -5,7 +5,10 @@ import 'package:firecheck/core/db/database.dart';
 import 'package:firecheck/core/sync/data/submission_payload_builder.dart';
 import 'package:firecheck/core/sync/data/sync_api.dart';
 import 'package:firecheck/core/sync/data/sync_jobs_repository.dart';
+import 'package:firecheck/core/sync/domain/resolution_decision.dart';
 import 'package:firecheck/core/sync/domain/retry_schedule.dart';
+import 'package:firecheck/core/sync/domain/submission_sync_status.dart';
+import 'package:firecheck/core/sync/domain/submit_attribution_result.dart';
 import 'package:firecheck/core/sync/domain/sync_entity_type.dart';
 import 'package:firecheck/core/sync/domain/sync_outcome.dart';
 import 'package:firecheck/core/sync/failure/assignment_lock_repository.dart';
@@ -85,6 +88,14 @@ class SyncWorker {
           return await _executeNewFeature(job.entityId);
         case SyncEntityType.featureGeometryUpdate:
           return await _executeFeatureGeometryUpdate(job.entityId);
+        case SyncEntityType.attributionUpload:
+          return await _executeAttributionUpload(job.entityId);
+        case SyncEntityType.attributionResolve:
+          return await _executeAttributionResolve(job.entityId);
+        case SyncEntityType.newFeatureUpload:
+          return await _executeNewFeatureUpload(job.entityId);
+        case SyncEntityType.newFeatureResolve:
+          return await _executeNewFeatureResolve(job.entityId);
         default:
           return PermanentFailure('unknown entity_type: ${job.entityType}');
       }
@@ -155,6 +166,167 @@ class SyncWorker {
       await repo.markFailed(rev.id);
     }
     return outcome;
+  }
+
+  /// Calls `submit_attribution_with_conflict_check`. Routes the three
+  /// possible structured results to local state transitions:
+  ///   - committed     → submission marked uploaded (same as legacy path)
+  ///   - agreed_skip   → server already has identical canonical; local
+  ///                     row is effectively withdrawn (orphan cleanup
+  ///                     handled separately)
+  ///   - conflict      → submission parked in awaiting_user_resolution
+  ///                     with pendingTheirsId set; review UI takes over
+  Future<SyncOutcome> _executeAttributionUpload(String submissionId) async {
+    final sub = await (db.select(db.submissions)
+          ..where((t) => t.id.equals(submissionId)))
+        .getSingleOrNull();
+    if (sub == null) {
+      return const PermanentFailure('submission missing');
+    }
+    final json = await payload.build(submissionId);
+    final response = await api.submitAttribution(payload: json);
+    if (response.outcome is! Success) {
+      return response.outcome;
+    }
+    final result = response.result!;
+    switch (result) {
+      case AttributionCommitted():
+        await (db.update(db.submissions)
+              ..where((t) => t.id.equals(submissionId)))
+            .write(
+          const SubmissionsCompanion(
+            syncStatus: Value(SubmissionSyncStatus.uploaded),
+            pendingTheirsId: Value(null),
+          ),
+        );
+      case AttributionAgreedSkip():
+        // Server's canonical wins identical values; our row is a duplicate.
+        await (db.update(db.submissions)
+              ..where((t) => t.id.equals(submissionId)))
+            .write(
+          const SubmissionsCompanion(
+            syncStatus: Value(SubmissionSyncStatus.withdrawn),
+            pendingTheirsId: Value(null),
+          ),
+        );
+      case AttributionConflict(:final theirSubmissionId):
+        await (db.update(db.submissions)
+              ..where((t) => t.id.equals(submissionId)))
+            .write(
+          SubmissionsCompanion(
+            syncStatus: const Value(SubmissionSyncStatus.awaitingUserResolution),
+            pendingTheirsId: Value(theirSubmissionId),
+          ),
+        );
+    }
+    return const Success();
+  }
+
+  /// Calls `submit_new_feature_with_dedup_check`. dedup_pending leaves the
+  /// row visible (the proximity trigger has already inserted it) and the
+  /// review UI surfaces it; review then dispatches a
+  /// `newFeatureResolve` job.
+  Future<SyncOutcome> _executeNewFeatureUpload(String featureId) async {
+    final feature = await (db.select(db.features)
+          ..where((t) => t.id.equals(featureId)))
+        .getSingleOrNull();
+    if (feature == null) {
+      return const PermanentFailure('feature missing');
+    }
+    final payload = <String, dynamic>{
+      'id': feature.id,
+      'assignment_id': feature.assignmentId,
+      'feature_type': feature.featureType,
+      'geometry_geojson': feature.geometryGeojson,
+      'is_new': feature.isNew,
+      'created_at': feature.createdAt.toIso8601String(),
+    };
+    final response = await api.submitNewFeatureWithDedup(payload);
+    return response.outcome;
+  }
+
+  /// Reads the queued decision out of `pending_resolutions`, calls
+  /// `resolve_attribution`, then updates local sync_status + clears the
+  /// queued row.
+  Future<SyncOutcome> _executeAttributionResolve(String submissionId) async {
+    final res = await (db.select(db.pendingResolutions)
+          ..where((t) =>
+              t.targetId.equals(submissionId) & t.kind.equals('attribution'),))
+        .getSingleOrNull();
+    if (res == null) {
+      return const PermanentFailure('no queued resolution');
+    }
+    final decision = _attributionDecisionFromWire(res.decision);
+    if (decision == null) {
+      return PermanentFailure('invalid_decision: ${res.decision}');
+    }
+    final outcome = await api.resolveAttribution(
+      pendingId: submissionId,
+      decision: decision,
+      resolutionNote: res.resolutionNote,
+    );
+    if (outcome is! Success) return outcome;
+
+    await db.transaction(() async {
+      await (db.update(db.submissions)
+            ..where((t) => t.id.equals(submissionId)))
+          .write(
+        SubmissionsCompanion(
+          syncStatus: Value(
+            decision == AttributionDecision.forceOverwrite
+                ? SubmissionSyncStatus.uploaded
+                : SubmissionSyncStatus.withdrawn,
+          ),
+          pendingTheirsId: const Value(null),
+        ),
+      );
+      await (db.delete(db.pendingResolutions)
+            ..where((t) =>
+                t.targetId.equals(submissionId) &
+                t.kind.equals('attribution'),))
+          .go();
+    });
+    return const Success();
+  }
+
+  Future<SyncOutcome> _executeNewFeatureResolve(String featureId) async {
+    final res = await (db.select(db.pendingResolutions)
+          ..where((t) =>
+              t.targetId.equals(featureId) & t.kind.equals('new_feature'),))
+        .getSingleOrNull();
+    if (res == null) {
+      return const PermanentFailure('no queued resolution');
+    }
+    final decision = _dedupDecisionFromWire(res.decision);
+    if (decision == null) {
+      return PermanentFailure('invalid_decision: ${res.decision}');
+    }
+    final outcome = await api.resolveNewFeature(
+      pendingId: featureId,
+      decision: decision,
+      resolutionNote: res.resolutionNote,
+    );
+    if (outcome is! Success) return outcome;
+
+    await (db.delete(db.pendingResolutions)
+          ..where((t) =>
+              t.targetId.equals(featureId) & t.kind.equals('new_feature'),))
+        .go();
+    return const Success();
+  }
+
+  AttributionDecision? _attributionDecisionFromWire(String wire) {
+    for (final d in AttributionDecision.values) {
+      if (d.wire == wire) return d;
+    }
+    return null;
+  }
+
+  DedupDecision? _dedupDecisionFromWire(String wire) {
+    for (final d in DedupDecision.values) {
+      if (d.wire == wire) return d;
+    }
+    return null;
   }
 
   Future<void> _applyOutcome(SyncJob job, SyncOutcome outcome) async {
@@ -228,7 +400,7 @@ class SyncWorker {
       try {
         await bundle!.exportFor(assignmentId);
       } on Object {
-        // Bundle errors don't block lock state; surfaced in Phase 4b UI.
+        // Bundle errors don't block lock state; surfaced in the UI separately.
       }
     }
     // Job goes back to pending so a future drain (after lock clears) can retry.

--- a/lib/core/sync/worker/workmanager_dispatcher.dart
+++ b/lib/core/sync/worker/workmanager_dispatcher.dart
@@ -27,10 +27,10 @@ void callbackDispatcher() {
       // Background isolate uses the same on-disk Drift DB.
       final db = AppDatabase.forTesting(NativeDatabase.memory());
       // NOTE: in production, WorkManager isolate should open the same
-      // sqlite file the main isolate uses. For Phase 4a we ship with the
-      // simpler path — the periodic tick isn't load-bearing for correctness
-      // (connectivity + foreground triggers are). Production-grade isolate
-      // sharing lands as Phase 5 polish.
+      // sqlite file the main isolate uses. We ship with the simpler path —
+      // the periodic tick isn't load-bearing for correctness (connectivity
+      // + foreground triggers are). Production-grade isolate sharing is
+      // deferred polish.
       final api = SupabaseSyncApi(Supabase.instance.client);
       final worker = SyncWorker(
         api: api,

--- a/lib/features/assignment/data/offline_tile_pack_repository.dart
+++ b/lib/features/assignment/data/offline_tile_pack_repository.dart
@@ -51,8 +51,7 @@ class OfflineTilePackRepository {
   }
 
   Future<void> markError(String id, String message) {
-    // The current schema has no error-message column; log only for Phase 1.
-    // Phase 4 may add a column if surfaced to UI.
+    // The current schema has no error-message column; log only.
     return (_db.update(_db.offlineTilePacks)..where((t) => t.id.equals(id)))
         .write(const OfflineTilePacksCompanion(status: Value('error')));
   }

--- a/lib/features/assignment/domain/get_maps_state.dart
+++ b/lib/features/assignment/domain/get_maps_state.dart
@@ -30,7 +30,7 @@ class PickingAssignment extends GetMapsState {
 }
 
 /// Emitted immediately when the user taps "Download Selected", before any
-/// network calls, so the UI shows a spinner within one frame (US-20).
+/// network calls, so the UI shows a spinner within one frame.
 class PreparingDownload extends GetMapsState {
   const PreparingDownload();
   @override

--- a/lib/features/assignment/presentation/assignment_lock_state.dart
+++ b/lib/features/assignment/presentation/assignment_lock_state.dart
@@ -4,9 +4,8 @@ import 'package:flutter/foundation.dart';
 
 /// User-facing lock state for the current assignment.
 ///
-/// Closed-remotely overrides Submitted. (Phase 4b accepts that the
-/// closed_remotely flag may flip after a successful submit; the user is
-/// blocked regardless.)
+/// Closed-remotely overrides Submitted: the closed_remotely flag may flip
+/// after a successful submit, but the user is blocked regardless.
 sealed class AssignmentLockState {
   const AssignmentLockState();
 }

--- a/lib/features/assignment/presentation/assignment_providers.dart
+++ b/lib/features/assignment/presentation/assignment_providers.dart
@@ -185,7 +185,7 @@ class GetMapsNotifier extends StateNotifier<GetMapsState> {
     final s = state;
     if (s is! PickingAssignment) return;
 
-    // Show spinner immediately so the user sees feedback within one frame (US-20).
+    // Show spinner immediately so the user sees feedback within one frame.
     state = const PreparingDownload();
 
     final selected =

--- a/lib/features/conflict_review/data/conflict_review_repository.dart
+++ b/lib/features/conflict_review/data/conflict_review_repository.dart
@@ -1,0 +1,154 @@
+import 'package:drift/drift.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/domain/resolution_decision.dart';
+import 'package:firecheck/core/sync/domain/submission_sync_status.dart';
+import 'package:firecheck/core/sync/domain/sync_entity_type.dart';
+import 'package:firecheck/core/sync/domain/sync_job_status.dart';
+import 'package:uuid/uuid.dart';
+
+/// Stages a resolution decision: writes the chosen action into
+/// `pending_resolutions` and enqueues a `*_resolve` sync_job so the
+/// worker can call the corresponding RPC when online.
+class ConflictReviewRepository {
+  ConflictReviewRepository(this._db);
+  final AppDatabase _db;
+  static const _uuid = Uuid();
+
+  /// Streams local submissions parked in `awaiting_user_resolution`.
+  /// The review list watches this.
+  Stream<List<Submission>> watchAwaitingSubmissions() {
+    return (_db.select(_db.submissions)
+          ..where((t) => t.syncStatus
+              .equals(SubmissionSyncStatus.awaitingUserResolution))
+          ..orderBy([
+            (t) => OrderingTerm(
+                  expression: t.updatedAt,
+                  mode: OrderingMode.desc,
+                ),
+          ]))
+        .watch();
+  }
+
+  /// Streams local features parked in dedup review — i.e. the feature
+  /// row is `is_new = true` and the proximity trigger flagged a
+  /// possible duplicate, and the user hasn't reviewed yet.
+  ///
+  /// The local features table doesn't carry possible_duplicate_of /
+  /// dedup_reviewed_at (those are server columns). Instead we surface
+  /// pending dedup reviews via the queued sync_jobs:
+  /// `new_feature_upload` jobs in `failed`/`dead` status, OR via the
+  /// pending_resolutions queue if the user already picked.
+  ///
+  /// For phase 5 we expose the simpler "features that have a queued
+  /// `pending_resolutions` row of kind=new_feature" — that's the user-
+  /// pickable set.
+  Stream<List<PendingResolution>> watchPendingDedupResolutions() {
+    return (_db.select(_db.pendingResolutions)
+          ..where((t) => t.kind.equals('new_feature'))
+          ..orderBy([
+            (t) => OrderingTerm(
+                  expression: t.createdAt,
+                  mode: OrderingMode.desc,
+                ),
+          ]))
+        .watch();
+  }
+
+  /// Commits a user's chosen attribution decision. Writes the row to
+  /// `pending_resolutions` (so the worker has the decision when it
+  /// runs) and enqueues an `attribution_resolve` sync_job.
+  ///
+  /// Idempotent: re-running with the same submissionId overwrites the
+  /// queued decision (user changed their mind before the worker ran).
+  /// "Skip" is *not* this method — skip simply doesn't write anything.
+  Future<void> queueAttributionDecision({
+    required String submissionId,
+    required AttributionDecision decision,
+    String? resolutionNote,
+  }) async {
+    final now = DateTime.now();
+    await _db.transaction(() async {
+      await _db.into(_db.pendingResolutions).insertOnConflictUpdate(
+            PendingResolutionsCompanion(
+              targetId: Value(submissionId),
+              kind: const Value('attribution'),
+              decision: Value(decision.wire),
+              resolutionNote: Value(resolutionNote),
+              createdAt: Value(now),
+            ),
+          );
+      final existing = await (_db.select(_db.syncJobs)
+            ..where((t) =>
+                t.entityType.equals(SyncEntityType.attributionResolve) &
+                t.entityId.equals(submissionId),))
+          .getSingleOrNull();
+      if (existing == null) {
+        await _db.into(_db.syncJobs).insert(
+              SyncJobsCompanion.insert(
+                id: _uuid.v4(),
+                entityType: SyncEntityType.attributionResolve,
+                entityId: submissionId,
+                createdAt: now,
+              ),
+            );
+      } else {
+        // Wake the job back up if it had previously errored.
+        await (_db.update(_db.syncJobs)
+              ..where((t) => t.id.equals(existing.id)))
+            .write(
+          const SyncJobsCompanion(
+            status: Value(SyncJobStatus.pending),
+            attempts: Value(0),
+            lastError: Value(null),
+            nextRetryAt: Value(null),
+          ),
+        );
+      }
+    });
+  }
+
+  Future<void> queueDedupDecision({
+    required String featureId,
+    required DedupDecision decision,
+    String? resolutionNote,
+  }) async {
+    final now = DateTime.now();
+    await _db.transaction(() async {
+      await _db.into(_db.pendingResolutions).insertOnConflictUpdate(
+            PendingResolutionsCompanion(
+              targetId: Value(featureId),
+              kind: const Value('new_feature'),
+              decision: Value(decision.wire),
+              resolutionNote: Value(resolutionNote),
+              createdAt: Value(now),
+            ),
+          );
+      final existing = await (_db.select(_db.syncJobs)
+            ..where((t) =>
+                t.entityType.equals(SyncEntityType.newFeatureResolve) &
+                t.entityId.equals(featureId),))
+          .getSingleOrNull();
+      if (existing == null) {
+        await _db.into(_db.syncJobs).insert(
+              SyncJobsCompanion.insert(
+                id: _uuid.v4(),
+                entityType: SyncEntityType.newFeatureResolve,
+                entityId: featureId,
+                createdAt: now,
+              ),
+            );
+      } else {
+        await (_db.update(_db.syncJobs)
+              ..where((t) => t.id.equals(existing.id)))
+            .write(
+          const SyncJobsCompanion(
+            status: Value(SyncJobStatus.pending),
+            attempts: Value(0),
+            lastError: Value(null),
+            nextRetryAt: Value(null),
+          ),
+        );
+      }
+    });
+  }
+}

--- a/lib/features/conflict_review/domain/local_attribution_flatten.dart
+++ b/lib/features/conflict_review/domain/local_attribution_flatten.dart
@@ -1,0 +1,113 @@
+import 'dart:convert';
+
+import 'package:firecheck/core/db/database.dart';
+
+/// Loads a local [Submission] together with its typed child rows and
+/// returns a single label → value map shaped the same way as
+/// `flattenRemoteAttributionForDisplay`, so the side-by-side compare
+/// can diff matching keys.
+Future<Map<String, Object?>> flattenLocalAttributionForDisplay({
+  required AppDatabase db,
+  required String submissionId,
+}) async {
+  final sub = await (db.select(db.submissions)
+        ..where((t) => t.id.equals(submissionId)))
+      .getSingleOrNull();
+  if (sub == null) return const {};
+  final feature = await (db.select(db.features)
+        ..where((t) => t.id.equals(sub.featureId)))
+      .getSingleOrNull();
+
+  final out = <String, Object?>{};
+  if (sub.doesNotExist) out['Does not exist'] = true;
+  if (sub.remarks != null && sub.remarks!.isNotEmpty) {
+    out['Remarks'] = sub.remarks;
+  }
+
+  if (feature?.featureType == 'building') {
+    final b = await (db.select(db.buildingAttributes)
+          ..where((t) => t.submissionId.equals(submissionId)))
+        .getSingleOrNull();
+    if (b != null) {
+      out.addAll({
+        'CBMS ID': b.cbmsId,
+        'Building name': b.buildingName,
+        'RA 9514 type': b.ra9514Type,
+        'Storeys': b.storeys,
+        'Material': b.material,
+        if (b.costIsExact)
+          'Estimated cost': b.costAmount
+        else if (b.costEstimateRange != null)
+          'Cost range': b.costEstimateRange,
+        'Fire-fighting facilities': _decodeArray(b.fireFightingFacilitiesJson),
+        'Fire load': _decodeArray(b.fireLoadJson),
+      });
+    }
+    final h = await (db.select(db.householdSurveys)
+          ..where((t) => t.submissionId.equals(submissionId)))
+        .getSingleOrNull();
+    if (h != null) {
+      out['Homeowner acknowledged'] = h.homeownerAcknowledged;
+      out['Lebel ng kahinaan'] = h.lebelNgKahinaan;
+      if (h.safetySuggestions != null) {
+        out['Safety suggestions'] = h.safetySuggestions;
+      }
+    }
+  } else if (feature?.featureType == 'road') {
+    final r = await (db.select(db.roadAttributes)
+          ..where((t) => t.submissionId.equals(submissionId)))
+        .getSingleOrNull();
+    if (r != null) {
+      out.addAll({
+        'Road name': r.roadName,
+        'Is bridge': r.isBridge,
+        'Width (m)': r.widthMeters,
+        'Road features': _decodeArray(r.roadFeaturesJson),
+        if (r.othersDescription != null)
+          'Other description': r.othersDescription,
+      });
+    }
+  }
+
+  out.removeWhere((_, v) => v == null);
+  return out;
+}
+
+List<dynamic> _decodeArray(String? raw) {
+  if (raw == null || raw.isEmpty) return const [];
+  try {
+    final decoded = jsonDecode(raw);
+    return decoded is List ? decoded : const [];
+  } on Object {
+    return const [];
+  }
+}
+
+/// Compares two flattened attribution maps and returns the set of keys
+/// whose values differ. List comparisons are unordered (cookie-sorted).
+Set<String> diffAttributionKeys(
+  Map<String, Object?> mine,
+  Map<String, Object?> theirs,
+) {
+  final keys = {...mine.keys, ...theirs.keys};
+  final differ = <String>{};
+  for (final k in keys) {
+    if (!_attrEqual(mine[k], theirs[k])) differ.add(k);
+  }
+  return differ;
+}
+
+bool _attrEqual(Object? a, Object? b) {
+  if (identical(a, b)) return true;
+  if (a == null || b == null) return a == b;
+  if (a is List && b is List) {
+    if (a.length != b.length) return false;
+    final aa = [...a]..sort((x, y) => '$x'.compareTo('$y'));
+    final bb = [...b]..sort((x, y) => '$x'.compareTo('$y'));
+    for (var i = 0; i < aa.length; i++) {
+      if (!_attrEqual(aa[i], bb[i])) return false;
+    }
+    return true;
+  }
+  return a == b;
+}

--- a/lib/features/conflict_review/presentation/attribution_conflict_screen.dart
+++ b/lib/features/conflict_review/presentation/attribution_conflict_screen.dart
@@ -1,0 +1,159 @@
+import 'package:firecheck/core/sync/domain/resolution_decision.dart';
+import 'package:firecheck/features/conflict_review/domain/local_attribution_flatten.dart';
+import 'package:firecheck/features/conflict_review/presentation/conflict_review_providers.dart';
+import 'package:firecheck/features/conflict_review/presentation/side_by_side_compare.dart';
+import 'package:firecheck/features/remote_activity/domain/remote_attribution_flatten.dart';
+import 'package:firecheck/features/remote_activity/presentation/remote_activity_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Side-by-side compare for a single existing-feature conflict. Three
+/// actions:
+///   - Keep theirs   (primary) — withdraws our row, the prior canonical wins
+///   - Use mine               — supersedes their row via force_overwrite
+///   - Skip — decide later    — leaves the row parked
+class AttributionConflictScreen extends ConsumerStatefulWidget {
+  const AttributionConflictScreen({required this.submissionId, super.key});
+  final String submissionId;
+
+  @override
+  ConsumerState<AttributionConflictScreen> createState() =>
+      _AttributionConflictScreenState();
+}
+
+class _AttributionConflictScreenState
+    extends ConsumerState<AttributionConflictScreen> {
+  bool _busy = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final mineAsync = ref.watch(
+      localAttributionForSubmissionProvider(widget.submissionId),
+    );
+    final subsAsync = ref.watch(awaitingSubmissionsProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Conflict')),
+      body: subsAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+        data: (subs) {
+          final sub = subs.where((s) => s.id == widget.submissionId).firstOrNull;
+          if (sub == null) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(24),
+                child: Text(
+                  'This submission is no longer in conflict. '
+                  'It may have been resolved on another device.',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+          final theirsAsync = ref.watch(
+            remoteAttributionForFeatureProvider(sub.featureId),
+          );
+          return mineAsync.when(
+            loading: () =>
+                const Center(child: CircularProgressIndicator()),
+            error: (e, _) => Center(child: Text('Error: $e')),
+            data: (mine) => theirsAsync.when(
+              loading: () =>
+                  const Center(child: CircularProgressIndicator()),
+              error: (e, _) => Center(child: Text('Error: $e')),
+              data: (theirsView) {
+                if (theirsView == null) {
+                  return const Center(
+                    child: Padding(
+                      padding: EdgeInsets.all(24),
+                      child: Text(
+                        "Theirs is no longer available — the other "
+                        'enumerator may have withdrawn it. Tap "Use mine" '
+                        'to commit your version as-is.',
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  );
+                }
+                final theirs =
+                    flattenRemoteAttributionForDisplay(theirsView);
+                final differing = diffAttributionKeys(mine, theirs);
+                return ListView(
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  children: [
+                    SideBySideCompare(
+                      mine: mine,
+                      theirs: theirs,
+                      differingKeys: differing,
+                      mineLabel: 'Yours',
+                      theirsLabel: 'Theirs',
+                    ),
+                    const SizedBox(height: 16),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          FilledButton(
+                            key: const Key('conflict-review.keep-theirs'),
+                            onPressed: _busy
+                                ? null
+                                : () => _resolve(
+                                    AttributionDecision.keepTheirs),
+                            child: const Text('Keep theirs'),
+                          ),
+                          const SizedBox(height: 8),
+                          OutlinedButton(
+                            key: const Key('conflict-review.use-mine'),
+                            onPressed: _busy
+                                ? null
+                                : () => _resolve(
+                                    AttributionDecision.forceOverwrite),
+                            child: const Text('Use mine'),
+                          ),
+                          const SizedBox(height: 8),
+                          TextButton(
+                            key: const Key('conflict-review.skip'),
+                            onPressed:
+                                _busy ? null : () => context.pop(),
+                            child: const Text('Skip — decide later'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _resolve(AttributionDecision decision) async {
+    setState(() => _busy = true);
+    final repo = ref.read(conflictReviewRepositoryProvider);
+    try {
+      await repo.queueAttributionDecision(
+        submissionId: widget.submissionId,
+        decision: decision,
+      );
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            decision == AttributionDecision.keepTheirs
+                ? 'Keeping theirs. Will sync when online.'
+                : 'Overwriting with yours. Will sync when online.',
+          ),
+        ),
+      );
+      context.pop();
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+}

--- a/lib/features/conflict_review/presentation/conflict_banner.dart
+++ b/lib/features/conflict_review/presentation/conflict_banner.dart
@@ -1,0 +1,48 @@
+import 'package:firecheck/features/conflict_review/presentation/conflict_review_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Slim banner placed on the home screen: "N conflicts to resolve →".
+/// Hidden when count is zero. Tapping routes to the review list.
+class ConflictBanner extends ConsumerWidget {
+  const ConflictBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final count = ref.watch(awaitingResolutionCountProvider);
+    if (count == 0) return const SizedBox.shrink();
+
+    return Material(
+      key: const Key('conflict-banner'),
+      color: Colors.orange.shade50,
+      borderRadius: BorderRadius.circular(8),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(8),
+        onTap: () => context.push('/resolve'),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          child: Row(
+            children: [
+              Icon(Icons.warning_amber_rounded,
+                  color: Colors.orange.shade800),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  count == 1
+                      ? '1 conflict to resolve'
+                      : '$count conflicts to resolve',
+                  style: TextStyle(
+                    color: Colors.orange.shade900,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              Icon(Icons.chevron_right, color: Colors.orange.shade800),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/conflict_review/presentation/conflict_review_list_screen.dart
+++ b/lib/features/conflict_review/presentation/conflict_review_list_screen.dart
@@ -1,0 +1,151 @@
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/features/conflict_review/presentation/conflict_review_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Single list of items requiring user decisions: existing-feature value
+/// conflicts on top, new-feature dedup reviews below.
+class ConflictReviewListScreen extends ConsumerWidget {
+  const ConflictReviewListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final subsAsync = ref.watch(awaitingSubmissionsProvider);
+    final dedupAsync = ref.watch(pendingDedupProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Resolve conflicts')),
+      body: subsAsync.when(
+        loading: () =>
+            const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+        data: (subs) => dedupAsync.when(
+          loading: () =>
+              const Center(child: CircularProgressIndicator()),
+          error: (e, _) => Center(child: Text('Error: $e')),
+          data: (dedup) {
+            if (subs.isEmpty && dedup.isEmpty) {
+              return const _Empty();
+            }
+            return ListView(
+              key: const Key('conflict-review.list'),
+              children: [
+                if (subs.isNotEmpty)
+                  const _SectionHeader('Attribution conflicts'),
+                for (final s in subs) _SubmissionTile(submission: s),
+                if (dedup.isNotEmpty)
+                  const _SectionHeader('New-feature dedup'),
+                for (final r in dedup) _DedupTile(resolution: r),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _Empty extends StatelessWidget {
+  const _Empty();
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.check_circle_outline,
+                size: 56, color: Colors.green.shade400),
+            const SizedBox(height: 12),
+            const Text('Nothing to resolve.',
+                style: TextStyle(fontWeight: FontWeight.w600)),
+            const SizedBox(height: 4),
+            Text(
+              "You're caught up. Conflicts and dedup decisions will appear "
+              'here when the server flags them.',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Colors.grey.shade700),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.text);
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+      child: Text(
+        text,
+        style: TextStyle(
+          color: Colors.grey.shade700,
+          fontWeight: FontWeight.w700,
+          fontSize: 12,
+          letterSpacing: 0.4,
+        ),
+      ),
+    );
+  }
+}
+
+class _SubmissionTile extends StatelessWidget {
+  const _SubmissionTile({required this.submission});
+  final Submission submission;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      key: Key('conflict-review.submission.${submission.id}'),
+      leading: const CircleAvatar(
+        backgroundColor: Color(0xFFFFE0B2),
+        child: Icon(Icons.warning_amber_rounded, color: Color(0xFFB85A00)),
+      ),
+      title: Text('Submission ${_short(submission.id)}',
+          style: const TextStyle(fontWeight: FontWeight.w600)),
+      subtitle: Text(
+        'Feature ${_short(submission.featureId)} • conflict with '
+        '${_short(submission.pendingTheirsId ?? '?')}',
+      ),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () => context.push(
+        '/resolve/attribution/${Uri.encodeComponent(submission.id)}',
+      ),
+    );
+  }
+}
+
+class _DedupTile extends StatelessWidget {
+  const _DedupTile({required this.resolution});
+  final PendingResolution resolution;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      key: Key('conflict-review.dedup.${resolution.targetId}'),
+      leading: const CircleAvatar(
+        backgroundColor: Color(0xFFFFCDD2),
+        child: Icon(Icons.merge_type, color: Color(0xFFB71C1C)),
+      ),
+      title: Text('New feature ${_short(resolution.targetId)}',
+          style: const TextStyle(fontWeight: FontWeight.w600)),
+      subtitle: Text(
+        'Pending: ${resolution.decision} '
+        '${resolution.resolutionNote == null ? '' : '— ${resolution.resolutionNote}'}',
+      ),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () => context.push(
+        '/resolve/dedup/${Uri.encodeComponent(resolution.targetId)}',
+      ),
+    );
+  }
+}
+
+String _short(String s) => s.length <= 8 ? s : s.substring(0, 8);

--- a/lib/features/conflict_review/presentation/conflict_review_providers.dart
+++ b/lib/features/conflict_review/presentation/conflict_review_providers.dart
@@ -1,0 +1,49 @@
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/features/conflict_review/data/conflict_review_repository.dart';
+import 'package:firecheck/features/conflict_review/domain/local_attribution_flatten.dart';
+import 'package:firecheck/features/home/presentation/home_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final conflictReviewRepositoryProvider =
+    Provider<ConflictReviewRepository>((ref) {
+  return ConflictReviewRepository(ref.watch(appDatabaseProvider));
+});
+
+/// Stream of submissions parked in `awaiting_user_resolution`.
+final awaitingSubmissionsProvider = StreamProvider<List<Submission>>((ref) {
+  return ref
+      .watch(conflictReviewRepositoryProvider)
+      .watchAwaitingSubmissions();
+});
+
+/// Stream of pending dedup decisions (kind=new_feature in
+/// pending_resolutions). Tracks the user-pickable dedup set for now;
+/// fuller "all features with possible_duplicate_of set" wiring will
+/// follow once the local features table mirrors the server's dedup cols.
+final pendingDedupProvider =
+    StreamProvider<List<PendingResolution>>((ref) {
+  return ref
+      .watch(conflictReviewRepositoryProvider)
+      .watchPendingDedupResolutions();
+});
+
+/// Flattened local attribution for a given submission, refreshed when
+/// the submission or its typed child row changes (Drift's reactivity).
+final localAttributionForSubmissionProvider =
+    FutureProvider.family<Map<String, Object?>, String>(
+  (ref, submissionId) async {
+    final db = ref.watch(appDatabaseProvider);
+    return flattenLocalAttributionForDisplay(
+      db: db,
+      submissionId: submissionId,
+    );
+  },
+);
+
+/// Banner count for the home screen: how many local submissions are
+/// awaiting user action right now.
+final awaitingResolutionCountProvider = Provider<int>((ref) {
+  final subs = ref.watch(awaitingSubmissionsProvider).valueOrNull ?? const [];
+  final dedup = ref.watch(pendingDedupProvider).valueOrNull ?? const [];
+  return subs.length + dedup.length;
+});

--- a/lib/features/conflict_review/presentation/dedup_review_screen.dart
+++ b/lib/features/conflict_review/presentation/dedup_review_screen.dart
@@ -1,0 +1,99 @@
+import 'package:firecheck/core/sync/domain/resolution_decision.dart';
+import 'package:firecheck/features/conflict_review/presentation/conflict_review_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Review screen for a new-feature dedup decision. Three actions:
+///   - Keep both       — both rows coexist as separate features
+///   - Replace theirs  — supersede the older feature with this one
+///   - Discard mine    — soft-delete this new feature
+///
+/// A mini-map header showing both geometries is intentionally deferred —
+/// the spec calls for it but it requires Mapbox plumbing best done in a
+/// later visual-polish pass. The decision-making is functional as-is.
+class DedupReviewScreen extends ConsumerStatefulWidget {
+  const DedupReviewScreen({required this.featureId, super.key});
+  final String featureId;
+
+  @override
+  ConsumerState<DedupReviewScreen> createState() => _DedupReviewScreenState();
+}
+
+class _DedupReviewScreenState extends ConsumerState<DedupReviewScreen> {
+  bool _busy = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Possible duplicate')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const Text(
+            'A nearby feature of the same type was already added by '
+            'another enumerator. Pick how to resolve.',
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Feature ${_short(widget.featureId)}',
+            style: const TextStyle(fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 24),
+          FilledButton(
+            key: const Key('dedup-review.keep-both'),
+            onPressed: _busy
+                ? null
+                : () => _resolve(DedupDecision.keepBoth),
+            child: const Text('Keep both'),
+          ),
+          const SizedBox(height: 8),
+          OutlinedButton(
+            key: const Key('dedup-review.replace-theirs'),
+            onPressed: _busy
+                ? null
+                : () => _resolve(DedupDecision.replaceTheirs),
+            child: const Text('Replace theirs'),
+          ),
+          const SizedBox(height: 8),
+          OutlinedButton(
+            key: const Key('dedup-review.discard-mine'),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: Colors.red.shade700,
+            ),
+            onPressed: _busy
+                ? null
+                : () => _resolve(DedupDecision.discardMine),
+            child: const Text('Discard mine'),
+          ),
+          const SizedBox(height: 8),
+          TextButton(
+            key: const Key('dedup-review.skip'),
+            onPressed: _busy ? null : () => context.pop(),
+            child: const Text('Skip — decide later'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _resolve(DedupDecision decision) async {
+    setState(() => _busy = true);
+    final repo = ref.read(conflictReviewRepositoryProvider);
+    try {
+      await repo.queueDedupDecision(
+        featureId: widget.featureId,
+        decision: decision,
+      );
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Queued: ${decision.wire}')),
+      );
+      context.pop();
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  String _short(String s) => s.length <= 8 ? s : s.substring(0, 8);
+}

--- a/lib/features/conflict_review/presentation/side_by_side_compare.dart
+++ b/lib/features/conflict_review/presentation/side_by_side_compare.dart
@@ -1,0 +1,161 @@
+import 'package:firecheck/features/remote_activity/presentation/attribute_kv_table.dart';
+import 'package:flutter/material.dart';
+
+/// Two-column "Yours / Theirs" view with differing values highlighted in
+/// both panels. Used by:
+///   - the existing-feature conflict review screen, with action buttons
+///     wired by the parent;
+///   - the new-feature dedup compare (parent supplies a mini-map header).
+///
+/// "Hide identical fields" toggle defaults to ON when at least
+/// [hideThreshold] fields are identical, to keep cognitive load down on
+/// long forms.
+class SideBySideCompare extends StatefulWidget {
+  const SideBySideCompare({
+    required this.mine,
+    required this.theirs,
+    required this.differingKeys,
+    super.key,
+    this.mineLabel = 'Yours',
+    this.theirsLabel = 'Theirs',
+    this.hideThreshold = 5,
+  });
+
+  final Map<String, Object?> mine;
+  final Map<String, Object?> theirs;
+  final Set<String> differingKeys;
+  final String mineLabel;
+  final String theirsLabel;
+  final int hideThreshold;
+
+  @override
+  State<SideBySideCompare> createState() => _SideBySideCompareState();
+}
+
+class _SideBySideCompareState extends State<SideBySideCompare> {
+  bool? _hideIdentical;
+
+  @override
+  Widget build(BuildContext context) {
+    final allKeys = {...widget.mine.keys, ...widget.theirs.keys}.toList();
+    final identicalCount = allKeys.length - widget.differingKeys.length;
+    final defaultHide = identicalCount >= widget.hideThreshold;
+    final hide = _hideIdentical ?? defaultHide;
+
+    final visibleKeys = hide
+        ? allKeys.where(widget.differingKeys.contains).toList()
+        : allKeys;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding:
+              const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
+            children: [
+              _DiffSummaryChip(
+                differing: widget.differingKeys.length,
+                total: allKeys.length,
+              ),
+              const Spacer(),
+              if (identicalCount > 0)
+                TextButton.icon(
+                  key: const Key('conflict-review.hide-identical-toggle'),
+                  icon: Icon(hide ? Icons.visibility : Icons.visibility_off),
+                  label: Text(hide
+                      ? 'Show identical fields'
+                      : 'Hide identical fields'),
+                  onPressed: () =>
+                      setState(() => _hideIdentical = !hide),
+                ),
+            ],
+          ),
+        ),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: _Column(
+                title: widget.mineLabel,
+                values: _onlyKeys(widget.mine, visibleKeys),
+                highlightKeys: widget.differingKeys,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: _Column(
+                title: widget.theirsLabel,
+                values: _onlyKeys(widget.theirs, visibleKeys),
+                highlightKeys: widget.differingKeys,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Map<String, Object?> _onlyKeys(
+    Map<String, Object?> src,
+    List<String> keys,
+  ) {
+    return {for (final k in keys) k: src[k]};
+  }
+}
+
+class _Column extends StatelessWidget {
+  const _Column({
+    required this.title,
+    required this.values,
+    required this.highlightKeys,
+  });
+  final String title;
+  final Map<String, Object?> values;
+  final Set<String> highlightKeys;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 4),
+      child: AttributeKvTable(
+        title: title,
+        values: values,
+        highlightKeys: highlightKeys,
+      ),
+    );
+  }
+}
+
+class _DiffSummaryChip extends StatelessWidget {
+  const _DiffSummaryChip({required this.differing, required this.total});
+  final int differing;
+  final int total;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = differing == 0
+        ? 'Identical'
+        : '$differing of $total fields differ';
+    final color = differing == 0
+        ? Colors.green.shade100
+        : Colors.amber.shade100;
+    final fg =
+        differing == 0 ? Colors.green.shade900 : Colors.amber.shade900;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: fg,
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -4,6 +4,7 @@ import 'package:firecheck/core/sync/shapefile/export/export_validation_result.da
 import 'package:firecheck/features/assignment/presentation/assignment_lock_providers.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_lock_state.dart';
 import 'package:firecheck/features/assignment/presentation/submitted_banner.dart';
+import 'package:firecheck/features/conflict_review/presentation/conflict_banner.dart';
 import 'package:firecheck/features/home/data/shapefile_export_notifier.dart';
 import 'package:firecheck/features/home/domain/export_state.dart';
 import 'package:firecheck/features/home/presentation/home_providers.dart';
@@ -49,6 +50,8 @@ class HomeScreen extends ConsumerWidget {
           child: Column(
             children: [
               const UploadBanner(),
+              const SizedBox(height: 8),
+              const ConflictBanner(),
               const SizedBox(height: 8),
               if (lock is Submitted)
                 SubmittedBanner(submittedAt: lock.submittedAt)

--- a/lib/features/map/geometry_editor/presentation/geometry_editor_overlay.dart
+++ b/lib/features/map/geometry_editor/presentation/geometry_editor_overlay.dart
@@ -39,9 +39,9 @@ class GeometryEditorOverlay extends ConsumerWidget {
 
     // For closed shapes (polygons), draw an invisible body-drag area covering
     // the outer ring's bounding rect. Pan on this area translates the entire
-    // shape (US-11). It's drawn FIRST so vertex/midpoint handles render on
-    // top — Flutter hit-tests in reverse z-order, so the smaller handle hit
-    // areas win, and only pans on empty interior fall through to the body.
+    // shape. It's drawn FIRST so vertex/midpoint handles render on top —
+    // Flutter hit-tests in reverse z-order, so the smaller handle hit areas
+    // win, and only pans on empty interior fall through to the body.
     if (state.isClosed && state.workingRings.isNotEmpty) {
       final outer = state.workingRings[0];
       if (outer.length >= 3) {

--- a/lib/features/map/presentation/map_providers.dart
+++ b/lib/features/map/presentation/map_providers.dart
@@ -15,7 +15,7 @@ final currentFeaturesProvider = StreamProvider<List<Feature>>((ref) {
 });
 
 /// Defaults to the fake renderer for widget tests / early-build safety.
-/// main.dart overrides this with MapboxMapRenderer (T19).
+/// main.dart overrides this with MapboxMapRenderer.
 final mapRendererProvider = Provider<MapRenderer>((ref) {
   return FakeMapRenderer();
 });

--- a/lib/features/map/presentation/map_renderer.dart
+++ b/lib/features/map/presentation/map_renderer.dart
@@ -26,7 +26,7 @@ abstract class MapRenderer {
     void Function(double lat, double lng)? onMapTap,
     CameraTarget? cameraTarget,
     CameraTarget? initialCameraTarget,
-    // US-9 reshape additions:
+    // Reshape additions:
     void Function(Feature)? onPolygonLongPress,
     String? reshapeWorkingPolygonGeojson,
     String? reshapeInvalidEdgeGeojson,
@@ -166,8 +166,8 @@ class _IdentityProjection implements MapProjection {
 }
 
 // MapboxMapRenderer is exercised via FakeMapRenderer in widget tests and via
-// the manual happy path in plan Task 18. The Mapbox plugin does not render
-// in flutter_tester.
+// the manual happy path on device. The Mapbox plugin does not render in
+// flutter_tester.
 
 /// Real renderer backed by `mapbox_maps_flutter` 2.22. Renders an actual map
 /// with polygon annotation managers for features + boundary, a point
@@ -281,17 +281,16 @@ class _MapboxMapViewState extends State<_MapboxMapView> {
 
   String _fingerprintOf(Feature f) => '${f.geometryGeojson}|${f.status}';
 
-  // US-9: working-polygon overlay rendered while reshape mode is active.
+  // Working-polygon overlay rendered while reshape mode is active.
   PolygonAnnotation? _reshapeWorkingAnnotation;
 
-  // US-9: lat/lng <-> screen-px projection state. Refreshed on camera change
-  // so GeometryEditorOverlay can read it synchronously during finger drags.
+  // lat/lng <-> screen-px projection state. Refreshed on camera change so
+  // GeometryEditorOverlay can read it synchronously during finger drags.
   _MapboxProjection? _projection;
   Size? _viewportSize;
 
-  // US-9 T13: set to true when _onMapCreated runs before the first
-  // LayoutBuilder pass so we can defer projection init until the viewport
-  // size is known.
+  // Set to true when _onMapCreated runs before the first LayoutBuilder pass
+  // so we can defer projection init until the viewport size is known.
   bool _projectionReadyPending = false;
 
   @override
@@ -328,7 +327,7 @@ class _MapboxMapViewState extends State<_MapboxMapView> {
             zoom: initial?.zoom ?? 15,
           ),
           // Without an explicit styleUri the map renders a black background
-          // because no style is loaded. Streets v12 is the Phase 1 spec choice.
+          // because no style is loaded.
           styleUri: 'mapbox://styles/mapbox/streets-v12',
           onMapCreated: _onMapCreated,
           // mapbox_maps_flutter 2.22 exposes a single-tap callback via
@@ -481,7 +480,7 @@ class _MapboxMapViewState extends State<_MapboxMapView> {
 
     // Guarantee the screen has at least one zoom/center sample by the time
     // the user can interact. Without this, zoom-button taps in the first
-    // few frames bail out (no _displayZoom yet) — see US-13 spec §5.
+    // few frames bail out (no _displayZoom yet).
     final initialState = await map.getCameraState();
     widget.onCameraChanged?.call(
       initialState.zoom,
@@ -489,8 +488,8 @@ class _MapboxMapViewState extends State<_MapboxMapView> {
       initialState.center.coordinates.lng.toDouble(),
     );
 
-    // US-9: instantiate the projection now that the map is alive and run
-    // an initial refresh so GeometryEditorOverlay has correct screen-px math
+    // Instantiate the projection now that the map is alive and run an
+    // initial refresh so GeometryEditorOverlay has correct screen-px math
     // before the user's first drag.
     final projection = _MapboxProjection(map);
     _projection = projection;

--- a/lib/features/map/presentation/map_screen.dart
+++ b/lib/features/map/presentation/map_screen.dart
@@ -78,7 +78,7 @@ class _MapScreenState extends ConsumerState<MapScreen> {
     // Subscribe so the GPS stream is hot from mount, not first tap.
     ref.watch(currentPositionProvider);
 
-    // T22: lock-while-reshape — if the assignment locks while the user is
+    // Lock-while-reshape — if the assignment locks while the user is
     // mid-reshape, dirty edits are blocked behind a non-dismissable dialog
     // (Exit discards), and a clean session exits silently.
     final isLocked = ref.watch(isAssignmentLockedProvider);
@@ -160,9 +160,9 @@ class _MapScreenState extends ConsumerState<MapScreen> {
                 projection: _reshapeProjection!,
               ),
             ),
-          // Phase 4 — multi-user attribution sync: shows "👥 N edited by
-          // others" when the remote_attributions_cache has rows from other
-          // enumerators. Hidden when count is zero. Sits below the AppBar.
+          // Shows "👥 N edited by others" when the remote_attributions_cache
+          // has rows from other enumerators. Hidden when count is zero. Sits
+          // below the AppBar.
           if (!reshapeActive && !sketchActive)
             const Positioned(
               left: 12,
@@ -315,8 +315,8 @@ class _MapScreenState extends ConsumerState<MapScreen> {
     if (s.originalFeature == null || assignment == null) return;
 
     // validateBuildingPolygon enforces polygon rules (closure, orientation,
-    // self-intersection). Polyline reshape (US-10) doesn't have those rules;
-    // skip the check when the working geometry is open.
+    // self-intersection). Polyline reshape doesn't have those rules; skip
+    // the check when the working geometry is open.
     //
     // Boundary handling: when the user provided an override reason at
     // reshape entry (e.g. they're editing a building from far away), also

--- a/lib/features/remote_activity/presentation/remote_activity_providers.dart
+++ b/lib/features/remote_activity/presentation/remote_activity_providers.dart
@@ -40,8 +40,8 @@ final othersRemoteAttributionsProvider =
 });
 
 /// Convenience: the canonical remote attribution (if any) for a given
-/// feature, by anyone OTHER than the current user. Phase 5 will read
-/// this at upload time to compute base_version_id.
+/// feature, by anyone OTHER than the current user. Read at upload time
+/// to compute base_version_id.
 final remoteAttributionForFeatureProvider =
     StreamProvider.family<RemoteAttributionView?, String>(
   (ref, featureId) {

--- a/lib/features/remote_activity/presentation/remote_attribution_detail_screen.dart
+++ b/lib/features/remote_activity/presentation/remote_attribution_detail_screen.dart
@@ -5,9 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-/// Read-only view of another enumerator's attribution for a feature.
-/// Phase 5 will reuse the underlying widgets in the side-by-side compare
-/// during conflict review.
+/// Read-only view of another enumerator's attribution for a feature. The
+/// underlying widgets are reused in the side-by-side compare during
+/// conflict review.
 class RemoteAttributionDetailScreen extends ConsumerWidget {
   const RemoteAttributionDetailScreen({required this.featureId, super.key});
   final String featureId;
@@ -43,10 +43,8 @@ class RemoteAttributionDetailScreen extends ConsumerWidget {
                 child: AttributeKvTable(values: values),
               ),
               const SizedBox(height: 12),
-              // Phase-5 hook: open form for local edit / "compare with mine".
-              // For phase 4 we surface a "Open feature" CTA that drops the
-              // user back into the standard feature form, where any local
-              // submission can be inspected.
+              // "Open feature" CTA that drops the user back into the standard
+              // feature form, where any local submission can be inspected.
               Padding(
                 padding:
                     const EdgeInsets.symmetric(horizontal: 16, vertical: 8),

--- a/lib/features/survey/building_form/domain/building_form_applicability.dart
+++ b/lib/features/survey/building_form/domain/building_form_applicability.dart
@@ -1,15 +1,13 @@
-// lib/features/survey/building_form/domain/building_form_applicability.dart
-//
 // Centralized model of which building-form fields are applicable to the
 // current path through the form, and which of those still need an answer.
-// Drives field-level visibility (US-6), automatic clearing of skipped
-// answers (US-7) and the remaining-questions indicator (US-8).
+// Drives field-level visibility, automatic clearing of skipped answers,
+// and the remaining-questions indicator.
 //
 // [geometry] flows through every applicability call so skip-logic that
 // depends on the feature's shape — area thresholds, vertex counts — can
-// re-evaluate the moment a reshape commits (Issue #44). Current rules
-// don't consume the signal yet; the parameter exists so adding a
-// geometry-dependent rule is a one-line change.
+// re-evaluate the moment a reshape commits. Current rules don't consume
+// the signal yet; the parameter exists so adding a geometry-dependent
+// rule is a one-line change.
 import 'package:firecheck/core/forms/field_requirements.dart';
 import 'package:firecheck/core/forms/geometry_signal.dart';
 import 'package:firecheck/features/survey/building_form/domain/building_form_state.dart';
@@ -30,8 +28,8 @@ enum BuildingFormField {
 /// state. Fields that are not applicable have their stored value cleared
 /// by [applyApplicability] so a stale answer cannot survive a path change.
 ///
-/// [hidden] is the form variant's `hideBuildingFields` set (US-41). When
-/// the variant hides a field it is treated identically to a non-applicable
+/// [hidden] is the form variant's `hideBuildingFields` set. When the
+/// variant hides a field it is treated identically to a non-applicable
 /// field: the input is not rendered, the value is auto-cleared, and the
 /// remaining-questions chip skips it.
 bool isApplicable(

--- a/lib/features/survey/building_form/domain/ra_9514_fallback.dart
+++ b/lib/features/survey/building_form/domain/ra_9514_fallback.dart
@@ -1,6 +1,6 @@
 /// Hardcoded fallback list of the 10 RA 9514 occupancy groups. Used when
-/// the local Drift `ra_9514_types` table is empty (which is the case until
-/// Phase 3's seed populates it).
+/// the local Drift `ra_9514_types` table is empty (before the seed
+/// populates it).
 class Ra9514Entry {
   const Ra9514Entry({required this.code, required this.labelKey});
   final String code;

--- a/lib/features/survey/building_form/presentation/building_form_notifier.dart
+++ b/lib/features/survey/building_form/presentation/building_form_notifier.dart
@@ -32,9 +32,9 @@ class BuildingFormNotifier extends StateNotifier<BuildingFormState> {
   final SubmissionRepository submissionRepo;
   final BuildingAttributesRepository attrsRepo;
   final FeatureRepository featureRepo;
-  // US-41: fields the active form variant hides for this user/assignment.
-  // Passed through to applyApplicability / remainingQuestionCount so the
-  // form behaves as if the hidden fields don't exist.
+  // Fields the active form variant hides for this user/assignment. Passed
+  // through to applyApplicability / remainingQuestionCount so the form
+  // behaves as if the hidden fields don't exist.
   final Set<BuildingFormField> hiddenFields;
 
   Timer? _debounce;
@@ -65,8 +65,8 @@ class BuildingFormNotifier extends StateNotifier<BuildingFormState> {
   void update(BuildingFormState Function(BuildingFormState) mutate) {
     // Sweep inapplicable fields after every mutation so a field that became
     // non-applicable (e.g. cost-range when the user just switched to exact)
-    // can't carry a stale value into the database (US-7). Visibility (US-6)
-    // and the remaining-questions count (US-8) read the same predicate.
+    // can't carry a stale value into the database. Visibility and the
+    // remaining-questions count read the same predicate.
     state = applyApplicability(
       mutate(state),
       hidden: hiddenFields,

--- a/lib/features/survey/building_form/presentation/remaining_questions_badge.dart
+++ b/lib/features/survey/building_form/presentation/remaining_questions_badge.dart
@@ -1,8 +1,6 @@
-// lib/features/survey/building_form/presentation/remaining_questions_badge.dart
-//
-// US-8: shows how many applicable fields on the enumerator's current path
-// still need an answer. Hides itself when the "does not exist" toggle is on
-// (no applicable fields remain to count).
+// Shows how many applicable fields on the enumerator's current path still
+// need an answer. Hides itself when the "does not exist" toggle is on (no
+// applicable fields remain to count).
 import 'package:firecheck/core/forms/field_requirements_providers.dart';
 import 'package:firecheck/core/forms/form_variant_providers.dart';
 import 'package:firecheck/features/survey/building_form/domain/building_form_applicability.dart';

--- a/lib/features/survey/road_form/domain/road_form_applicability.dart
+++ b/lib/features/survey/road_form/domain/road_form_applicability.dart
@@ -1,10 +1,9 @@
-// lib/features/survey/road_form/domain/road_form_applicability.dart
-//
 // Same shape as the building variant: centralized applicability rules for
-// road-form fields, driving US-6 / US-7 / US-8.
+// road-form fields, driving field visibility, auto-clearing of skipped
+// answers, and the remaining-questions indicator.
 //
 // [geometry] is threaded through so geometry-dependent skip rules
-// re-evaluate when a road polyline is reshaped mid-survey (Issue #44).
+// re-evaluate when a road polyline is reshaped mid-survey.
 import 'package:firecheck/core/forms/field_requirements.dart';
 import 'package:firecheck/core/forms/geometry_signal.dart';
 import 'package:firecheck/features/survey/road_form/domain/road_form_state.dart';
@@ -16,9 +15,9 @@ enum RoadFormField {
   othersDescription,
 }
 
-/// [hidden] is the form variant's `hideRoadFields` set (US-41). When the
-/// variant hides a field, it is treated identically to a non-applicable
-/// field: not rendered, not counted.
+/// [hidden] is the form variant's `hideRoadFields` set. When the variant
+/// hides a field, it is treated identically to a non-applicable field:
+/// not rendered, not counted.
 bool isApplicable(
   RoadFormState s,
   RoadFormField f, {

--- a/lib/features/survey/road_form/presentation/road_form_notifier.dart
+++ b/lib/features/survey/road_form/presentation/road_form_notifier.dart
@@ -21,12 +21,12 @@ class RoadFormNotifier extends StateNotifier<RoadFormState> {
   final String featureId;
   final RoadAttributesRepository attrsRepo;
   final SubmissionRepository submissionRepo;
-  // US-41: fields the active form variant hides for this user/assignment.
+  // Fields the active form variant hides for this user/assignment.
   final Set<RoadFormField> hiddenFields;
 
   /// Latest geometry-derived signal for the feature this form is filling.
   /// Updated by [onGeometryChanged] whenever a reshape commit lands so
-  /// skip-logic re-evaluates automatically (Issue #44).
+  /// skip-logic re-evaluates automatically.
   GeometrySignal? _geometrySignal;
   GeometrySignal? get geometrySignal => _geometrySignal;
 
@@ -34,8 +34,8 @@ class RoadFormNotifier extends StateNotifier<RoadFormState> {
   static const _window = Duration(milliseconds: 500);
 
   void update(RoadFormState Function(RoadFormState) mutate) {
-    // Apply field applicability after the mutation — US-6/US-7 share this
-    // hook with the remaining-questions count (US-8).
+    // Apply field applicability after the mutation — field visibility and
+    // auto-clear share this hook with the remaining-questions count.
     state = applyApplicability(
       mutate(state),
       hidden: hiddenFields,

--- a/lib/features/survey/road_form/presentation/road_remaining_questions_badge.dart
+++ b/lib/features/survey/road_form/presentation/road_remaining_questions_badge.dart
@@ -1,6 +1,4 @@
-// lib/features/survey/road_form/presentation/road_remaining_questions_badge.dart
-//
-// US-8 (road variant): shows applicable-but-unanswered count for the road
+// Road-form variant: shows applicable-but-unanswered count for the road
 // form. Shares the chip widget with the building variant for visual parity.
 import 'package:firecheck/core/forms/field_requirements_providers.dart';
 import 'package:firecheck/core/forms/form_variant_providers.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -184,12 +184,11 @@ class _SyncBootstrapState extends ConsumerState<_SyncBootstrap> {
     super.dispose();
   }
 
-  /// Phases 2 + 3 of multi-user attribution sync: cold-open full pull
-  /// (phase 2) plus realtime subscription with connection state machine
-  /// (phase 3). Must be (re)evaluated on every auth state change — the
-  /// common flow is app launch → sign-in screen → user signs in, so a
-  /// one-shot check at `initState` would never fire start() for that
-  /// session and the cache would stay empty until app restart.
+  /// Cold-open full pull plus realtime subscription with connection state
+  /// machine. Must be (re)evaluated on every auth state change — the common
+  /// flow is app launch → sign-in screen → user signs in, so a one-shot
+  /// check at `initState` would never fire start() for that session and the
+  /// cache would stay empty until app restart.
   void _wireRemoteSyncToAuth() {
     final client = Supabase.instance.client;
     if (client.auth.currentSession != null) {

--- a/test/core/db/database_test.dart
+++ b/test/core/db/database_test.dart
@@ -44,9 +44,9 @@ void main() {
       expect(db.schemaVersion, greaterThanOrEqualTo(3));
     });
 
-    test('the DB registers exactly the 16 expected tables', () {
+    test('the DB registers exactly the 17 expected tables', () {
       final names = db.allTables.map((t) => t.actualTableName).toSet();
-      expect(names, hasLength(16));
+      expect(names, hasLength(17));
       expect(
         names,
         equals({
@@ -63,10 +63,10 @@ void main() {
           'offline_tile_packs',
           'feature_geometry_revisions',
           'drive_upload_jobs',
-          // Multi-user attribution sync — phase 2:
           'remote_attributions_cache',
           'remote_new_features_cache',
           'assignment_sync_cursors',
+          'pending_resolutions',
         }),
       );
     });

--- a/test/core/db/migration_v7_to_v8_test.dart
+++ b/test/core/db/migration_v7_to_v8_test.dart
@@ -154,6 +154,22 @@ void main() {
               drive_folder_id TEXT
             )
           ''');
+          // submissions: later migrations (v10→v11) `addColumn` to this
+          // table, so it must exist in the seeded v7 schema even though
+          // this test is scoped to v7→v8.
+          rawDb.execute('''
+            CREATE TABLE IF NOT EXISTS submissions (
+              id TEXT NOT NULL PRIMARY KEY,
+              feature_id TEXT NOT NULL,
+              submitted_by TEXT,
+              does_not_exist INTEGER NOT NULL DEFAULT 0,
+              remarks TEXT,
+              sync_status TEXT NOT NULL DEFAULT 'draft',
+              override_reason TEXT,
+              created_at INTEGER NOT NULL,
+              updated_at INTEGER NOT NULL
+            )
+          ''');
         },
       ),
     );

--- a/test/core/photos/photo_capture_controller_test.dart
+++ b/test/core/photos/photo_capture_controller_test.dart
@@ -29,7 +29,7 @@ void main() {
     storage = InMemoryPhotoStorage(root: tempDir.path);
 
     // Seed the FK chain so photos.submission_id has a valid parent. With
-    // PRAGMA foreign_keys = ON (Phase 1), an orphan insert would fail.
+    // PRAGMA foreign_keys = ON, an orphan insert would fail.
     final now = DateTime.now();
     await db.into(db.features).insert(
           FeaturesCompanion.insert(

--- a/test/core/sync/domain/finalize_submission_test.dart
+++ b/test/core/sync/domain/finalize_submission_test.dart
@@ -59,7 +59,7 @@ void main() {
 
     final jobs = await db.select(db.syncJobs).get();
     expect(jobs, hasLength(1));
-    expect(jobs.first.entityType, SyncEntityType.submission);
+    expect(jobs.first.entityType, SyncEntityType.attributionUpload);
     expect(jobs.first.entityId, 's1');
     expect(jobs.first.status, SyncJobStatus.pending);
   });
@@ -99,7 +99,7 @@ void main() {
     final r = await useCase.execute('s1');
     expect(r.newFeatureQueued, isTrue);
     final job = await (db.select(db.syncJobs)
-          ..where((t) => t.entityType.equals(SyncEntityType.newFeature)))
+          ..where((t) => t.entityType.equals(SyncEntityType.newFeatureUpload)))
         .getSingle();
     expect(job.entityId, 'f1');
   });

--- a/test/core/sync/worker/attribution_resolve_test.dart
+++ b/test/core/sync/worker/attribution_resolve_test.dart
@@ -1,0 +1,111 @@
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/data/fake_sync_api.dart';
+import 'package:firecheck/core/sync/data/submission_payload_builder.dart';
+import 'package:firecheck/core/sync/data/sync_jobs_repository.dart';
+import 'package:firecheck/core/sync/domain/resolution_decision.dart';
+import 'package:firecheck/core/sync/domain/sync_entity_type.dart';
+import 'package:firecheck/core/sync/failure/assignment_lock_repository.dart';
+import 'package:firecheck/core/sync/worker/sync_worker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase db;
+  late FakeSyncApi api;
+  late SyncWorker worker;
+  final now = DateTime.utc(2026, 5, 19, 10);
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    api = FakeSyncApi();
+    worker = SyncWorker(
+      api: api,
+      jobs: SyncJobsRepository(db),
+      payload: SubmissionPayloadBuilder(db),
+      lock: AssignmentLockRepository(db),
+      db: db,
+    );
+
+    await db.into(db.assignments).insert(
+          AssignmentsCompanion.insert(
+            id: 'a1',
+            enumeratorId: 'me',
+            campaignId: 'c1',
+            boundaryPolygonGeojson: '{}',
+            createdAt: now,
+          ),
+        );
+    await db.into(db.features).insert(
+          FeaturesCompanion.insert(
+            id: 'f1',
+            assignmentId: 'a1',
+            featureType: 'building',
+            geometryGeojson: '{}',
+            createdAt: now,
+          ),
+        );
+    await db.into(db.submissions).insert(
+          SubmissionsCompanion.insert(
+            id: 's1',
+            featureId: 'f1',
+            syncStatus: const Value('awaiting_user_resolution'),
+            pendingTheirsId: const Value('s_remote'),
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
+  });
+
+  tearDown(() => db.close());
+
+  Future<Submission> currentSubmission() =>
+      (db.select(db.submissions)..where((t) => t.id.equals('s1'))).getSingle();
+
+  Future<void> seedResolve(String wire) async {
+    await db.into(db.pendingResolutions).insert(
+          PendingResolutionsCompanion.insert(
+            targetId: 's1',
+            kind: 'attribution',
+            decision: wire,
+            createdAt: now,
+          ),
+        );
+    await db.into(db.syncJobs).insert(
+          SyncJobsCompanion.insert(
+            id: 'j_resolve',
+            entityType: SyncEntityType.attributionResolve,
+            entityId: 's1',
+            createdAt: now,
+          ),
+        );
+  }
+
+  test('keep_theirs → submission flipped to withdrawn, resolution cleared',
+      () async {
+    await seedResolve(AttributionDecision.keepTheirs.wire);
+    await worker.drain();
+
+    final s = await currentSubmission();
+    expect(s.syncStatus, 'withdrawn');
+    expect(s.pendingTheirsId, isNull);
+
+    final res = await db.select(db.pendingResolutions).get();
+    expect(res, isEmpty);
+
+    expect(api.resolveAttributionCalls.single.decision,
+        AttributionDecision.keepTheirs);
+  });
+
+  test('force_overwrite → submission flipped to uploaded', () async {
+    await seedResolve(AttributionDecision.forceOverwrite.wire);
+    await worker.drain();
+
+    final s = await currentSubmission();
+    expect(s.syncStatus, 'uploaded');
+    expect(s.pendingTheirsId, isNull);
+
+    expect(api.resolveAttributionCalls.single.decision,
+        AttributionDecision.forceOverwrite);
+  });
+}

--- a/test/core/sync/worker/attribution_upload_test.dart
+++ b/test/core/sync/worker/attribution_upload_test.dart
@@ -1,0 +1,111 @@
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/data/fake_sync_api.dart';
+import 'package:firecheck/core/sync/data/submission_payload_builder.dart';
+import 'package:firecheck/core/sync/data/sync_jobs_repository.dart';
+import 'package:firecheck/core/sync/domain/submit_attribution_result.dart';
+import 'package:firecheck/core/sync/domain/sync_entity_type.dart';
+import 'package:firecheck/core/sync/failure/assignment_lock_repository.dart';
+import 'package:firecheck/core/sync/worker/sync_worker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase db;
+  late FakeSyncApi api;
+  late SyncWorker worker;
+  final now = DateTime.utc(2026, 5, 19, 10);
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    api = FakeSyncApi();
+    worker = SyncWorker(
+      api: api,
+      jobs: SyncJobsRepository(db),
+      payload: SubmissionPayloadBuilder(db),
+      lock: AssignmentLockRepository(db),
+      db: db,
+    );
+
+    await db.into(db.assignments).insert(
+          AssignmentsCompanion.insert(
+            id: 'a1',
+            enumeratorId: 'me',
+            campaignId: 'c1',
+            boundaryPolygonGeojson: '{}',
+            createdAt: now,
+          ),
+        );
+    await db.into(db.features).insert(
+          FeaturesCompanion.insert(
+            id: 'f1',
+            assignmentId: 'a1',
+            featureType: 'building',
+            geometryGeojson: '{}',
+            createdAt: now,
+          ),
+        );
+    await db.into(db.submissions).insert(
+          SubmissionsCompanion.insert(
+            id: 's1',
+            featureId: 'f1',
+            syncStatus: const Value('queued'),
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
+    await db.into(db.syncJobs).insert(
+          SyncJobsCompanion.insert(
+            id: 'job-uuid-0000-0001',
+            entityType: SyncEntityType.attributionUpload,
+            entityId: 's1',
+            createdAt: now,
+          ),
+        );
+  });
+
+  tearDown(() => db.close());
+
+  Future<Submission> currentSubmission() =>
+      (db.select(db.submissions)..where((t) => t.id.equals('s1'))).getSingle();
+
+  test('committed → submission marked uploaded', () async {
+    api.enqueueSubmitAttribution(
+      result: const AttributionCommitted('s1'),
+    );
+    await worker.drain();
+    final s = await currentSubmission();
+    expect(s.syncStatus, 'uploaded');
+    expect(s.pendingTheirsId, isNull);
+  });
+
+  test('agreed_skip → submission marked withdrawn', () async {
+    api.enqueueSubmitAttribution(
+      result: const AttributionAgreedSkip('s_remote'),
+    );
+    await worker.drain();
+    final s = await currentSubmission();
+    expect(s.syncStatus, 'withdrawn');
+    expect(s.pendingTheirsId, isNull);
+  });
+
+  test('conflict → submission parked with pendingTheirsId set', () async {
+    api.enqueueSubmitAttribution(
+      result: const AttributionConflict(
+        pendingId: 's1',
+        theirSubmissionId: 's_remote',
+      ),
+    );
+    await worker.drain();
+    final s = await currentSubmission();
+    expect(s.syncStatus, 'awaiting_user_resolution');
+    expect(s.pendingTheirsId, 's_remote');
+
+    // The job itself succeeded — parking is a state on the submission,
+    // not on the job (worker terminology: outcome=Success).
+    final job = await (db.select(db.syncJobs)
+          ..where((t) => t.id.equals('job-uuid-0000-0001')))
+        .getSingle();
+    expect(job.status, 'success');
+  });
+}

--- a/test/core/sync/worker/sync_worker_assignment_closed_test.dart
+++ b/test/core/sync/worker/sync_worker_assignment_closed_test.dart
@@ -48,7 +48,8 @@ void main() {
     addTearDown(() => tmp.deleteSync(recursive: true));
     await _seed(db);
     final lock = AssignmentLockRepository(db);
-    final api = FakeSyncApi()..enqueueSubmission(const AssignmentClosed('a1'));
+    final api = FakeSyncApi()
+      ..enqueueSubmitAttribution(outcome: const AssignmentClosed('a1'));
     final worker = SyncWorker(
       api: api,
       jobs: SyncJobsRepository(db),

--- a/test/core/sync/worker/sync_worker_auth_test.dart
+++ b/test/core/sync/worker/sync_worker_auth_test.dart
@@ -43,8 +43,8 @@ void main() {
     addTearDown(db.close);
     await _seed(db);
     final api = FakeSyncApi()
-      ..enqueueSubmission(const AuthExpired())
-      ..enqueueSubmission(const Success());
+      ..enqueueSubmitAttribution(outcome: const AuthExpired())
+      ..enqueueSubmitAttribution();
     var refreshCalls = 0;
     final worker = SyncWorker(
       api: api,
@@ -67,7 +67,8 @@ void main() {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     addTearDown(db.close);
     await _seed(db);
-    final api = FakeSyncApi()..enqueueSubmission(const AuthExpired());
+    final api = FakeSyncApi()
+      ..enqueueSubmitAttribution(outcome: const AuthExpired());
     final worker = SyncWorker(
       api: api,
       jobs: SyncJobsRepository(db),
@@ -89,8 +90,8 @@ void main() {
     addTearDown(db.close);
     await _seed(db);
     final api = FakeSyncApi()
-      ..enqueueSubmission(const AuthExpired())
-      ..enqueueSubmission(const AuthExpired());
+      ..enqueueSubmitAttribution(outcome: const AuthExpired())
+      ..enqueueSubmitAttribution(outcome: const AuthExpired());
     final worker = SyncWorker(
       api: api,
       jobs: SyncJobsRepository(db),

--- a/test/core/sync/worker/sync_worker_happy_path_test.dart
+++ b/test/core/sync/worker/sync_worker_happy_path_test.dart
@@ -71,13 +71,18 @@ void main() {
         .getSingle();
     expect(sub.syncStatus, 'uploaded');
 
-    expect(api.uploadSubmissionCalls, hasLength(1));
+    // FinalizeSubmissionUseCase now enqueues `attribution_upload`, which
+    // routes through the conflict-aware RPC. The legacy `uploadSubmission`
+    // surface stays for any in-flight legacy jobs from before the
+    // rollout but is not exercised here.
+    expect(api.submitAttributionCalls, hasLength(1));
+    expect(api.uploadSubmissionCalls, isEmpty);
   });
 
   test('drain() de-dupes overlapping calls', () async {
     final f1 = worker.drain();
     final f2 = worker.drain();
     await Future.wait([f1, f2]);
-    expect(api.uploadSubmissionCalls, hasLength(1));
+    expect(api.submitAttributionCalls, hasLength(1));
   });
 }

--- a/test/core/sync/worker/sync_worker_retry_test.dart
+++ b/test/core/sync/worker/sync_worker_retry_test.dart
@@ -42,7 +42,7 @@ void main() {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     addTearDown(db.close);
     await _seed(db);
-    final api = FakeSyncApi()..enqueueSubmission(const TransientFailure('500'));
+    final api = FakeSyncApi()..enqueueSubmitAttribution(outcome: const TransientFailure('500'));
     final worker = SyncWorker(
       api: api,
       jobs: SyncJobsRepository(db),
@@ -66,7 +66,7 @@ void main() {
     await (db.update(db.syncJobs)
           ..where((t) => t.id.equals(jobBefore.id)))
         .write(const SyncJobsCompanion(attempts: Value(4)));
-    final api = FakeSyncApi()..enqueueSubmission(const TransientFailure('500'));
+    final api = FakeSyncApi()..enqueueSubmitAttribution(outcome: const TransientFailure('500'));
     final worker = SyncWorker(
       api: api,
       jobs: SyncJobsRepository(db),
@@ -85,7 +85,7 @@ void main() {
     addTearDown(db.close);
     await _seed(db);
     final api = FakeSyncApi()
-      ..enqueueSubmission(const PermanentFailure('400 bad request'));
+      ..enqueueSubmitAttribution(outcome: const PermanentFailure('400 bad request'));
     final worker = SyncWorker(
       api: api,
       jobs: SyncJobsRepository(db),

--- a/test/features/conflict_review/conflict_review_repository_test.dart
+++ b/test/features/conflict_review/conflict_review_repository_test.dart
@@ -1,0 +1,94 @@
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/domain/resolution_decision.dart';
+import 'package:firecheck/core/sync/domain/sync_entity_type.dart';
+import 'package:firecheck/features/conflict_review/data/conflict_review_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase db;
+  late ConflictReviewRepository repo;
+  final now = DateTime.utc(2026, 5, 19, 10);
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = ConflictReviewRepository(db);
+  });
+  tearDown(() => db.close());
+
+  Future<List<SyncJob>> jobs() =>
+      (db.select(db.syncJobs)).get();
+
+  test('queueAttributionDecision inserts pending_resolutions + sync_job',
+      () async {
+    await repo.queueAttributionDecision(
+      submissionId: 's1',
+      decision: AttributionDecision.keepTheirs,
+      resolutionNote: 'duplicate',
+    );
+
+    final pr = await db.select(db.pendingResolutions).get();
+    expect(pr, hasLength(1));
+    expect(pr.first.targetId, 's1');
+    expect(pr.first.kind, 'attribution');
+    expect(pr.first.decision, 'keep_theirs');
+    expect(pr.first.resolutionNote, 'duplicate');
+
+    final js = await jobs();
+    expect(js, hasLength(1));
+    expect(js.first.entityType, SyncEntityType.attributionResolve);
+    expect(js.first.entityId, 's1');
+    expect(js.first.status, 'pending');
+  });
+
+  test('re-queue overwrites decision and resets the job', () async {
+    await repo.queueAttributionDecision(
+      submissionId: 's1',
+      decision: AttributionDecision.keepTheirs,
+    );
+    // Simulate a stalled job that was marked failed.
+    await (db.update(db.syncJobs)
+          ..where(
+            (t) => t.entityType.equals(SyncEntityType.attributionResolve),
+          ))
+        .write(
+      SyncJobsCompanion(
+        status: const Value('dead'),
+        attempts: const Value(3),
+        lastError: const Value('boom'),
+        nextRetryAt: Value(now.add(const Duration(hours: 1))),
+      ),
+    );
+
+    await repo.queueAttributionDecision(
+      submissionId: 's1',
+      decision: AttributionDecision.forceOverwrite,
+    );
+
+    final pr = await db.select(db.pendingResolutions).get();
+    expect(pr.single.decision, 'force_overwrite',
+        reason: 'changed-mind decision overwrites the prior queued one');
+
+    final j = (await jobs()).single;
+    expect(j.status, 'pending');
+    expect(j.attempts, 0);
+    expect(j.lastError, isNull);
+    expect(j.nextRetryAt, isNull);
+  });
+
+  test('queueDedupDecision routes via newFeatureResolve', () async {
+    await repo.queueDedupDecision(
+      featureId: 'f1',
+      decision: DedupDecision.discardMine,
+    );
+
+    final pr = await db.select(db.pendingResolutions).get();
+    expect(pr.single.kind, 'new_feature');
+    expect(pr.single.decision, 'discard_mine');
+
+    final j = (await jobs()).single;
+    expect(j.entityType, SyncEntityType.newFeatureResolve);
+    expect(j.entityId, 'f1');
+  });
+}

--- a/test/features/conflict_review/local_attribution_flatten_test.dart
+++ b/test/features/conflict_review/local_attribution_flatten_test.dart
@@ -1,0 +1,49 @@
+import 'package:firecheck/features/conflict_review/domain/local_attribution_flatten.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('diffAttributionKeys returns differing keys', () {
+    final mine = {
+      'roof': 'tile',
+      'floors': 3,
+      'use': 'residential',
+    };
+    final theirs = {
+      'roof': 'tile',
+      'floors': 2,
+      'use': 'residential',
+    };
+    expect(diffAttributionKeys(mine, theirs), {'floors'});
+  });
+
+  test('diffAttributionKeys treats null and missing as equal', () {
+    expect(diffAttributionKeys({'a': null}, {}), isEmpty);
+  });
+
+  test('diffAttributionKeys treats lists order-insensitively', () {
+    expect(
+      diffAttributionKeys(
+        {'features': ['a', 'b']},
+        {'features': ['b', 'a']},
+      ),
+      isEmpty,
+    );
+  });
+
+  test('diffAttributionKeys detects list length differences', () {
+    expect(
+      diffAttributionKeys(
+        {'features': ['a', 'b']},
+        {'features': ['a']},
+      ),
+      {'features'},
+    );
+  });
+
+  test('keys present on only one side count as differing', () {
+    expect(
+      diffAttributionKeys({'a': 1, 'b': 2}, {'a': 1}),
+      {'b'},
+    );
+  });
+}

--- a/test/features/map/map_screen_polyline_reshape_test.dart
+++ b/test/features/map/map_screen_polyline_reshape_test.dart
@@ -43,7 +43,7 @@ void main() {
     await renderer.simulatePolygonLongPress(road);
     await tester.pumpAndSettle();
 
-    // Same action sheet polygons get — that's the user story.
+    // Same action sheet polygons get.
     expect(
       find.byKey(const Key('reshape.actionsheet.openForm')),
       findsOneWidget,
@@ -60,7 +60,7 @@ void main() {
     expect(state.isActive, isTrue);
     expect(state.originalFeature?.id, road.id);
     // Polyline reshape must NOT enable the closed-shape body-drag /
-    // self-intersection latches — that's what the user story is asking for.
+    // self-intersection latches.
     expect(state.isClosed, isFalse);
     expect(state.selfIntersects, isFalse);
   });

--- a/test/features/map/map_screen_recenter_test.dart
+++ b/test/features/map/map_screen_recenter_test.dart
@@ -65,9 +65,9 @@ Future<void> pumpMap(
       analyticsServiceProvider.overrideWithValue(analytics),
       currentFeaturesProvider.overrideWith((_) => Stream.value(const [])),
       currentAssignmentProvider.overrideWith((_) => Stream.value(fakeAssignment())),
-      // Phase 4 map-badge chip watches the remote attribution cache via
-      // Drift; in the map screen tests we don't wire a real DB, so short-
-      // circuit the data source to avoid a pending-timer leak at teardown.
+      // Map-badge chip watches the remote attribution cache via Drift; in
+      // the map screen tests we don't wire a real DB, so short-circuit the
+      // data source to avoid a pending-timer leak at teardown.
       othersRemoteAttributionsProvider.overrideWith(
         (_) => Stream.value(const []),
       ),

--- a/test/features/map/map_screen_reshape_test.dart
+++ b/test/features/map/map_screen_reshape_test.dart
@@ -138,13 +138,13 @@ void main() {
       );
     });
 
-    // (Removed in plan Task 12: the old "add-mode on suppresses long-press"
-    // test. The sketch-mode equivalent — that tapping an existing feature
-    // while sketching is suppressed — is covered by sketch_flow_test.dart's
-    // gesture-suppression group.)
+    // The old "add-mode on suppresses long-press" test was removed; the
+    // sketch-mode equivalent — that tapping an existing feature while
+    // sketching is suppressed — is covered by sketch_flow_test.dart's
+    // gesture-suppression group.
   });
 
-  group('US-9 T19 distance gate + override-reason → enterReshape', () {
+  group('distance gate + override-reason → enterReshape', () {
     testWidgets('Reshape with GPS within 50m enters edit mode (no dialog)',
         (tester) async {
       final renderer = FakeMapRenderer();

--- a/test/features/map/map_screen_road_test.dart
+++ b/test/features/map/map_screen_road_test.dart
@@ -68,8 +68,8 @@ Widget _buildSubject({
       assignmentLockStateProvider
           .overrideWith((_) => Stream.value(const Unlocked())),
       currentUserIdProvider.overrideWith((ref) => 'u1'),
-      // Phase 4 map-badge chip — short-circuit its Drift watch so pending
-      // timers don't leak across the test boundary.
+      // Map-badge chip — short-circuit its Drift watch so pending timers
+      // don't leak across the test boundary.
       othersRemoteAttributionsProvider.overrideWith(
         (_) => Stream.value(const []),
       ),

--- a/test/integration/review_happy_path_test.dart
+++ b/test/integration/review_happy_path_test.dart
@@ -96,8 +96,7 @@ void main() {
     expect(a.submittedAt, isNotNull, reason: 'submitted_at should be stamped');
   }, skip: true,);
   // Marked skip: requires the SyncController triggerNow to be wired with
-  // its real worker — manual happy path on the emulator covers this in
-  // Task 25. The integration test stays in tree as a documentation
+  // its real worker. The integration test stays in tree as a documentation
   // anchor; flip skip:false once the SyncController gets a synchronous
-  // drain helper (Phase 5).
+  // drain helper.
 }

--- a/test/integration/set_up_complete_feature_test.dart
+++ b/test/integration/set_up_complete_feature_test.dart
@@ -69,8 +69,8 @@ void main() {
     await tester.pumpAndSettle();
 
     // 3. Drop vertices (simulated as long-press for Point-based add)
-    // simulateLongPress was removed in plan Task 8; this whole test is
-    // skipped and will be rewritten in plan Task 12 for the sketch flow.
+    // simulateLongPress was removed; this whole test is skipped and will
+    // be rewritten for the sketch flow.
     await renderer.simulateMapTap(10.31810, 123.88270);
     await tester.pumpAndSettle();
 
@@ -122,7 +122,7 @@ void main() {
     // 7. Back on map, verify feature status is complete (green)
     final updatedFeature = await (db.select(db.features)..where((t) => t.id.equals(featureId))).getSingle();
     expect(updatedFeature.status, 'complete');
-    // skip reason: rewritten in plan Task 12 for sketch flow
+    // skip reason: pending rewrite for sketch flow
   }, skip: true);
 }
 


### PR DESCRIPTION
## Summary

Switches the push path off `upload_submission_bundle` / `upload_new_feature` and onto the conflict- and dedup-aware RPCs from the backend foundation (`submit_attribution_with_conflict_check`, `submit_new_feature_with_dedup_check`). Ships the user-facing review screens that resolve parked outcomes.

## What changes for users

- **Home screen** gains a "N conflicts to resolve →" banner when the server flags conflicts or possible duplicates. Hidden when zero.
- **`/resolve`** lists attribution conflicts on top, new-feature dedup reviews below. Empty-state for the common case.
- **`/resolve/attribution/:submissionId`** shows the local vs remote attributes side-by-side with diff highlighting, a diff-summary chip ("X of Y fields differ"), and a "Hide identical fields" toggle that defaults ON when ≥5 fields match. Three actions: Keep theirs / Use mine / Skip — decide later.
- **`/resolve/dedup/:featureId`** offers Keep both / Replace theirs / Discard mine / Skip. Mini-map header intentionally deferred to a later visual-polish pass.

## Push layer architecture

- New SyncEntityType values: `attribution_upload`, `attribution_resolve`, `new_feature_upload`, `new_feature_resolve`. SyncWorker dispatches each to the matching RPC.
- `attribution_upload` routes through a structured `SubmitAttributionResult` sealed type:
  - `committed` → submission marked uploaded
  - `agreed_skip` → submission marked withdrawn (server already had identical canonical)
  - `conflict` → submission parked in `awaiting_user_resolution` with `pendingTheirsId` set
- `attribution_resolve` / `new_feature_resolve` read a queued decision from the new `pending_resolutions` table, call the corresponding `resolve_*` RPC, then flip the submission's `sync_status` accordingly (uploaded for `force_overwrite`, withdrawn for `keep_theirs`). Survives offline because both the decision and the sync_job persist.
- `FinalizeSubmissionUseCase` now enqueues under the new types. Legacy `submission` / `new_feature` types remain functional for in-flight jobs from before the rollout; the gating SQL in `SyncJobsRepository` accepts both legacy and new strings in its blocking / ordering clauses.

## Schema (v10 → v11)

- `submissions.pendingTheirsId` — UUID of the conflicting canonical when parked, so the review UI can render side-by-side without re-querying.
- `pending_resolutions(targetId, kind, decision, resolutionNote, createdAt)` — a small persistent queue of user decisions awaiting the worker. Survives process restarts so users can resolve offline.

## Verification

- ✅ 13 new tests: worker upload (committed / agreed_skip / conflict transitions), worker resolve (`keep_theirs → withdrawn`; `force_overwrite → uploaded`), `ConflictReviewRepository` queueing + idempotent re-queue, flatten + diff helpers.
- ✅ 5 existing sync_worker_* tests updated to enqueue via the new `submitAttribution` surface. `FakeSyncApi` accepts a Success-with-no-result shorthand and defaults to committed with the payload's id.
- ✅ Full suite: **783 passing, 3 pre-existing failures on \`main\`, 0 regressions**, 2 skipped.
- ✅ `dart analyze` on touched files: no errors.

## Side cleanup

This branch also picks up a sweep removing phase / user-story / spec scaffolding labels from comments across the codebase, per recent local convention.

## Test plan

- [ ] Two devices on the same assignment: A submits an attribution for building F. B (online) submits a *different* attribution for the same building. B's upload should park in `awaiting_user_resolution` and the home-screen banner should show 1.
- [ ] Open `/resolve` on B → side-by-side compare visible with differing fields highlighted.
- [ ] Pick "Keep theirs" — B's submission flips to `withdrawn`. Pick "Use mine" instead — B's submission becomes `uploaded` and A's canonical row supersedes.
- [ ] Submit a new feature with another nearby (within 5m) — review screen surfaces in `/resolve` and queues the chosen decision; sync worker drains it when online.

## Out of scope (next phase)

- Phase 6: Decommission old upload path + scheduled orphan-photo cleanup job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)