### PR TITLE
Multi-user attribution sync — dedup-pending fix + decommission legacy path + orphan-photo cleanup

### DIFF
--- a/lib/core/db/database.dart
+++ b/lib/core/db/database.dart
@@ -52,7 +52,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 11;
+  int get schemaVersion => 12;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -127,6 +127,14 @@ class AppDatabase extends _$AppDatabase {
             // chosen decision while it awaits the resolve_* RPC call.
             await m.addColumn(submissions, submissions.pendingTheirsId);
             await m.createTable(pendingResolutions);
+          }
+          if (from < 12) {
+            // v11 → v12: features.pendingDedupOf tracks the candidate
+            // duplicate's UUID after a dedup-pending upload. Non-null =
+            // needs user review; cleared on resolve. Without this the
+            // review list can't surface dedup_pending uploads — they'd
+            // look like normal successes.
+            await m.addColumn(features, features.pendingDedupOf);
           }
         },
         beforeOpen: (details) async {

--- a/lib/core/db/database.dart
+++ b/lib/core/db/database.dart
@@ -52,7 +52,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 12;
+  int get schemaVersion => 13;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -135,6 +135,23 @@ class AppDatabase extends _$AppDatabase {
             // review list can't surface dedup_pending uploads — they'd
             // look like normal successes.
             await m.addColumn(features, features.pendingDedupOf);
+          }
+          if (from < 13) {
+            // v12 → v13: rewrite any queued sync_jobs that still carry
+            // the legacy `submission` / `new_feature` entity_type. The
+            // matching worker handlers were removed in this release,
+            // so without this update an offline queue from a prior
+            // install would dead-letter as "unknown entity_type" on
+            // first drain. Idempotent — already-rewritten rows are
+            // skipped by the WHERE clause.
+            await customStatement(
+              "UPDATE sync_jobs SET entity_type = 'attribution_upload' "
+              "WHERE entity_type = 'submission'",
+            );
+            await customStatement(
+              "UPDATE sync_jobs SET entity_type = 'new_feature_upload' "
+              "WHERE entity_type = 'new_feature'",
+            );
           }
         },
         beforeOpen: (details) async {

--- a/lib/core/db/database.g.dart
+++ b/lib/core/db/database.g.dart
@@ -1063,6 +1063,12 @@ class $FeaturesTable extends Features with TableInfo<$FeaturesTable, Feature> {
       type: DriftSqlType.string,
       requiredDuringInsert: false,
       defaultValue: const Constant('unfilled'));
+  static const VerificationMeta _pendingDedupOfMeta =
+      const VerificationMeta('pendingDedupOf');
+  @override
+  late final GeneratedColumn<String> pendingDedupOf = GeneratedColumn<String>(
+      'pending_dedup_of', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
   static const VerificationMeta _createdAtMeta =
       const VerificationMeta('createdAt');
   @override
@@ -1077,6 +1083,7 @@ class $FeaturesTable extends Features with TableInfo<$FeaturesTable, Feature> {
         geometryGeojson,
         isNew,
         status,
+        pendingDedupOf,
         createdAt
       ];
   @override
@@ -1126,6 +1133,12 @@ class $FeaturesTable extends Features with TableInfo<$FeaturesTable, Feature> {
       context.handle(_statusMeta,
           status.isAcceptableOrUnknown(data['status']!, _statusMeta));
     }
+    if (data.containsKey('pending_dedup_of')) {
+      context.handle(
+          _pendingDedupOfMeta,
+          pendingDedupOf.isAcceptableOrUnknown(
+              data['pending_dedup_of']!, _pendingDedupOfMeta));
+    }
     if (data.containsKey('created_at')) {
       context.handle(_createdAtMeta,
           createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
@@ -1153,6 +1166,8 @@ class $FeaturesTable extends Features with TableInfo<$FeaturesTable, Feature> {
           .read(DriftSqlType.bool, data['${effectivePrefix}is_new'])!,
       status: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}status'])!,
+      pendingDedupOf: attachedDatabase.typeMapping.read(
+          DriftSqlType.string, data['${effectivePrefix}pending_dedup_of']),
       createdAt: attachedDatabase.typeMapping
           .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
     );
@@ -1171,6 +1186,7 @@ class Feature extends DataClass implements Insertable<Feature> {
   final String geometryGeojson;
   final bool isNew;
   final String status;
+  final String? pendingDedupOf;
   final DateTime createdAt;
   const Feature(
       {required this.id,
@@ -1179,6 +1195,7 @@ class Feature extends DataClass implements Insertable<Feature> {
       required this.geometryGeojson,
       required this.isNew,
       required this.status,
+      this.pendingDedupOf,
       required this.createdAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -1189,6 +1206,9 @@ class Feature extends DataClass implements Insertable<Feature> {
     map['geometry_geojson'] = Variable<String>(geometryGeojson);
     map['is_new'] = Variable<bool>(isNew);
     map['status'] = Variable<String>(status);
+    if (!nullToAbsent || pendingDedupOf != null) {
+      map['pending_dedup_of'] = Variable<String>(pendingDedupOf);
+    }
     map['created_at'] = Variable<DateTime>(createdAt);
     return map;
   }
@@ -1201,6 +1221,9 @@ class Feature extends DataClass implements Insertable<Feature> {
       geometryGeojson: Value(geometryGeojson),
       isNew: Value(isNew),
       status: Value(status),
+      pendingDedupOf: pendingDedupOf == null && nullToAbsent
+          ? const Value.absent()
+          : Value(pendingDedupOf),
       createdAt: Value(createdAt),
     );
   }
@@ -1215,6 +1238,7 @@ class Feature extends DataClass implements Insertable<Feature> {
       geometryGeojson: serializer.fromJson<String>(json['geometryGeojson']),
       isNew: serializer.fromJson<bool>(json['isNew']),
       status: serializer.fromJson<String>(json['status']),
+      pendingDedupOf: serializer.fromJson<String?>(json['pendingDedupOf']),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
     );
   }
@@ -1228,6 +1252,7 @@ class Feature extends DataClass implements Insertable<Feature> {
       'geometryGeojson': serializer.toJson<String>(geometryGeojson),
       'isNew': serializer.toJson<bool>(isNew),
       'status': serializer.toJson<String>(status),
+      'pendingDedupOf': serializer.toJson<String?>(pendingDedupOf),
       'createdAt': serializer.toJson<DateTime>(createdAt),
     };
   }
@@ -1239,6 +1264,7 @@ class Feature extends DataClass implements Insertable<Feature> {
           String? geometryGeojson,
           bool? isNew,
           String? status,
+          Value<String?> pendingDedupOf = const Value.absent(),
           DateTime? createdAt}) =>
       Feature(
         id: id ?? this.id,
@@ -1247,6 +1273,8 @@ class Feature extends DataClass implements Insertable<Feature> {
         geometryGeojson: geometryGeojson ?? this.geometryGeojson,
         isNew: isNew ?? this.isNew,
         status: status ?? this.status,
+        pendingDedupOf:
+            pendingDedupOf.present ? pendingDedupOf.value : this.pendingDedupOf,
         createdAt: createdAt ?? this.createdAt,
       );
   Feature copyWithCompanion(FeaturesCompanion data) {
@@ -1262,6 +1290,9 @@ class Feature extends DataClass implements Insertable<Feature> {
           : this.geometryGeojson,
       isNew: data.isNew.present ? data.isNew.value : this.isNew,
       status: data.status.present ? data.status.value : this.status,
+      pendingDedupOf: data.pendingDedupOf.present
+          ? data.pendingDedupOf.value
+          : this.pendingDedupOf,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
     );
   }
@@ -1275,14 +1306,15 @@ class Feature extends DataClass implements Insertable<Feature> {
           ..write('geometryGeojson: $geometryGeojson, ')
           ..write('isNew: $isNew, ')
           ..write('status: $status, ')
+          ..write('pendingDedupOf: $pendingDedupOf, ')
           ..write('createdAt: $createdAt')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(
-      id, assignmentId, featureType, geometryGeojson, isNew, status, createdAt);
+  int get hashCode => Object.hash(id, assignmentId, featureType,
+      geometryGeojson, isNew, status, pendingDedupOf, createdAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -1293,6 +1325,7 @@ class Feature extends DataClass implements Insertable<Feature> {
           other.geometryGeojson == this.geometryGeojson &&
           other.isNew == this.isNew &&
           other.status == this.status &&
+          other.pendingDedupOf == this.pendingDedupOf &&
           other.createdAt == this.createdAt);
 }
 
@@ -1303,6 +1336,7 @@ class FeaturesCompanion extends UpdateCompanion<Feature> {
   final Value<String> geometryGeojson;
   final Value<bool> isNew;
   final Value<String> status;
+  final Value<String?> pendingDedupOf;
   final Value<DateTime> createdAt;
   final Value<int> rowid;
   const FeaturesCompanion({
@@ -1312,6 +1346,7 @@ class FeaturesCompanion extends UpdateCompanion<Feature> {
     this.geometryGeojson = const Value.absent(),
     this.isNew = const Value.absent(),
     this.status = const Value.absent(),
+    this.pendingDedupOf = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.rowid = const Value.absent(),
   });
@@ -1322,6 +1357,7 @@ class FeaturesCompanion extends UpdateCompanion<Feature> {
     required String geometryGeojson,
     this.isNew = const Value.absent(),
     this.status = const Value.absent(),
+    this.pendingDedupOf = const Value.absent(),
     required DateTime createdAt,
     this.rowid = const Value.absent(),
   })  : id = Value(id),
@@ -1336,6 +1372,7 @@ class FeaturesCompanion extends UpdateCompanion<Feature> {
     Expression<String>? geometryGeojson,
     Expression<bool>? isNew,
     Expression<String>? status,
+    Expression<String>? pendingDedupOf,
     Expression<DateTime>? createdAt,
     Expression<int>? rowid,
   }) {
@@ -1346,6 +1383,7 @@ class FeaturesCompanion extends UpdateCompanion<Feature> {
       if (geometryGeojson != null) 'geometry_geojson': geometryGeojson,
       if (isNew != null) 'is_new': isNew,
       if (status != null) 'status': status,
+      if (pendingDedupOf != null) 'pending_dedup_of': pendingDedupOf,
       if (createdAt != null) 'created_at': createdAt,
       if (rowid != null) 'rowid': rowid,
     });
@@ -1358,6 +1396,7 @@ class FeaturesCompanion extends UpdateCompanion<Feature> {
       Value<String>? geometryGeojson,
       Value<bool>? isNew,
       Value<String>? status,
+      Value<String?>? pendingDedupOf,
       Value<DateTime>? createdAt,
       Value<int>? rowid}) {
     return FeaturesCompanion(
@@ -1367,6 +1406,7 @@ class FeaturesCompanion extends UpdateCompanion<Feature> {
       geometryGeojson: geometryGeojson ?? this.geometryGeojson,
       isNew: isNew ?? this.isNew,
       status: status ?? this.status,
+      pendingDedupOf: pendingDedupOf ?? this.pendingDedupOf,
       createdAt: createdAt ?? this.createdAt,
       rowid: rowid ?? this.rowid,
     );
@@ -1393,6 +1433,9 @@ class FeaturesCompanion extends UpdateCompanion<Feature> {
     if (status.present) {
       map['status'] = Variable<String>(status.value);
     }
+    if (pendingDedupOf.present) {
+      map['pending_dedup_of'] = Variable<String>(pendingDedupOf.value);
+    }
     if (createdAt.present) {
       map['created_at'] = Variable<DateTime>(createdAt.value);
     }
@@ -1411,6 +1454,7 @@ class FeaturesCompanion extends UpdateCompanion<Feature> {
           ..write('geometryGeojson: $geometryGeojson, ')
           ..write('isNew: $isNew, ')
           ..write('status: $status, ')
+          ..write('pendingDedupOf: $pendingDedupOf, ')
           ..write('createdAt: $createdAt, ')
           ..write('rowid: $rowid')
           ..write(')'))
@@ -8838,6 +8882,7 @@ typedef $$FeaturesTableCreateCompanionBuilder = FeaturesCompanion Function({
   required String geometryGeojson,
   Value<bool> isNew,
   Value<String> status,
+  Value<String?> pendingDedupOf,
   required DateTime createdAt,
   Value<int> rowid,
 });
@@ -8848,6 +8893,7 @@ typedef $$FeaturesTableUpdateCompanionBuilder = FeaturesCompanion Function({
   Value<String> geometryGeojson,
   Value<bool> isNew,
   Value<String> status,
+  Value<String?> pendingDedupOf,
   Value<DateTime> createdAt,
   Value<int> rowid,
 });
@@ -8879,6 +8925,10 @@ class $$FeaturesTableFilterComposer
 
   ColumnFilters<String> get status => $composableBuilder(
       column: $table.status, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get pendingDedupOf => $composableBuilder(
+      column: $table.pendingDedupOf,
+      builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get createdAt => $composableBuilder(
       column: $table.createdAt, builder: (column) => ColumnFilters(column));
@@ -8913,6 +8963,10 @@ class $$FeaturesTableOrderingComposer
   ColumnOrderings<String> get status => $composableBuilder(
       column: $table.status, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<String> get pendingDedupOf => $composableBuilder(
+      column: $table.pendingDedupOf,
+      builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<DateTime> get createdAt => $composableBuilder(
       column: $table.createdAt, builder: (column) => ColumnOrderings(column));
 }
@@ -8943,6 +8997,9 @@ class $$FeaturesTableAnnotationComposer
 
   GeneratedColumn<String> get status =>
       $composableBuilder(column: $table.status, builder: (column) => column);
+
+  GeneratedColumn<String> get pendingDedupOf => $composableBuilder(
+      column: $table.pendingDedupOf, builder: (column) => column);
 
   GeneratedColumn<DateTime> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
@@ -8977,6 +9034,7 @@ class $$FeaturesTableTableManager extends RootTableManager<
             Value<String> geometryGeojson = const Value.absent(),
             Value<bool> isNew = const Value.absent(),
             Value<String> status = const Value.absent(),
+            Value<String?> pendingDedupOf = const Value.absent(),
             Value<DateTime> createdAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -8987,6 +9045,7 @@ class $$FeaturesTableTableManager extends RootTableManager<
             geometryGeojson: geometryGeojson,
             isNew: isNew,
             status: status,
+            pendingDedupOf: pendingDedupOf,
             createdAt: createdAt,
             rowid: rowid,
           ),
@@ -8997,6 +9056,7 @@ class $$FeaturesTableTableManager extends RootTableManager<
             required String geometryGeojson,
             Value<bool> isNew = const Value.absent(),
             Value<String> status = const Value.absent(),
+            Value<String?> pendingDedupOf = const Value.absent(),
             required DateTime createdAt,
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -9007,6 +9067,7 @@ class $$FeaturesTableTableManager extends RootTableManager<
             geometryGeojson: geometryGeojson,
             isNew: isNew,
             status: status,
+            pendingDedupOf: pendingDedupOf,
             createdAt: createdAt,
             rowid: rowid,
           ),

--- a/lib/core/db/tables/features.dart
+++ b/lib/core/db/tables/features.dart
@@ -9,6 +9,11 @@ class Features extends Table {
   BoolColumn get isNew => boolean().withDefault(const Constant(false))();
   TextColumn get status =>
       text().withDefault(const Constant('unfilled'))(); // unfilled|in_progress|complete
+  // When the server's dedup-aware upload returns `dedup_pending`, the
+  // UUID of the existing canonical row it might duplicate is stored here.
+  // Non-null = "needs user review"; cleared once the user resolves.
+  // Mirrors the server's `features.possible_duplicate_of` column.
+  TextColumn get pendingDedupOf => text().nullable()();
   DateTimeColumn get createdAt => dateTime()();
 
   @override

--- a/lib/core/sync/data/fake_sync_api.dart
+++ b/lib/core/sync/data/fake_sync_api.dart
@@ -9,37 +9,25 @@ import 'package:firecheck/core/sync/domain/sync_outcome.dart';
 /// Test double whose responses are seeded by the test. Each method consumes
 /// one queued outcome per call; if no responses are queued, returns Success.
 class FakeSyncApi implements SyncApi {
-  final List<SyncOutcome> _submissionResponses = [];
   final List<SyncOutcome> _photoUploadResponses = [];
   final List<SyncOutcome> _photoMarkResponses = [];
-  final List<SyncOutcome> _newFeatureResponses = [];
   final List<SyncOutcome> _featureGeometryUpdateResponses = [];
 
   /// Records of every call, in order, for assertions.
-  final List<Map<String, dynamic>> uploadSubmissionCalls = [];
   final List<({String submissionId, String photoId})> uploadPhotoFileCalls =
       [];
   final List<({String photoId, String storagePath})> markPhotoUploadedCalls =
       [];
-  final List<Feature> uploadNewFeatureCalls = [];
   final List<FeatureGeometryRevision> uploadFeatureGeometryUpdateCalls = [];
 
   /// Configure the next outcome each method should return.
-  void enqueueSubmission(SyncOutcome o) => _submissionResponses.add(o);
   void enqueuePhotoUpload(SyncOutcome o) => _photoUploadResponses.add(o);
   void enqueuePhotoMark(SyncOutcome o) => _photoMarkResponses.add(o);
-  void enqueueNewFeature(SyncOutcome o) => _newFeatureResponses.add(o);
   void enqueueFeatureGeometryUpdate(SyncOutcome o) =>
       _featureGeometryUpdateResponses.add(o);
 
   SyncOutcome _next(List<SyncOutcome> q) =>
       q.isEmpty ? const Success() : q.removeAt(0);
-
-  @override
-  Future<SyncOutcome> uploadSubmission(Map<String, dynamic> payload) async {
-    uploadSubmissionCalls.add(payload);
-    return _next(_submissionResponses);
-  }
 
   @override
   Future<({SyncOutcome outcome, String? storagePath})> uploadPhotoFile({
@@ -60,12 +48,6 @@ class FakeSyncApi implements SyncApi {
   }) async {
     markPhotoUploadedCalls.add((photoId: photoId, storagePath: storagePath));
     return _next(_photoMarkResponses);
-  }
-
-  @override
-  Future<SyncOutcome> uploadNewFeature(Feature feature) async {
-    uploadNewFeatureCalls.add(feature);
-    return _next(_newFeatureResponses);
   }
 
   @override

--- a/lib/core/sync/data/supabase_sync_api.dart
+++ b/lib/core/sync/data/supabase_sync_api.dart
@@ -13,23 +13,6 @@ class SupabaseSyncApi implements SyncApi {
   static const _photosBucket = 'photos';
 
   @override
-  Future<SyncOutcome> uploadSubmission(Map<String, dynamic> payload) async {
-    try {
-      await _client.rpc<dynamic>(
-        'upload_submission_bundle',
-        params: {'payload': payload},
-      );
-      return const Success();
-    } on PostgrestException catch (e) {
-      return _mapPostgrestException(e, payload);
-    } on AuthException {
-      return const AuthExpired();
-    } on Object catch (e) {
-      return TransientFailure(e.toString());
-    }
-  }
-
-  @override
   Future<({SyncOutcome outcome, String? storagePath})> uploadPhotoFile({
     required String submissionId,
     required String photoId,
@@ -64,35 +47,6 @@ class SupabaseSyncApi implements SyncApi {
       await _client.from('photos').update({
         'storage_path': storagePath,
       }).eq('id', photoId);
-      return const Success();
-    } on PostgrestException catch (e) {
-      return _mapPostgrestException(e, null);
-    } on AuthException {
-      return const AuthExpired();
-    } on Object catch (e) {
-      return TransientFailure(e.toString());
-    }
-  }
-
-  @override
-  Future<SyncOutcome> uploadNewFeature(Feature feature) async {
-    try {
-      // Goes through upload_new_feature RPC because features.geometry is
-      // PostGIS — PostgREST can't auto-convert raw GeoJSON. The RPC uses
-      // ST_GeomFromGeoJSON server-side.
-      await _client.rpc<dynamic>(
-        'upload_new_feature',
-        params: {
-          'payload': {
-            'id': feature.id,
-            'assignment_id': feature.assignmentId,
-            'feature_type': feature.featureType,
-            'geometry_geojson': feature.geometryGeojson,
-            'is_new': feature.isNew,
-            'created_at': feature.createdAt.toIso8601String(),
-          },
-        },
-      );
       return const Success();
     } on PostgrestException catch (e) {
       return _mapPostgrestException(e, null);

--- a/lib/core/sync/data/sync_api.dart
+++ b/lib/core/sync/data/sync_api.dart
@@ -8,8 +8,6 @@ import 'package:firecheck/core/sync/domain/sync_outcome.dart';
 /// Network surface area required by SyncWorker. Real impl in
 /// supabase_sync_api.dart; in-memory fake in fake_sync_api.dart.
 abstract class SyncApi {
-  Future<SyncOutcome> uploadSubmission(Map<String, dynamic> payload);
-
   /// Uploads a photo file to Storage, returning the storage_path on success.
   /// Encoded as a SyncOutcome to handle 401/409/permanent/transient uniformly.
   Future<({SyncOutcome outcome, String? storagePath})> uploadPhotoFile({
@@ -22,8 +20,6 @@ abstract class SyncApi {
     required String photoId,
     required String storagePath,
   });
-
-  Future<SyncOutcome> uploadNewFeature(Feature feature);
 
   Future<SyncOutcome> uploadFeatureGeometryUpdate(FeatureGeometryRevision revision);
 

--- a/lib/core/sync/data/sync_jobs_repository.dart
+++ b/lib/core/sync/data/sync_jobs_repository.dart
@@ -16,16 +16,11 @@ class SyncJobsRepository {
     return _db.transaction(() async {
       // Gate two interlocking conditions:
       //   1. Photo jobs that block on a submission wait for the local
-      //      submission row to reach sync_status='uploaded' — that's the
-      //      same terminal state for both the legacy `submission` path
-      //      and the new `attribution_upload` path, so this gate is
-      //      type-agnostic.
+      //      submission row to reach sync_status='uploaded'.
       //   2. Attribution upload jobs whose feature is new wait for the
       //      corresponding new-feature upload job to reach `success`.
       //      Otherwise the submission's feature_id FK fails on the
-      //      server. Both legacy (`submission` / `new_feature`) and new
-      //      (`attribution_upload` / `new_feature_upload`) variants are
-      //      accepted on either side.
+      //      server.
       final raw = await _db.customSelect(
         '''
         SELECT j.* FROM sync_jobs j
@@ -39,7 +34,7 @@ class SyncJobsRepository {
             )
           )
           AND NOT (
-            j.entity_type IN ('submission','attribution_upload')
+            j.entity_type = 'attribution_upload'
             AND EXISTS (
               SELECT 1 FROM submissions s2
               JOIN features f2 ON f2.id = s2.feature_id
@@ -47,7 +42,7 @@ class SyncJobsRepository {
                 AND f2.is_new = 1
                 AND NOT EXISTS (
                   SELECT 1 FROM sync_jobs nf
-                  WHERE nf.entity_type IN ('new_feature','new_feature_upload')
+                  WHERE nf.entity_type = 'new_feature_upload'
                     AND nf.entity_id = f2.id
                     AND nf.status = 'success'
                 )
@@ -55,9 +50,7 @@ class SyncJobsRepository {
           )
         ORDER BY (
           CASE j.entity_type
-            WHEN 'new_feature'         THEN 0
             WHEN 'new_feature_upload'  THEN 0
-            WHEN 'submission'          THEN 1
             WHEN 'attribution_upload'  THEN 1
             ELSE                            2
           END

--- a/lib/core/sync/domain/finalize_submission.dart
+++ b/lib/core/sync/domain/finalize_submission.dart
@@ -30,14 +30,10 @@ class FinalizeSubmissionUseCase {
       ),);
 
       // 2. Submission sync_job (skip-if-exists). Routes through the
-      // conflict-aware RPC. A stale enqueue under the legacy
-      // `submission` type is also treated as "already queued" so we
-      // don't double-upload mid-rollout.
-      final existingNew =
+      // conflict-aware RPC.
+      final existing =
           await _findJob(SyncEntityType.attributionUpload, submissionId);
-      final existingLegacy =
-          await _findJob(SyncEntityType.submission, submissionId);
-      if (existingNew == null && existingLegacy == null) {
+      if (existing == null) {
         await _db.into(_db.syncJobs).insert(SyncJobsCompanion.insert(
               id: _uuid.v4(),
               entityType: SyncEntityType.attributionUpload,
@@ -65,7 +61,7 @@ class FinalizeSubmissionUseCase {
       }
 
       // 4. New-feature sync_job if applicable (skip-if-exists). Routes
-      // through the dedup-aware RPC; legacy entry tolerated.
+      // through the dedup-aware RPC.
       final submission = await (_db.select(_db.submissions)
             ..where((t) => t.id.equals(submissionId)))
           .getSingle();
@@ -74,11 +70,9 @@ class FinalizeSubmissionUseCase {
           .getSingle();
       var newFeatureQueued = false;
       if (feature.isNew) {
-        final existingNew =
+        final existing =
             await _findJob(SyncEntityType.newFeatureUpload, feature.id);
-        final existingLegacy =
-            await _findJob(SyncEntityType.newFeature, feature.id);
-        if (existingNew == null && existingLegacy == null) {
+        if (existing == null) {
           await _db.into(_db.syncJobs).insert(SyncJobsCompanion.insert(
                 id: _uuid.v4(),
                 entityType: SyncEntityType.newFeatureUpload,

--- a/lib/core/sync/domain/sync_entity_type.dart
+++ b/lib/core/sync/domain/sync_entity_type.dart
@@ -1,22 +1,15 @@
 /// String constants used in sync_jobs.entity_type.
 ///
-/// The conflict/dedup-aware types route through their respective RPCs:
+/// All upload paths route through the conflict / dedup-aware RPCs:
 ///   - attributionUpload     → submit_attribution_with_conflict_check
 ///   - attributionResolve    → resolve_attribution
 ///   - newFeatureUpload      → submit_new_feature_with_dedup_check
 ///   - newFeatureResolve     → resolve_new_feature
-///
-/// The legacy [submission] and [newFeature] types remain (and still work)
-/// for one release as a fallback. New submissions enqueue under the new
-/// types; the legacy code paths will be removed in a follow-up release.
 class SyncEntityType {
   SyncEntityType._();
-  static const submission = 'submission';
   static const photo = 'photo';
-  static const newFeature = 'new_feature';
   static const featureGeometryUpdate = 'feature_geometry_update';
 
-  // Multi-user attribution sync types.
   static const attributionUpload = 'attribution_upload';
   static const attributionResolve = 'attribution_resolve';
   static const newFeatureUpload = 'new_feature_upload';

--- a/lib/core/sync/worker/sync_worker.dart
+++ b/lib/core/sync/worker/sync_worker.dart
@@ -80,12 +80,8 @@ class SyncWorker {
   Future<SyncOutcome> _execute(SyncJob job) async {
     try {
       switch (job.entityType) {
-        case SyncEntityType.submission:
-          return await _executeSubmission(job.entityId);
         case SyncEntityType.photo:
           return await _executePhoto(job.entityId);
-        case SyncEntityType.newFeature:
-          return await _executeNewFeature(job.entityId);
         case SyncEntityType.featureGeometryUpdate:
           return await _executeFeatureGeometryUpdate(job.entityId);
         case SyncEntityType.attributionUpload:
@@ -102,17 +98,6 @@ class SyncWorker {
     } on Object catch (e) {
       return TransientFailure(e.toString());
     }
-  }
-
-  Future<SyncOutcome> _executeSubmission(String submissionId) async {
-    final json = await payload.build(submissionId);
-    final outcome = await api.uploadSubmission(json);
-    if (outcome is Success) {
-      await (db.update(db.submissions)
-            ..where((t) => t.id.equals(submissionId)))
-          .write(const SubmissionsCompanion(syncStatus: Value('uploaded')));
-    }
-    return outcome;
   }
 
   Future<SyncOutcome> _executePhoto(String photoId) async {
@@ -144,13 +129,6 @@ class SyncWorker {
       );
     }
     return mark;
-  }
-
-  Future<SyncOutcome> _executeNewFeature(String featureId) async {
-    final feature = await (db.select(db.features)
-          ..where((t) => t.id.equals(featureId)))
-        .getSingle();
-    return api.uploadNewFeature(feature);
   }
 
   Future<SyncOutcome> _executeFeatureGeometryUpdate(String revisionId) async {
@@ -242,7 +220,25 @@ class SyncWorker {
       'created_at': feature.createdAt.toIso8601String(),
     };
     final response = await api.submitNewFeatureWithDedup(payload);
-    return response.outcome;
+    if (response.outcome is! Success) return response.outcome;
+    final result = response.result!;
+    switch (result) {
+      case NewFeatureCommitted():
+        // Nothing to persist locally — the feature already exists in our
+        // table and is now canonical on the server too.
+        break;
+      case NewFeatureDedupPending(:final possibleDuplicateOf):
+        // Persist the duplicate pointer so the review list can surface
+        // the feature and the user can pick a resolution. Without this,
+        // a dedup_pending response looks identical to committed and the
+        // user never sees the prompt.
+        await (db.update(db.features)
+              ..where((t) => t.id.equals(featureId)))
+            .write(
+          FeaturesCompanion(pendingDedupOf: Value(possibleDuplicateOf)),
+        );
+    }
+    return const Success();
   }
 
   /// Reads the queued decision out of `pending_resolutions`, calls
@@ -308,10 +304,18 @@ class SyncWorker {
     );
     if (outcome is! Success) return outcome;
 
-    await (db.delete(db.pendingResolutions)
-          ..where((t) =>
-              t.targetId.equals(featureId) & t.kind.equals('new_feature'),))
-        .go();
+    await db.transaction(() async {
+      // Clear the local pendingDedupOf marker so the review list stops
+      // surfacing this feature. The server has now consolidated state
+      // via the audit log + supersede chain.
+      await (db.update(db.features)
+            ..where((t) => t.id.equals(featureId)))
+          .write(const FeaturesCompanion(pendingDedupOf: Value(null)));
+      await (db.delete(db.pendingResolutions)
+            ..where((t) =>
+                t.targetId.equals(featureId) & t.kind.equals('new_feature'),))
+          .go();
+    });
     return const Success();
   }
 

--- a/lib/features/conflict_review/data/conflict_review_repository.dart
+++ b/lib/features/conflict_review/data/conflict_review_repository.dart
@@ -29,22 +29,13 @@ class ConflictReviewRepository {
         .watch();
   }
 
-  /// Streams local features parked in dedup review — i.e. the feature
-  /// row is `is_new = true` and the proximity trigger flagged a
-  /// possible duplicate, and the user hasn't reviewed yet.
-  ///
-  /// The local features table doesn't carry possible_duplicate_of /
-  /// dedup_reviewed_at (those are server columns). Instead we surface
-  /// pending dedup reviews via the queued sync_jobs:
-  /// `new_feature_upload` jobs in `failed`/`dead` status, OR via the
-  /// pending_resolutions queue if the user already picked.
-  ///
-  /// For phase 5 we expose the simpler "features that have a queued
-  /// `pending_resolutions` row of kind=new_feature" — that's the user-
-  /// pickable set.
-  Stream<List<PendingResolution>> watchPendingDedupResolutions() {
-    return (_db.select(_db.pendingResolutions)
-          ..where((t) => t.kind.equals('new_feature'))
+  /// Streams local features parked in dedup review — i.e. the
+  /// dedup-aware upload returned `dedup_pending` and the local row was
+  /// flagged via `pendingDedupOf`. Cleared when the worker drains the
+  /// matching `new_feature_resolve` sync_job.
+  Stream<List<Feature>> watchPendingDedupFeatures() {
+    return (_db.select(_db.features)
+          ..where((t) => t.pendingDedupOf.isNotNull())
           ..orderBy([
             (t) => OrderingTerm(
                   expression: t.createdAt,

--- a/lib/features/conflict_review/presentation/conflict_review_list_screen.dart
+++ b/lib/features/conflict_review/presentation/conflict_review_list_screen.dart
@@ -36,7 +36,7 @@ class ConflictReviewListScreen extends ConsumerWidget {
                 for (final s in subs) _SubmissionTile(submission: s),
                 if (dedup.isNotEmpty)
                   const _SectionHeader('New-feature dedup'),
-                for (final r in dedup) _DedupTile(resolution: r),
+                for (final f in dedup) _DedupTile(feature: f),
               ],
             );
           },
@@ -123,29 +123,33 @@ class _SubmissionTile extends StatelessWidget {
 }
 
 class _DedupTile extends StatelessWidget {
-  const _DedupTile({required this.resolution});
-  final PendingResolution resolution;
+  const _DedupTile({required this.feature});
+  final Feature feature;
 
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      key: Key('conflict-review.dedup.${resolution.targetId}'),
+      key: Key('conflict-review.dedup.${feature.id}'),
       leading: const CircleAvatar(
         backgroundColor: Color(0xFFFFCDD2),
         child: Icon(Icons.merge_type, color: Color(0xFFB71C1C)),
       ),
-      title: Text('New feature ${_short(resolution.targetId)}',
-          style: const TextStyle(fontWeight: FontWeight.w600)),
+      title: Text(
+        '${_capitalize(feature.featureType)} ${_short(feature.id)}',
+        style: const TextStyle(fontWeight: FontWeight.w600),
+      ),
       subtitle: Text(
-        'Pending: ${resolution.decision} '
-        '${resolution.resolutionNote == null ? '' : '— ${resolution.resolutionNote}'}',
+        'Possible duplicate of ${_short(feature.pendingDedupOf ?? '?')}',
       ),
       trailing: const Icon(Icons.chevron_right),
       onTap: () => context.push(
-        '/resolve/dedup/${Uri.encodeComponent(resolution.targetId)}',
+        '/resolve/dedup/${Uri.encodeComponent(feature.id)}',
       ),
     );
   }
 }
+
+String _capitalize(String s) =>
+    s.isEmpty ? s : '${s[0].toUpperCase()}${s.substring(1)}';
 
 String _short(String s) => s.length <= 8 ? s : s.substring(0, 8);

--- a/lib/features/conflict_review/presentation/conflict_review_providers.dart
+++ b/lib/features/conflict_review/presentation/conflict_review_providers.dart
@@ -16,15 +16,14 @@ final awaitingSubmissionsProvider = StreamProvider<List<Submission>>((ref) {
       .watchAwaitingSubmissions();
 });
 
-/// Stream of pending dedup decisions (kind=new_feature in
-/// pending_resolutions). Tracks the user-pickable dedup set for now;
-/// fuller "all features with possible_duplicate_of set" wiring will
-/// follow once the local features table mirrors the server's dedup cols.
-final pendingDedupProvider =
-    StreamProvider<List<PendingResolution>>((ref) {
+/// Stream of features awaiting dedup review — `pendingDedupOf` is set
+/// by the worker when `submit_new_feature_with_dedup_check` returns
+/// `dedup_pending`. Cleared when the matching `new_feature_resolve`
+/// job runs to completion.
+final pendingDedupProvider = StreamProvider<List<Feature>>((ref) {
   return ref
       .watch(conflictReviewRepositoryProvider)
-      .watchPendingDedupResolutions();
+      .watchPendingDedupFeatures();
 });
 
 /// Flattened local attribution for a given submission, refreshed when

--- a/supabase/migrations/029_cleanup_orphan_photos.sql
+++ b/supabase/migrations/029_cleanup_orphan_photos.sql
@@ -75,7 +75,11 @@ end $$;
 
 revoke all on function public.cleanup_orphan_photos() from public;
 revoke all on function public.cleanup_orphan_photos() from authenticated;
--- service_role keeps its implicit privilege; pg_cron runs as superuser.
+-- `security definer` only sets the *runtime* identity; callers still need
+-- their own EXECUTE grant. service_role does not inherit it from public,
+-- so the explicit grant below is what makes manual invocations work on
+-- environments without pg_cron. (pg_cron itself runs as superuser.)
+grant execute on function public.cleanup_orphan_photos() to service_role;
 
 -- Schedule nightly at 03:00 UTC if pg_cron is available. Safe to run
 -- on instances without pg_cron — the do-block silently skips.

--- a/supabase/migrations/029_cleanup_orphan_photos.sql
+++ b/supabase/migrations/029_cleanup_orphan_photos.sql
@@ -1,0 +1,97 @@
+-- supabase/migrations/029_cleanup_orphan_photos.sql
+-- Scheduled cleanup of orphaned photo storage objects.
+--
+-- Orphans accumulate from the conflict / dedup review flows:
+--   * `agreed_skip` deletes the loser's `submissions` row outright
+--     (and its `building_attributes` / `road_attributes` / `household_surveys`),
+--     cascading to its `photos` rows via `on delete cascade`. The storage
+--     objects under bucket `photos` survive the cascade.
+--   * `resolve_attribution(keep_theirs)` deletes the pending submission
+--     the same way.
+--   * `resolve_new_feature(discard_mine)` soft-deletes a submission via
+--     `superseded_at = now(), superseded_by_id = null` — the photo rows
+--     stay but their content is no longer needed.
+--
+-- This migration adds a `cleanup_orphan_photos()` function and (if
+-- pg_cron is enabled) schedules it nightly. Manual invocation via
+-- `select public.cleanup_orphan_photos();` is also supported.
+--
+-- The function is intentionally `security definer` and not granted to
+-- `authenticated` — only `service_role` and pg_cron run it.
+
+create or replace function public.cleanup_orphan_photos()
+returns table(deleted_objects int, deleted_photo_rows int)
+language plpgsql
+security definer
+as $$
+declare
+  v_deleted_objects int := 0;
+  v_deleted_rows int := 0;
+begin
+  -- Step 1: explicit "discard" submissions (superseded_at IS NOT NULL,
+  -- superseded_by_id IS NULL). Their photo rows still exist; remove the
+  -- storage objects + rows together.
+  with discarded as (
+    select p.id as photo_id, p.storage_path
+    from public.photos p
+    join public.submissions s on s.id = p.submission_id
+    where s.superseded_at is not null
+      and s.superseded_by_id is null
+      and p.storage_path is not null
+  ),
+  obj_delete as (
+    delete from storage.objects o
+    where o.bucket_id = 'photos'
+      and o.name in (select storage_path from discarded)
+    returning 1
+  )
+  select count(*) into v_deleted_objects from obj_delete;
+
+  delete from public.photos p
+  using public.submissions s
+  where s.id = p.submission_id
+    and s.superseded_at is not null
+    and s.superseded_by_id is null;
+  get diagnostics v_deleted_rows = row_count;
+
+  -- Step 2: storage objects with no `photos.storage_path` reference at
+  -- all (left behind by deleted submissions or external manual edits).
+  with stranded as (
+    delete from storage.objects o
+    where o.bucket_id = 'photos'
+      and not exists (
+        select 1 from public.photos p where p.storage_path = o.name
+      )
+    returning 1
+  )
+  select v_deleted_objects + count(*)
+    into v_deleted_objects
+    from stranded;
+
+  deleted_objects := v_deleted_objects;
+  deleted_photo_rows := v_deleted_rows;
+  return next;
+end $$;
+
+revoke all on function public.cleanup_orphan_photos() from public;
+revoke all on function public.cleanup_orphan_photos() from authenticated;
+-- service_role keeps its implicit privilege; pg_cron runs as superuser.
+
+-- Schedule nightly at 03:00 UTC if pg_cron is available. Safe to run
+-- on instances without pg_cron — the do-block silently skips.
+do $$
+begin
+  if exists (select 1 from pg_extension where extname = 'pg_cron') then
+    -- Drop any prior schedule with this name to make the migration
+    -- idempotent across re-applies.
+    perform cron.unschedule('cleanup-orphan-photos')
+      where exists (
+        select 1 from cron.job where jobname = 'cleanup-orphan-photos'
+      );
+    perform cron.schedule(
+      'cleanup-orphan-photos',
+      '0 3 * * *',
+      $cron$ select public.cleanup_orphan_photos(); $cron$
+    );
+  end if;
+end $$;

--- a/test/core/db/migration_v12_to_v13_test.dart
+++ b/test/core/db/migration_v12_to_v13_test.dart
@@ -1,0 +1,69 @@
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Verifies the v12 → v13 migration rewrites legacy sync_job entity_type
+/// strings so an offline queue from a prior install doesn't dead-letter
+/// after the legacy handlers are removed.
+void main() {
+  test(
+    'legacy submission / new_feature sync_jobs are rewritten to the new types',
+    () async {
+      final db = AppDatabase.forTesting(
+        NativeDatabase.memory(
+          setup: (rawDb) {
+            // Seed the DB at v12 so onUpgrade fires only the v12→v13
+            // step. Below we materialise just the columns the rewrite
+            // statements touch — the test doesn't need a fully
+            // representative schema.
+            rawDb.execute('PRAGMA user_version = 12');
+            rawDb.execute('''
+              CREATE TABLE IF NOT EXISTS sync_jobs (
+                id TEXT NOT NULL PRIMARY KEY,
+                entity_type TEXT NOT NULL,
+                entity_id TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                blocks_on_submission_id TEXT,
+                attempts INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT,
+                next_retry_at INTEGER,
+                created_at INTEGER NOT NULL
+              )
+            ''');
+            // Two legacy rows, one already-migrated row, one unrelated
+            // type (photo). Only the first two should be rewritten.
+            rawDb.execute(
+              "INSERT INTO sync_jobs(id, entity_type, entity_id, created_at) "
+              "VALUES ('j1', 'submission', 's1', 0), "
+              "       ('j2', 'new_feature', 'f1', 0), "
+              "       ('j3', 'attribution_upload', 's2', 0), "
+              "       ('j4', 'photo', 'p1', 0)",
+            );
+          },
+        ),
+      );
+      addTearDown(db.close);
+
+      // Touch the DB so onUpgrade fires.
+      final jobs = await (db.select(db.syncJobs)).get();
+      expect(jobs, hasLength(4));
+
+      Future<String> typeOf(String id) async {
+        final j = await (db.select(db.syncJobs)
+              ..where((t) => t.id.equals(id)))
+            .getSingle();
+        return j.entityType;
+      }
+
+      expect(await typeOf('j1'), 'attribution_upload',
+          reason: 'legacy submission rewrites to attribution_upload');
+      expect(await typeOf('j2'), 'new_feature_upload',
+          reason: 'legacy new_feature rewrites to new_feature_upload');
+      expect(await typeOf('j3'), 'attribution_upload',
+          reason: 'already-new rows are left alone');
+      expect(await typeOf('j4'), 'photo',
+          reason: 'unrelated types are left alone');
+    },
+  );
+}

--- a/test/core/db/migration_v7_to_v8_test.dart
+++ b/test/core/db/migration_v7_to_v8_test.dart
@@ -154,9 +154,9 @@ void main() {
               drive_folder_id TEXT
             )
           ''');
-          // submissions: later migrations (v10→v11) `addColumn` to this
-          // table, so it must exist in the seeded v7 schema even though
-          // this test is scoped to v7→v8.
+          // submissions / features: later migrations (v10→v11, v11→v12)
+          // `addColumn` to these tables, so they must exist in the
+          // seeded v7 schema even though this test is scoped to v7→v8.
           rawDb.execute('''
             CREATE TABLE IF NOT EXISTS submissions (
               id TEXT NOT NULL PRIMARY KEY,
@@ -168,6 +168,17 @@ void main() {
               override_reason TEXT,
               created_at INTEGER NOT NULL,
               updated_at INTEGER NOT NULL
+            )
+          ''');
+          rawDb.execute('''
+            CREATE TABLE IF NOT EXISTS features (
+              id TEXT NOT NULL PRIMARY KEY,
+              assignment_id TEXT NOT NULL,
+              feature_type TEXT NOT NULL,
+              geometry_geojson TEXT NOT NULL,
+              is_new INTEGER NOT NULL DEFAULT 0,
+              status TEXT NOT NULL DEFAULT 'unfilled',
+              created_at INTEGER NOT NULL
             )
           ''');
         },

--- a/test/core/db/migration_v7_to_v8_test.dart
+++ b/test/core/db/migration_v7_to_v8_test.dart
@@ -181,6 +181,22 @@ void main() {
               created_at INTEGER NOT NULL
             )
           ''');
+          // sync_jobs: the v12→v13 step rewrites legacy entity_type
+          // values in this table, so it must exist in the seeded v7
+          // schema even though this test is scoped to v7→v8.
+          rawDb.execute('''
+            CREATE TABLE IF NOT EXISTS sync_jobs (
+              id TEXT NOT NULL PRIMARY KEY,
+              entity_type TEXT NOT NULL,
+              entity_id TEXT NOT NULL,
+              status TEXT NOT NULL DEFAULT 'pending',
+              blocks_on_submission_id TEXT,
+              attempts INTEGER NOT NULL DEFAULT 0,
+              last_error TEXT,
+              next_retry_at INTEGER,
+              created_at INTEGER NOT NULL
+            )
+          ''');
         },
       ),
     );

--- a/test/core/sync/data/remote_attributions_pull_service_test.dart
+++ b/test/core/sync/data/remote_attributions_pull_service_test.dart
@@ -170,7 +170,13 @@ void main() {
     ];
     api.newFeatures = const [];
 
-    final svc = RemoteAttributionsPullService(api: api, cache: cache);
+    // Pin `now` so the cursor freshness check doesn't depend on wall-clock
+    // time at test execution (otherwise this test goes stale after 24h).
+    final svc = RemoteAttributionsPullService(
+      api: api,
+      cache: cache,
+      now: () => DateTime.utc(2026, 5, 18, 11),
+    );
     final result = await svc.pullDelta('a1');
 
     expect(result.kind, PullKind.delta);

--- a/test/core/sync/data/sync_jobs_repository_test.dart
+++ b/test/core/sync/data/sync_jobs_repository_test.dart
@@ -68,7 +68,7 @@ void main() {
 
   test('claimUpToN returns up to N pending jobs and marks them in_progress',
       () async {
-    await insertJob(id: 'j1', entityType: 'submission', entityId: 's1');
+    await insertJob(id: 'j1', entityType: 'attribution_upload', entityId: 's1');
     final claimed = await repo.claimUpToN(3, now: now);
     expect(claimed, hasLength(1));
     expect(claimed.first.id, 'j1');
@@ -82,7 +82,7 @@ void main() {
       () async {
     await insertJob(
       id: 'j1',
-      entityType: 'submission',
+      entityType: 'attribution_upload',
       entityId: 's1',
       nextRetry: now.add(const Duration(minutes: 5)),
     );
@@ -93,7 +93,7 @@ void main() {
   test('claimUpToN claims a job whose next_retry_at has elapsed', () async {
     await insertJob(
       id: 'j1',
-      entityType: 'submission',
+      entityType: 'attribution_upload',
       entityId: 's1',
       nextRetry: now.subtract(const Duration(minutes: 1)),
     );
@@ -101,13 +101,13 @@ void main() {
     expect(claimed, hasLength(1));
   });
 
-  test('claimUpToN orders submission jobs first, then by created_at',
+  test('claimUpToN orders attribution_upload jobs ahead of photos',
       () async {
     await insertJob(
         id: 'j-photo', entityType: 'photo', entityId: 'p1',);
     await insertJob(
         id: 'j-sub',
-        entityType: 'submission',
+        entityType: 'attribution_upload',
         entityId: 's1',
         createdAtOffset: const Duration(seconds: 1),);
     final claimed = await repo.claimUpToN(2, now: now);
@@ -154,7 +154,7 @@ void main() {
   });
 
   test('markSuccess transitions to success', () async {
-    await insertJob(id: 'j1', entityType: 'submission', entityId: 's1');
+    await insertJob(id: 'j1', entityType: 'attribution_upload', entityId: 's1');
     await repo.markSuccess('j1');
     final r = await (db.select(db.syncJobs)..where((t) => t.id.equals('j1')))
         .getSingle();
@@ -163,7 +163,7 @@ void main() {
 
   test('markPendingRetry advances attempts + sets next_retry_at + lastError',
       () async {
-    await insertJob(id: 'j1', entityType: 'submission', entityId: 's1');
+    await insertJob(id: 'j1', entityType: 'attribution_upload', entityId: 's1');
     final scheduled = now.add(const Duration(seconds: 30));
     await repo.markPendingRetry(
       'j1',
@@ -180,7 +180,7 @@ void main() {
   });
 
   test('markDead transitions to dead', () async {
-    await insertJob(id: 'j1', entityType: 'submission', entityId: 's1');
+    await insertJob(id: 'j1', entityType: 'attribution_upload', entityId: 's1');
     await repo.markDead('j1', error: '4xx', attempts: 5);
     final r = await (db.select(db.syncJobs)..where((t) => t.id.equals('j1')))
         .getSingle();
@@ -191,9 +191,9 @@ void main() {
 
   test('findByEntity returns existing job or null', () async {
     expect(
-        await repo.findByEntity(SyncEntityType.submission, 's1'), isNull,);
-    await insertJob(id: 'j1', entityType: 'submission', entityId: 's1');
-    final found = await repo.findByEntity(SyncEntityType.submission, 's1');
+        await repo.findByEntity(SyncEntityType.attributionUpload, 's1'), isNull,);
+    await insertJob(id: 'j1', entityType: 'attribution_upload', entityId: 's1');
+    final found = await repo.findByEntity(SyncEntityType.attributionUpload, 's1');
     expect(found, isNotNull);
     expect(found!.id, 'j1');
   });

--- a/test/core/sync/worker/new_feature_upload_dedup_test.dart
+++ b/test/core/sync/worker/new_feature_upload_dedup_test.dart
@@ -1,0 +1,130 @@
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
+import 'package:firecheck/core/db/database.dart';
+import 'package:firecheck/core/sync/data/fake_sync_api.dart';
+import 'package:firecheck/core/sync/data/submission_payload_builder.dart';
+import 'package:firecheck/core/sync/data/sync_jobs_repository.dart';
+import 'package:firecheck/core/sync/domain/resolution_decision.dart';
+import 'package:firecheck/core/sync/domain/submit_attribution_result.dart';
+import 'package:firecheck/core/sync/domain/sync_entity_type.dart';
+import 'package:firecheck/core/sync/failure/assignment_lock_repository.dart';
+import 'package:firecheck/core/sync/worker/sync_worker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Regression coverage for the P1 fix: when `submit_new_feature_with_dedup_check`
+/// returns `dedup_pending`, the worker MUST persist the duplicate pointer
+/// locally so the review screen can surface the feature.
+void main() {
+  late AppDatabase db;
+  late FakeSyncApi api;
+  late SyncWorker worker;
+  final now = DateTime.utc(2026, 5, 19, 10);
+
+  Future<void> seedFeature() async {
+    await db.into(db.assignments).insert(
+          AssignmentsCompanion.insert(
+            id: 'a1',
+            enumeratorId: 'me',
+            campaignId: 'c1',
+            boundaryPolygonGeojson: '{}',
+            createdAt: now,
+          ),
+        );
+    await db.into(db.features).insert(
+          FeaturesCompanion.insert(
+            id: 'f1',
+            assignmentId: 'a1',
+            featureType: 'building',
+            geometryGeojson: '{}',
+            isNew: const Value(true),
+            createdAt: now,
+          ),
+        );
+  }
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    api = FakeSyncApi();
+    worker = SyncWorker(
+      api: api,
+      jobs: SyncJobsRepository(db),
+      payload: SubmissionPayloadBuilder(db),
+      lock: AssignmentLockRepository(db),
+      db: db,
+    );
+    await seedFeature();
+    await db.into(db.syncJobs).insert(
+          SyncJobsCompanion.insert(
+            id: 'job-uuid-0000-0001',
+            entityType: SyncEntityType.newFeatureUpload,
+            entityId: 'f1',
+            createdAt: now,
+          ),
+        );
+  });
+
+  tearDown(() => db.close());
+
+  Future<Feature> currentFeature() =>
+      (db.select(db.features)..where((t) => t.id.equals('f1'))).getSingle();
+
+  test('committed → pendingDedupOf stays null', () async {
+    api.enqueueSubmitNewFeature(
+      result: const NewFeatureCommitted('f1'),
+    );
+    await worker.drain();
+    final f = await currentFeature();
+    expect(f.pendingDedupOf, isNull);
+  });
+
+  test(
+      'dedup_pending → pendingDedupOf set so the review list surfaces the feature',
+      () async {
+    api.enqueueSubmitNewFeature(
+      result: const NewFeatureDedupPending(
+        pendingId: 'f1',
+        possibleDuplicateOf: 'f_remote',
+      ),
+    );
+    await worker.drain();
+    final f = await currentFeature();
+    expect(f.pendingDedupOf, 'f_remote');
+
+    // Worker still treats the job as completed — parking is local-state,
+    // not job-state.
+    final job = await (db.select(db.syncJobs)
+          ..where((t) => t.id.equals('job-uuid-0000-0001')))
+        .getSingle();
+    expect(job.status, 'success');
+  });
+
+  test('newFeatureResolve → pendingDedupOf cleared on success', () async {
+    // Pretend dedup_pending already landed.
+    await (db.update(db.features)..where((t) => t.id.equals('f1'))).write(
+      const FeaturesCompanion(pendingDedupOf: Value('f_remote')),
+    );
+    await db.into(db.pendingResolutions).insert(
+          PendingResolutionsCompanion.insert(
+            targetId: 'f1',
+            kind: 'new_feature',
+            decision: DedupDecision.keepBoth.wire,
+            createdAt: now,
+          ),
+        );
+    await db.into(db.syncJobs).insert(
+          SyncJobsCompanion.insert(
+            id: 'job-uuid-0000-0002',
+            entityType: SyncEntityType.newFeatureResolve,
+            entityId: 'f1',
+            createdAt: now,
+          ),
+        );
+
+    await worker.drain();
+
+    final f = await currentFeature();
+    expect(f.pendingDedupOf, isNull);
+    final pr = await db.select(db.pendingResolutions).get();
+    expect(pr, isEmpty);
+  });
+}

--- a/test/core/sync/worker/sync_worker_assignment_closed_test.dart
+++ b/test/core/sync/worker/sync_worker_assignment_closed_test.dart
@@ -77,6 +77,6 @@ void main() {
       db: db,
     );
     await worker.drain();
-    expect(api.uploadSubmissionCalls, isEmpty);
+    expect(api.submitAttributionCalls, isEmpty);
   });
 }

--- a/test/core/sync/worker/sync_worker_happy_path_test.dart
+++ b/test/core/sync/worker/sync_worker_happy_path_test.dart
@@ -71,12 +71,9 @@ void main() {
         .getSingle();
     expect(sub.syncStatus, 'uploaded');
 
-    // FinalizeSubmissionUseCase now enqueues `attribution_upload`, which
-    // routes through the conflict-aware RPC. The legacy `uploadSubmission`
-    // surface stays for any in-flight legacy jobs from before the
-    // rollout but is not exercised here.
+    // FinalizeSubmissionUseCase enqueues `attribution_upload` and the
+    // worker routes through the conflict-aware RPC.
     expect(api.submitAttributionCalls, hasLength(1));
-    expect(api.uploadSubmissionCalls, isEmpty);
   });
 
   test('drain() de-dupes overlapping calls', () async {


### PR DESCRIPTION
## Summary

Three changes bundled:

1. **P1 fix from PR #59 review** — dedup-pending uploads now surface in the review list.
2. **Decommission the legacy upload path** — the client no longer enqueues `submission` / `new_feature` sync-job types.
3. **Orphan-photo cleanup migration** — server-side scheduled function deletes leftover storage objects.

## P1 — Surface dedup-pending uploads

Previously the worker treated `dedup_pending` identically to `committed`: job marked success, no local state change. The conflict-review list only watched `pending_resolutions`, which is populated *after* the user picks — so a freshly flagged duplicate had nowhere to surface and no `new_feature_resolve` job could ever be queued.

Fix:
- New `features.pendingDedupOf` column (schema v11→v12) — UUID of the candidate duplicate returned by the server.
- Worker writes it on `NewFeatureDedupPending`, clears it (in the same tx as the `pending_resolutions` delete) on resolve success.
- `ConflictReviewRepository.watchPendingDedupFeatures()` streams `features` where `pendingDedupOf` is set. The review list surfaces freshly flagged duplicates immediately; tapping queues a decision as before.

## Decommission

- Removed `SyncEntityType.submission` and `.newFeature`.
- Dropped `SyncApi.uploadSubmission` + `uploadNewFeature` from interface, Supabase impl, and FakeSyncApi.
- Removed the matching `_executeSubmission` / `_executeNewFeature` handlers from `SyncWorker`.
- Simplified `FinalizeSubmissionUseCase`: no more dual-key lookup against legacy + new entity types.
- `SyncJobsRepository` gating SQL: dropped the IN-clause variants and duplicate ORDER BY buckets; only the conflict-aware types appear now.

The legacy `upload_submission_bundle` and `upload_new_feature` server-side functions stay — the new conflict-aware RPCs call them as internal helpers. The Dart client no longer calls them directly.

## Orphan-photo cleanup (migration 029)

`public.cleanup_orphan_photos()` SECURITY DEFINER function:
- Deletes photo rows + storage objects for submissions whose `superseded_at IS NOT NULL AND superseded_by_id IS NULL` (the explicit-discard shape used by `resolve_new_feature(discard_mine)`).
- Sweeps any `storage.objects` under bucket `photos` with no `photos.storage_path` reference (left behind by `agreed_skip` and `resolve_attribution(keep_theirs)` cascading deletes).
- Revoked from `authenticated` + `public`; only `service_role` and `pg_cron` invoke it.
- Nightly at 03:00 UTC if pg_cron is available; silently skipped on instances without it.

## Verification

- ✅ 3 new tests in `new_feature_upload_dedup_test.dart` cover the P1 fix: committed leaves `pendingDedupOf` null; dedup_pending sets it; resolve clears it.
- ✅ Existing `sync_worker_*` tests updated for the removed `uploadSubmissionCalls` / `uploadNewFeatureCalls` fields.
- ✅ `sync_jobs_repository_test` updated for the dropped `SyncEntityType.submission` constant.
- ✅ `migration_v7_to_v8_test` now seeds a `features` table since the new v11→v12 migration `addColumn`s into it.
- ✅ Fixed a temporal flake: `remote_attributions_pull_service_test` "delta uses stored cursor" now pins `now()` so the freshness check doesn't go stale after 24h of wall-clock drift past the seeded cursor.
- ✅ Full suite: **786 passing, 3 pre-existing failures on \`main\`, 0 regressions**, 2 skipped.
- ✅ `dart analyze` on touched files: no errors.

## Test plan

- [ ] Apply migration 029 to staging. Confirm `cleanup_orphan_photos()` exists and is not callable by `authenticated`.
- [ ] Insert a photo whose `storage_path` doesn't appear in `storage.objects`; insert a `storage.objects` row under bucket `photos` with no matching `photos.storage_path`. Call `select * from public.cleanup_orphan_photos();` — the orphan object should be deleted.
- [ ] Run a multi-device dedup flow: device A adds a new feature near a feature device B has already submitted. Device A's upload should park (no badge previously; now a conflict banner appears). Pick "Discard mine" — feature's `pendingDedupOf` clears, `resolve_new_feature` RPC fires, audit row written.
- [ ] Verify upgrading an existing pre-v11 device still works (v9 → v10 → v11 → v12 chained migrations).

## What's still alive

- The legacy `upload_submission_bundle` and `upload_new_feature` server functions remain (internal helpers for the conflict-aware RPCs).
- A scheduled retention policy on `attribution_audit_log` is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)