### PR TITLE
chore: clear pre-existing analyzer warnings + 3 failing tests

### DIFF
--- a/lib/core/sync/shapefile/validation/rules/r2_file_set_rule.dart
+++ b/lib/core/sync/shapefile/validation/rules/r2_file_set_rule.dart
@@ -2,29 +2,55 @@ import 'dart:typed_data';
 import 'package:firecheck/core/sync/shapefile/validation/shapefile_validation_rule.dart';
 import 'package:flutter/foundation.dart';
 
+/// Checks that every required shapefile component is present in the
+/// downloaded set and non-empty. A shapefile *layer* is the trio
+/// `.shp + .dbf + .shx` plus a `.prj` for projection metadata; an
+/// assignment ships three layers (boundary / buildings / roads), so the
+/// complete set is 3 × 4 = 12 files.
+///
+/// Returns [RuleFatal] if any required file is missing or zero bytes,
+/// [RuleWarning] if the total size exceeds 100 MB (slow-to-load hint),
+/// otherwise [RulePassed].
 @immutable
 class FileSetRule extends ShapefileValidationRule {
   const FileSetRule();
 
   static const _largeSizeThreshold = 100 * 1024 * 1024; // 100 MB
 
+  static const _layers = ['boundary', 'buildings', 'roads'];
+  static const _extensions = ['.shp', '.dbf', '.shx', '.prj'];
+
   @override
   RuleOutcome check(
     Map<String, Uint8List> files,
     Map<String, String> expectedMd5s,
   ) {
-    final hasShp = files.keys.any((k) => k.endsWith('.shp'));
-    if (!hasShp) {
-      return const RuleFatal(
-        ruleName: 'file_set',
-        userMessage: 'Map files are missing or incomplete.',
-      );
+    for (final layer in _layers) {
+      for (final ext in _extensions) {
+        final name = '$layer$ext';
+        final bytes = files[name];
+        if (bytes == null) {
+          return RuleFatal(
+            ruleName: 'file_set',
+            userMessage:
+                'Map files are missing or incomplete (missing $name).',
+          );
+        }
+        if (bytes.isEmpty) {
+          return RuleFatal(
+            ruleName: 'file_set',
+            userMessage:
+                'Map files are missing or incomplete ($name is empty).',
+          );
+        }
+      }
     }
 
     final totalBytes = files.values.fold(0, (sum, b) => sum + b.length);
     if (totalBytes > _largeSizeThreshold) {
       return const RuleWarning(
-        userMessage: 'This assignment is unusually large and may be slow to load.',
+        userMessage:
+            'This assignment is unusually large and may be slow to load.',
       );
     }
 

--- a/lib/features/assignment/presentation/assignment_providers.dart
+++ b/lib/features/assignment/presentation/assignment_providers.dart
@@ -318,7 +318,18 @@ class GetMapsNotifier extends StateNotifier<GetMapsState> {
         message: fatal.userMessage,
         fileChecksum: fatal.computedChecksum,
       ));
-      // Log only — attempt import anyway with whatever files are available.
+      if (!mounted) return;
+      // Fatal rules indicate corrupt / incomplete shapefiles — surface as
+      // a non-retryable error instead of attempting an import that would
+      // almost certainly fail downstream with a less actionable message.
+      state = GetMapsError(
+        ShapefileValidationFailure(
+          fatal.userMessage,
+          ruleName: fatal.ruleName,
+        ),
+        isRetryable: false,
+      );
+      return;
     }
 
     if (!report.hasFatals && report.hasWarnings) {

--- a/lib/features/home/data/shapefile_export_notifier.dart
+++ b/lib/features/home/data/shapefile_export_notifier.dart
@@ -1,4 +1,3 @@
-import 'package:firecheck/core/sync/shapefile/export/export_validation_result.dart';
 import 'package:firecheck/core/sync/shapefile/export/shapefile_export_validator.dart';
 import 'package:firecheck/core/sync/shapefile/export/shapefile_exporter.dart';
 import 'package:firecheck/features/assignment/presentation/assignment_providers.dart';

--- a/lib/features/map/geometry_editor/presentation/geometry_editor_controller.dart
+++ b/lib/features/map/geometry_editor/presentation/geometry_editor_controller.dart
@@ -197,8 +197,8 @@ class GeometryEditorController extends Notifier<GeometryEditorState> {
     final rings = state.workingRings
         .map(
           (r) => r
-              .map(
-                (v) => (lng: v.lng + dLng, lat: v.lat + dLat) as LngLat,
+              .map<LngLat>(
+                (v) => (lng: v.lng + dLng, lat: v.lat + dLat),
               )
               .toList(),
         )
@@ -228,8 +228,8 @@ class GeometryEditorController extends Notifier<GeometryEditorState> {
       case Translate():
         for (var r = 0; r < rings.length; r++) {
           rings[r] = rings[r]
-              .map(
-                (v) => (lng: v.lng - top.dLng, lat: v.lat - top.dLat) as LngLat,
+              .map<LngLat>(
+                (v) => (lng: v.lng - top.dLng, lat: v.lat - top.dLat),
               )
               .toList();
         }
@@ -320,8 +320,8 @@ List<LngLat> _parseRing(dynamic ring) {
   return list;
 }
 
-List<LngLat> _parseLine(List coords) => coords.map<LngLat>((p) {
-      final pair = p as List;
+List<LngLat> _parseLine(List<dynamic> coords) => coords.map<LngLat>((p) {
+      final pair = p as List<dynamic>;
       return (
         lng: (pair[0] as num).toDouble(),
         lat: (pair[1] as num).toDouble(),


### PR DESCRIPTION
After the multi-user attribution sync work landed, the suite still had 3 unrelated failures and 4 unrelated warnings carried over from \`main\`. This sweep brings the tree to a green baseline.

## Tests fixed (real bugs the prior code masked)

- **FileSetRule (shapefile validation)** — was only checking that *some* `.shp` file existed and the total size threshold. It never verified the full 12-file set (3 layers × 4 extensions) or that no file was zero bytes. Two `r2_file_set_rule_test` cases asserted that contract and failed silently. The rule now enforces it; user-visible message names the offending file.
- **GetMapsNotifier** — was logging a fatal shapefile validation result and then attempting the import anyway. That's exactly the case where the import will fail with a less actionable downstream error. The notifier now transitions to \`GetMapsError(isRetryable: false)\` wrapping a \`ShapefileValidationFailure\` — matches the test contract and the user-facing behavior the test name implies.

## Warnings cleared

- \`shapefile_export_notifier.dart\`: removed unused \`export_validation_result.dart\` import.
- \`geometry_editor_controller.dart\`: two unnecessary \`as LngLat\` casts replaced with \`.map<LngLat>(...)\`; one \`List\` parameter typed as \`List<dynamic>\`.

## Verification

- ✅ \`flutter test\`: **790 pass / 2 skipped / 0 fail**
- ✅ \`dart analyze lib/\`: **0 errors, 0 warnings**

🤖 Generated with [Claude Code](https://claude.com/claude-code)